### PR TITLE
Update docs for neo4j 2.1.8

### DIFF
--- a/docs/source/import.rst
+++ b/docs/source/import.rst
@@ -62,8 +62,8 @@ advantage of doing so is that the data is loaded only once for all
 scripts you may want to execute allowing you to benefit from Neo4J's
 caching for increased speed.
 
-To install the neo4j server, download version 2.1.5 from
-http://www.neo4j.org/download/.
+To install the neo4j server, download version 2.1.8 from
+http://www.neo4j.com/download/other-releases.
 
 Once downloaded, unpack the archive into a directory of your choice,
 which we will call ``$Neo4jDir`` in the following. 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -39,8 +39,8 @@ software should be installed:
   not build with Java 6. It has been tested with OpenJDK-7 but should
   also work fine with Oracle's JVM.
   
-- **Neo4J 2.1.5 Community Edition.**  The graph database `Neo4J
-  <http://www.neo4j.org/download/>`_ provides access to 
+- **Neo4J 2.1.X Community Edition.**  The graph database `Neo4J
+  <http://www.neo4j.com/>`_ provides access to 
   the imported code.
 
 - **Gremlin for Neo4J 2.X.** The `Gremlin plugion for Neo4J 2.X
@@ -58,7 +58,7 @@ the following projects.
 * `Apache Commons CLI Command Line Parser 1.2
   <http://commons.apache.org/proper/commons-cli/>`_
 * `Neo4J 2.1.5 Community Edition
-  <http://www.neo4j.org/download/other_versions>`_
+  <http://www.neo4j.com/download/other-releases>`_
 
 * `The Apache Ant build tool <http://ant.apache.org/>`_ (tested with
   version 1.9.2).
@@ -137,8 +137,8 @@ advantage of doing so is that the data is loaded only once for all
 scripts you may want to execute allowing you to benefit from Neo4J's
 caching for increased speed.
 
-To install the neo4j server, download version 2.1.5 from
-http://www.neo4j.org/download/.
+To install the neo4j server, download version 2.1.8 from
+http://www.neo4j.com/download/other-releases.
 
 Once downloaded, unpack the archive into a directory of your choice,
 which we will call ``$Neo4jDir`` in the following. 


### PR DESCRIPTION
The current documentation refers to neo4j 2.1.5. This version is no longer available and the download links are outdated.
You might also want to update http://mlsec.org/joern/lib/lib.tar.gz and http://mlsec.org/joern/lib/lib-dev.tar.gz with jars from neo4j 2.1.8.
 