### PR TITLE
fix “Child Num Bug of IdentifierDecl” issue #54

### DIFF
--- a/src/ast/ASTNode.java
+++ b/src/ast/ASTNode.java
@@ -9,7 +9,7 @@ import ast.expressions.BinaryExpression;
 import ast.expressions.Expression;
 import ast.walking.ASTNodeVisitor;
 
-public class ASTNode
+public class ASTNode implements Cloneable
 {
 
 	protected String codeStr = null;
@@ -148,6 +148,24 @@ public class ASTNode
 			return ((Expression) this).getOperator();
 		}
 		return null;
+	}
+	
+	public ASTNode clone() throws CloneNotSupportedException
+	{
+		ASTNode node = (ASTNode)super.clone();
+		node.setCodeStr(codeStr);
+		node.initializeFromContext(parseTreeNodeContext);
+		if(isInCFG())
+			node.markAsCFGNode();
+		if(children != null)
+		{
+			for(ASTNode n:children)
+			{
+				node.addChild(n.clone());
+			}
+		}
+		node.setChildNumber(childNumber);
+		return node;
 	}
 
 }

--- a/src/ast/expressions/Expression.java
+++ b/src/ast/expressions/Expression.java
@@ -22,4 +22,10 @@ public class Expression extends ASTNode
 		return operator;
 	}
 	
+	public Expression clone() throws CloneNotSupportedException
+	{
+		Expression node = (Expression)super.clone();
+		node.setOperator(operator);
+		return node;
+	}
 }

--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -16,4 +16,17 @@ public class Identifier extends Expression
 	{
 		visitor.visit(this);
 	}
+	
+	public Identifier clone()
+	{
+		Identifier node = null;
+		try{
+			node = (Identifier)super.clone();
+		}
+		catch(CloneNotSupportedException e)
+		{
+			e.printStackTrace();
+		}
+		return node;
+	}
 }

--- a/src/parsing/C/Functions/builder/FunctionContentBuilder.java
+++ b/src/parsing/C/Functions/builder/FunctionContentBuilder.java
@@ -545,7 +545,7 @@ public class FunctionContentBuilder extends ASTNodeBuilder
 		// This is also a bit of a hack. As we go up,
 		// we introduce an artificial assignment-node.
 
-		assign.addChild(identifierDecl.getName());
+		assign.addChild(identifierDecl.getName().clone());
 		assign.addChild(lastChild);
 
 		identifierDecl.addChild(assign);


### PR DESCRIPTION
Add clone() function to fix the wrong childnum BUG caused by reference copy.

This problem is caused by line:548 in FunctionContentBuilder.java.
```
assign.addChild(identifierDecl.getName());
```
This statement add the child(class type:Identifier) of identifierDecl(class type:IdentifierDecl) to assgin(class type:AssignmentExpr). The childnum of this child is modified by the addChild method, thus it is wrong for the original parent identifierDecl.

Fix this problem by clone this child.

Here is a piece of testCode.
```
static void wdm_in_callback(struct urb *urb)
{
        int status = urb->status;
}
```
Use joern to parse it, start the Neo4j database and run the gremlin query bellow.
```
echo "queryNodeIndex('type:IdentifierDecl').filter{it.code.contains(\"status\")}.out()" |joern-lookup -g
```
The correct answer should be:
```
(n18 {childNum:"0",code:"int",functionId:2,type:"IdentifierDeclType"})
(n17 {childNum:"1",code:"status",functionId:2,type:"Identifier"})
(n12 {childNum:"2",code:"status = urb -> status",functionId:2,operator:"=",type:"AssignmentExpr"})
(n23 {code:"status",functionId:2,type:"Symbol"})
```
