### PR TITLE
Rewrite of function extractor, support for actual output of PHP parser.

### DIFF
--- a/src/ast/php/functionDef/Closure.java
+++ b/src/ast/php/functionDef/Closure.java
@@ -1,0 +1,7 @@
+package ast.php.functionDef;
+
+import ast.functionDef.FunctionDef;
+
+public class Closure extends FunctionDef
+{
+}

--- a/src/ast/php/functionDef/TopLevelFunctionDef.java
+++ b/src/ast/php/functionDef/TopLevelFunctionDef.java
@@ -1,0 +1,29 @@
+package ast.php.functionDef;
+
+import ast.ASTNode;
+import ast.functionDef.FunctionDef;
+import ast.functionDef.ParameterList;
+
+public class TopLevelFunctionDef extends FunctionDef
+{
+
+	public void addChild(ASTNode node)
+	{
+		// do not allow ParameterList's in top-level functions
+		if (!(node instanceof ParameterList))
+			super.addChild(node);
+	}
+
+	@Override
+	public String getFunctionSignature()
+	{
+		return getName().getEscapedCodeStr();
+	}
+
+	@Override
+	public ParameterList getParameterList()
+	{
+		return null;
+	}
+
+}

--- a/src/inputModules/csv/KeyedCSV/KeyedCSVReader.java
+++ b/src/inputModules/csv/KeyedCSV/KeyedCSVReader.java
@@ -36,7 +36,9 @@ public class KeyedCSVReader
 		{
 			String field = header.get(i);
 			keys[i] = createKeyFromFields(field);
-			keyRow += field + ",";
+			keyRow += field;
+			if( i < header.size() - 1)
+				keyRow += ",";
 		}
 
 	}

--- a/src/inputModules/csv/KeyedCSV/KeyedCSVRow.java
+++ b/src/inputModules/csv/KeyedCSV/KeyedCSVRow.java
@@ -1,6 +1,7 @@
 package inputModules.csv.KeyedCSV;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.commons.csv.CSVRecord;
@@ -28,11 +29,15 @@ public class KeyedCSVRow
 	{
 		stringRepr = "";
 		int i = 0;
-		for (String r : record)
+		Iterator<String> recIt = record.iterator();
+		while (recIt.hasNext())
 		{
+			String r = recIt.next();
 			String keyStr = keys[i].getName();
 			values.put(keyStr, r);
-			stringRepr += r + ",";
+			stringRepr += r;
+			if (recIt.hasNext())
+				stringRepr += ",";
 			i++;
 		}
 	}

--- a/src/inputModules/csv/KeyedCSV/exceptions/InvalidCSVFile.java
+++ b/src/inputModules/csv/KeyedCSV/exceptions/InvalidCSVFile.java
@@ -5,4 +5,7 @@ public class InvalidCSVFile extends Exception
 
 	private static final long serialVersionUID = -7279016694374921095L;
 
+	public InvalidCSVFile(String message) {
+		super(message);
+	}
 }

--- a/src/inputModules/csv/csv2ast/CSV2AST.java
+++ b/src/inputModules/csv/csv2ast/CSV2AST.java
@@ -64,7 +64,7 @@ public class CSV2AST
 		// first row must be a function type;
 		// otherwise we cannot create a function node
 		keyedRow = reader.getNextRow();
-		if( null == keyedRow || !PHPCSVNodeTypes.funcTypes.contains(keyedRow.getFieldForKey("type")))
+		if( null == keyedRow || !PHPCSVNodeTypes.funcTypes.contains(keyedRow.getFieldForKey(PHPCSVNodeTypes.TYPE)))
 			throw new InvalidCSVFile( "Type of first row is not a function declaration.");
 		
 		FunctionDef root = (FunctionDef) ast.getNodeById( nodeInterpreter.handle(keyedRow, ast));

--- a/src/inputModules/csv/csv2ast/CSVRowInterpreter.java
+++ b/src/inputModules/csv/csv2ast/CSVRowInterpreter.java
@@ -4,5 +4,5 @@ import inputModules.csv.KeyedCSV.KeyedCSVRow;
 
 public interface CSVRowInterpreter
 {
-	public void handle(KeyedCSVRow row, ASTUnderConstruction ast);
+	public long handle(KeyedCSVRow row, ASTUnderConstruction ast);
 }

--- a/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
+++ b/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
@@ -49,7 +49,7 @@ public class CSVFunctionExtractor
 		// TODO Currently we intentionally assign id -1 the AST_TOPLEVEL node;
 		// this is fine since we only support one top-level function for now.
 		// We will improve on this once we add File nodes.
-		topLevelFuncAST.addNodeRow("-1,AST_TOPLEVEL,,,,,,,<toplevel>,");
+		topLevelFuncAST.addNodeRow("-1," + PHPCSVNodeTypes.TYPE_TOPLEVEL + ",,,,,,,<toplevel>,");
 		topLevelFuncAST.addEdgeRow(edgeReader.getKeyRow());
 		csvStack.push(topLevelFuncAST);
 		funcIdStack.push("-1");
@@ -115,8 +115,8 @@ public class CSVFunctionExtractor
 
 			KeyedCSVRow currNodeRow = nodeReader.getNextRow();
 			System.out.println(currNodeRow);
-			String currType = currNodeRow.getFieldForKey("type");		
-			String currFuncId = currNodeRow.getFieldForKey("funcid");
+			String currType = currNodeRow.getFieldForKey(PHPCSVNodeTypes.TYPE);
+			String currFuncId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.FUNCID);
 								
 			// if this is a top-level node, use id of artificial top-level function
 			if( currFuncId.equals("")) currFuncId = "-1";
@@ -176,7 +176,7 @@ public class CSVFunctionExtractor
 		csvStack.peek().addNodeRow( currNodeRow.toString());
 		if( PHPCSVNodeTypes.funcTypes.contains(currType)) {
 			// if we met a function declaration node, push a new CSVAST atop the stack
-			String currId = currNodeRow.getFieldForKey("id");
+			String currId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.NODE_ID);
 			initFuncAST(currId);
 			// *also* add the declaration onto the newly created CSVAST
 			// (see javadoc of getNextFunction())

--- a/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
+++ b/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
@@ -2,24 +2,24 @@ package inputModules.csv.csvFuncExtractor;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Stack;
 
 import ast.functionDef.FunctionDef;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.CSV2AST;
+import tools.phpast2cfg.PHPCSVNodeTypes;
 
 public class CSVFunctionExtractor
 {
 
-	String functionId = "";
 	KeyedCSVReader nodeReader;
 	KeyedCSVReader edgeReader;
-	CSVAST csvAST;
-	CSVAST topLevelFuncAST;
+	Stack<CSVAST> csvStack = new Stack<CSVAST>();
+	Stack<String> funcIdStack = new Stack<String>();
+	int finishedFunctions = 0;
 	CSV2AST csv2ast = new CSV2AST();
-
-	KeyedCSVRow lastNodeRow;
-	private boolean topLevelReturned = false;
 
 	public void setLanguage(String language)
 	{
@@ -33,91 +33,155 @@ public class CSVFunctionExtractor
 		edgeReader = new KeyedCSVReader();
 		nodeReader.init(nodeStrReader);
 		edgeReader.init(edgeStrReader);
+		// TODO eventually, initiating a top-level function CSVAST will
+		// not happen here, but upon encountering a File node
 		initTopLevelFuncAST();
-	}
-
-	public FunctionDef getNextFunction() throws IOException
-	{
-
-		initCSVAST();
-		boolean rowsLeft = readNextCSV();
-
-		if (csvAST != topLevelFuncAST && csvAST.getNumberOfNodes() != 0)
-			return csv2ast.convert(csvAST);
-
-		else if (csvAST == topLevelFuncAST && rowsLeft == false
-				&& csvAST.getNumberOfNodes() > 1 && !topLevelReturned)
-		{
-			topLevelReturned = true;
-			return csv2ast.convert(topLevelFuncAST);
-		}
-
-		return null;
-	}
-
-	private void initCSVAST()
-	{
-		if (functionId.equals(""))
-			csvAST = topLevelFuncAST;
-		else
-		{
-			csvAST = new CSVAST();
-			csvAST.addNodeRow(nodeReader.getKeyRow());
-			csvAST.addEdgeRow(edgeReader.getKeyRow());
-		}
-
-		if (lastNodeRow != null)
-			csvAST.addNodeRow(lastNodeRow.toString());
 	}
 
 	private void initTopLevelFuncAST()
 	{
-		topLevelFuncAST = new CSVAST();
+		CSVAST topLevelFuncAST = new CSVAST();
 		topLevelFuncAST.addNodeRow(nodeReader.getKeyRow());
-		topLevelFuncAST.addNodeRow("-1,AST_METHOD,,<topLevel>\n");
+		// We use a pseudo-nodetype for top-level functions.
+		// These have different properties and different children
+		// and should be unambiguously distinguishable from
+		// AST_FUNC_DECL, AST_METHOD and AST_CLOSURE nodes.
+		// TODO Currently we intentionally assign id -1 the AST_TOPLEVEL node;
+		// this is fine since we only support one top-level function for now.
+		// We will improve on this once we add File nodes.
+		topLevelFuncAST.addNodeRow("-1,AST_TOPLEVEL,,,,,,,<toplevel>,");
 		topLevelFuncAST.addEdgeRow(edgeReader.getKeyRow());
+		csvStack.push(topLevelFuncAST);
+		funcIdStack.push("-1");
 	}
 
-	private boolean readNextCSV()
+	private void initFuncAST(String funcId)
 	{
-		return addNodeRowsUntilNextFunctionId();
+		CSVAST csvAST = new CSVAST();
+		csvAST.addNodeRow(nodeReader.getKeyRow());
+		csvAST.addEdgeRow(edgeReader.getKeyRow());
+		csvStack.push(csvAST);
+		funcIdStack.push(funcId);
+	}
+	
+	public FunctionDef getNextFunction()
+			throws IOException, InvalidCSVFile
+	{
+		CSVAST csvAST = null;
+		csvAST = getNodeRowsOfNextFunction();
+		FunctionDef function = null;
+		if(csvAST != null)
+			function = csv2ast.convert(csvAST);
+		return function;
 	}
 
-	private boolean addNodeRowsUntilNextFunctionId()
+	/**
+	 * This function reads lines from the nodeReader:
+	 * 1. It first continuously adds lines that have the same funcid as the
+	 *    funcid currently on top of the funcIdStack to the CSVAST on top of
+	 *    the csvStack.
+	 * 2. Upon finding a function declaration:
+	 *    a) It adds the line to the CSVAST on top of the csvStack, since the
+	 *       declaration as such is indeed part of the outer scope and belongs there.
+	 *    b) It pushes a new CSVAST on top of  the csvStack and that function's id
+	 *       on top of the funcIdStack. The line is also added to this new CSVAST.
+	 *       Do note that this means that we intentionally duplicate a line by adding it
+	 *       to two separate CSVAST instances. This second addition is needed for
+	 *       technical reasons, because the line contains meta-information about the
+	 *       function (e.g., its name) that we will need when converting the CSVAST to an
+	 *       ast.functionDef.FunctionDef node using the CSV2AST class.
+	 * 3. Upon finding a funcId different from the one on top of the funcIdStack,
+	 *    it looks for that funcId within the stack. In a valid CSV file, this
+	 *    funcId must have been previously declared by a function declaration.
+	 *    a) If it is not found, an exception is thrown.
+	 *    b) If it is found, the line is added to the correct csvAST within the stack.
+	 *       Additionally, we know that we finished scanning at least one function (since
+	 *       we got back to the "outer" scope). The distance from the top of the stack to
+	 *       the csvAST that we just added the current line to is the number of functions
+	 *       that we finished scanning. We set the global variable finishedFunctions to that
+	 *       number. For the next that many calls of getNodeRowsOfNextFunction(), we simply
+	 *       pop the csvStack (and the funcIdStack) and return the topmost CSVAST.
+	 *      
+	 *  @return The CSV lines corresponding to the next function, or null if we arrived at
+	 *          the end of the CSV file and there is nothing more to return.
+	 */
+	private CSVAST getNodeRowsOfNextFunction() throws InvalidCSVFile
 	{
-		boolean rowsLeft;
-
-		while (true)
+		
+		CSVAST csvAST = null;
+		
+		while( 0 == finishedFunctions && nodeReader.hasNextRow())
 		{
-			rowsLeft = nodeReader.hasNextRow();
-			if (!rowsLeft)
-				break;
 
-			lastNodeRow = nodeReader.getNextRow();
-			System.out.println(lastNodeRow);
-			String newFuncId = lastNodeRow.getFieldForKey("funcId");
-
-			if (!newFuncId.equals(functionId))
-			{
-				if (!functionId.equals(""))
-				{
-					// we were last inside a function.
-					// By breaking, we just return it.
-					functionId = newFuncId;
-					break;
-				} else
-				{
-					// finished top-level scope
-					functionId = newFuncId;
-					initCSVAST();
-					continue;
+			KeyedCSVRow currNodeRow = nodeReader.getNextRow();
+			System.out.println(currNodeRow);
+			String currType = currNodeRow.getFieldForKey("type");		
+			String currFuncId = currNodeRow.getFieldForKey("funcid");
+								
+			// if this is a top-level node, use id of artificial top-level function
+			if( currFuncId.equals("")) currFuncId = "-1";
+								
+			// the funcid is still the same
+			if( currFuncId.equals( funcIdStack.peek()))
+				addRowAndInitASTForFuncType(currNodeRow, currType);
+			// the funcid changed
+			else {
+				// how many functions did we just finish?
+				finishedFunctions = funcIdStack.search(currFuncId) - 1;
+				// if currFuncId is not in the stack, fail; this should never happen with a valid CSV file
+				if( finishedFunctions < 1)
+					throw new InvalidCSVFile("funcid " + currFuncId +
+							" has never been initialized by a function declaration.");
+				// put the current line on the correct CSVAST
+				Stack<CSVAST> tmpCSVStack = new Stack<CSVAST>();
+				Stack<String> tmpFuncIdStack = new Stack<String>();
+				for( int i = 0; i < finishedFunctions; i++) {
+					tmpCSVStack.push( csvStack.pop());
+					tmpFuncIdStack.push( funcIdStack.pop());
 				}
+				addRowAndInitASTForFuncType(currNodeRow, currType);
+				// put everything back
+				for( int i = 0; i < finishedFunctions; i++) {
+					csvStack.push( tmpCSVStack.pop());
+					funcIdStack.push( tmpFuncIdStack.pop());
+				}
+				// We finished at least one function.
+				// By breaking, we just return it.
+				break;
 			}
-
-			csvAST.addNodeRow(lastNodeRow.toString());
 		}
+		
+		if( !nodeReader.hasNextRow())
+			finishedFunctions = csvStack.size();
+			
+		// If we are here, it means one of two things:
+		// - We broke out of the loop because we finished scanning a function;
+		//   then, finishedFunctions is greater than 0 and there are at least
+		//   that many CSVAST's on the stack
+		// - The nodeReader does not have any more rows to read.
+		//   In this case, just pop the stack and return the popped element.
+		//   This can occur several times, e.g., if a function was at the very end
+		//   of a file, first that function will be returned, then the top-level function.
+		if( finishedFunctions > 0) {
+			csvAST = csvStack.pop();
+			funcIdStack.pop();
+			finishedFunctions--;
+		}
+		
+		return csvAST;
+	}
 
-		return rowsLeft;
+	private void addRowAndInitASTForFuncType(KeyedCSVRow currNodeRow, String currType)
+	{
+		csvStack.peek().addNodeRow( currNodeRow.toString());
+		if( PHPCSVNodeTypes.funcTypes.contains(currType)) {
+			// if we met a function declaration node, push a new CSVAST atop the stack
+			String currId = currNodeRow.getFieldForKey("id");
+			initFuncAST(currId);
+			// *also* add the declaration onto the newly created CSVAST
+			// (see javadoc of getNextFunction())
+			csvStack.peek().addNodeRow( currNodeRow.toString());
+		}
 	}
 
 }

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -12,60 +12,98 @@ import ast.ASTNode;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.CSV2AST;
 
 public class TestCSV2AST
 {
-
-	String edgeFileHeader = "START_ID, END_ID, TYPE";
+	// See {@link http://neo4j.com/docs/stable/import-tool-header-format.html} for detailed
+	// information about the header file format
+	String nodeHeader = "id:ID,type,flags:string[],lineno:int,code,childnum:int,funcid:int,endlineno:int,name,doccomment\n";
+	// TODO the edge header contains types, not names, i.e., it should be:
+	//String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
+	String edgeHeader = "START_ID,END_ID,TYPE\n";
 
 	@Test
-	public void testMethodCreation() throws IOException
+	public void testFunctionCreation() throws IOException, InvalidCSVFile
 	{
-		String str = "id:ID,type,name\n1,AST_METHOD,foo";
-		FunctionDef func = createASTFromStrings(str, edgeFileHeader);
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		
 		assertTrue(func != null);
 	}
 
 	@Test
-	public void testMethodName() throws IOException
+	public void testFunctionName() throws IOException, InvalidCSVFile
 	{
-		String str = "id:ID,type,name\n1,AST_METHOD,foo";
-		FunctionDef funcDef = createASTFromStrings(str, edgeFileHeader);
-		assertEquals("foo", funcDef.getName().getEscapedCodeStr());
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		
+		assertEquals("foo", func.getName().getEscapedCodeStr());
 	}
 
 	@Test
-	public void testMissingMethodName() throws IOException
+	public void testMissingFunctiondName() throws IOException, InvalidCSVFile
 	{
-		String str = "id:ID,type\n1,AST_METHOD";
-		FunctionDef funcDef = createASTFromStrings(str, edgeFileHeader);
-		assertEquals("", funcDef.getName().getEscapedCodeStr());
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,,\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		
+		assertEquals("", func.getName().getEscapedCodeStr());
 	}
 
+	// TODO remove this.
+	// Function names should be stored as a property of FunctionDef in PHP ASTs.
 	@Test
-	public void testEdgeBetweenFuncAndName() throws IOException
+	public void testEdgeBetweenFuncAndName() throws IOException, InvalidCSVFile
 	{
-		String str = "id:ID,type,name\n1,AST_METHOD,foo";
-		FunctionDef funcDef = createASTFromStrings(str, edgeFileHeader);
-		ASTNode child = funcDef.getChild(0);
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		ASTNode child = func.getChild(0);
+		
 		assertTrue(child instanceof Identifier);
 	}
 
+	/**
+	 * function foo() {
+	 *   $a = 3;
+	 * }
+	 */
 	@Test
-	public void testSimpleEdgeImport() throws IOException
+	public void testSimpleEdgeImport() throws IOException, InvalidCSVFile
 	{
-		String nodeStr = "id:ID,type,name\n1,AST_METHOD,foo\n"
-				+ "2,AST_STMT_LIST\n" + "3,AST_ASSIGN";
-		String edgeStr = "START_ID,END_ID,TYPE\n1,2\n2,3\n";
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,AST_ASSIGN,,4,,0,2,,,\n";
+		nodeStr += "7,AST_VAR,,4,,0,2,,,\n";
+		nodeStr += "8,string,,4,\"a\",0,2,,,\n";
+		nodeStr += "9,integer,,4,3,1,2,,,\n";
+		nodeStr += "10,NULL,,3,,3,2,,,\n";
 
-		FunctionDef funcDef = createASTFromStrings(nodeStr, edgeStr);
-		CompoundStatement content = funcDef.getContent();
+		String edgeStr = edgeHeader;
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "2,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "2,5,PARENT_OF\n";
+		edgeStr += "2,10,PARENT_OF\n";
+
+		FunctionDef func = createASTFromStrings(nodeStr, edgeStr);
+		CompoundStatement content = func.getContent();
+
 		assertEquals(1, content.getChildCount());
 	}
 
 	private FunctionDef createASTFromStrings(String nodeStr, String edgeStr)
-			throws IOException
+			throws IOException, InvalidCSVFile
 	{
 		CSV2AST csv2AST = new CSV2AST();
 		StringReader nodeReader = new StringReader(nodeStr);

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -42,10 +42,8 @@ public class TestCSVFunctionExtractor
 	{
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
-		// Currently we always generate exactly one top-level CSVAST.
-		// TODO this will change once we introduce File nodes.
-		//assertTrue(function == null);
-		assertEquals("<toplevel>", function.getName().getEscapedCodeStr());
+
+		assertTrue(function == null);
 	}
 
 	/**
@@ -55,8 +53,8 @@ public class TestCSVFunctionExtractor
 	public void testSingleFunction() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
 		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
 		nodeStr += "4,NULL,,3,,1,2,,,\n";
@@ -70,7 +68,7 @@ public class TestCSVFunctionExtractor
 		FunctionDef function2 = extractor.getNextFunction();
 		
 		assertEquals("foo", function.getName().getEscapedCodeStr());
-		assertEquals("<toplevel>", function2.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
 	}
 
 	/**
@@ -81,8 +79,8 @@ public class TestCSVFunctionExtractor
 	public void testFunctionPlusTopLevel() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
 		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
 		nodeStr += "4,NULL,,3,,1,2,,,\n";
@@ -100,7 +98,7 @@ public class TestCSVFunctionExtractor
 		FunctionDef function3 = extractor.getNextFunction();
 		
 		assertEquals("foo", function.getName().getEscapedCodeStr());
-		assertEquals("<toplevel>", function2.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
 		assertTrue(function3 == null);
 	}
 
@@ -113,8 +111,8 @@ public class TestCSVFunctionExtractor
 	public void testTopLevelFuncTopLevel() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
 		nodeStr += "2,AST_CONST,,3,,0,,,,\n";
 		nodeStr += "3,AST_NAME,NAME_NOT_FQ,3,,0,,,,\n";
 		nodeStr += "4,string,,3,\"true\",0,,,,\n";
@@ -135,7 +133,7 @@ public class TestCSVFunctionExtractor
 		FunctionDef function3 = extractor.getNextFunction();
 
 		assertEquals("foo", function.getName().getEscapedCodeStr());
-		assertEquals("<toplevel>", function2.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
 		assertTrue(function3 == null);
 	}
 
@@ -147,8 +145,8 @@ public class TestCSVFunctionExtractor
 	public void testTwoFunctions() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
 		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
 		nodeStr += "4,NULL,,3,,1,2,,,\n";
@@ -169,7 +167,7 @@ public class TestCSVFunctionExtractor
 
 		assertEquals("foo", function.getName().getEscapedCodeStr());
 		assertEquals("bar", function2.getName().getEscapedCodeStr());
-		assertEquals("<toplevel>", function3.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function3.getName().getEscapedCodeStr());
 	}
 	
 	/**
@@ -181,8 +179,8 @@ public class TestCSVFunctionExtractor
 	public void testFunctionWithInnerFunction() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
 		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
 		nodeStr += "4,NULL,,3,,1,2,,,\n";
@@ -203,7 +201,7 @@ public class TestCSVFunctionExtractor
 
 		assertEquals("bar", function.getName().getEscapedCodeStr());
 		assertEquals("foo", function2.getName().getEscapedCodeStr());
-		assertEquals("<toplevel>", function3.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function3.getName().getEscapedCodeStr());
 	}
 	
 	/**
@@ -233,7 +231,6 @@ public class TestCSVFunctionExtractor
 		nodeStr += "14,NULL,,7,,1,12,,,\n";
 		nodeStr += "15,AST_STMT_LIST,,7,,2,12,,,\n";
 		nodeStr += "16,NULL,,7,,3,12,,,\n";
-
 	
 		nodeReader = new StringReader(nodeStr);
 
@@ -246,7 +243,72 @@ public class TestCSVFunctionExtractor
 		assertEquals("bar", function.getName().getEscapedCodeStr());
 		assertEquals("foo", function2.getName().getEscapedCodeStr());
 		assertEquals("buz", function3.getName().getEscapedCodeStr());
-		assertEquals("<toplevel>", function4.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function4.getName().getEscapedCodeStr());
+	}
+
+	/**
+	 * foo.php
+	 * -------
+	 * function foo() {}
+	 *
+	 * bar.php
+	 * -------
+	 * function bar() {}
+	 */
+	@Test
+	public void testTwoFiles() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,Directory,,,,,,,\"foobar\",\n";
+		nodeStr += "1,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+		nodeStr += "8,File,,,,,,,\"bar.php\",\n";
+		nodeStr += "9,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "10,AST_FUNC_DECL,,3,,0,,3,bar,\n";
+		nodeStr += "11,AST_PARAM_LIST,,3,,0,10,,,\n";
+		nodeStr += "12,NULL,,3,,1,10,,,\n";
+		nodeStr += "13,AST_STMT_LIST,,3,,2,10,,,\n";
+		nodeStr += "14,NULL,,3,,3,10,,,\n";
+
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+		FunctionDef function4 = extractor.getNextFunction();
+
+		assertEquals("foo", function.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
+		assertEquals("bar", function3.getName().getEscapedCodeStr());
+		assertEquals("<bar.php>", function4.getName().getEscapedCodeStr());
+	}
+
+	/**
+	 * An invalid CSV file which contains no file node to
+	 * initialize top-level code.
+	 */
+	@Test(expected=InvalidCSVFile.class)
+	public void testInvalidNoFileNode() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,NULL,,3,,3,2,,,\n";
+
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		extractor.getNextFunction();
 	}
 	
 	/**
@@ -258,8 +320,8 @@ public class TestCSVFunctionExtractor
 	public void testInvalidUninitializedFuncId() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
 		//nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
 		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
 		nodeStr += "4,NULL,,3,,1,2,,,\n";

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.functionDef.FunctionDef;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csvFuncExtractor.CSVFunctionExtractor;
 
 public class TestCSVFunctionExtractor
@@ -17,8 +18,10 @@ public class TestCSVFunctionExtractor
 	CSVFunctionExtractor extractor;
 	StringReader nodeReader;
 	StringReader edgeReader;
-	String nodeHeader = "id:ID,type,funcId:int,name\n";
-	String edgeHeader = "from,to,type\n";
+	// See {@link http://neo4j.com/docs/stable/import-tool-header-format.html} for detailed
+	// information about the header file format
+	String nodeHeader = "id:ID,type,flags:string[],lineno:int,code,childnum:int,funcid:int,endlineno:int,name,doccomment\n";
+	String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
 
 	@Before
 	public void init()
@@ -29,78 +32,243 @@ public class TestCSVFunctionExtractor
 		edgeReader = new StringReader(edgeHeader);
 	}
 
+	/**
+	 * Note that it is not actually possible to generate a header-only
+	 * CSV file with our PHP parser. Even an empty file will generate
+	 * two nodes: one File node and one AST_STMT_LIST node.
+	 */
 	@Test
-	public void testHeaderOnly() throws IOException
+	public void testHeaderOnly() throws IOException, InvalidCSVFile
 	{
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
-		assertTrue(function == null);
+		// Currently we always generate exactly one top-level CSVAST.
+		// TODO this will change once we introduce File nodes.
+		//assertTrue(function == null);
+		assertEquals("<toplevel>", function.getName().getEscapedCodeStr());
 	}
 
+	/**
+	 * function foo() {}
+	 */
 	@Test
-	public void testSingleFunction() throws IOException
+	public void testSingleFunction() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "0,AST_METHOD,1,foo\n";
-		nodeStr += "1,type,1\n";
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,NULL,,3,,3,2,,,\n";
+		
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		
 		assertEquals("foo", function.getName().getEscapedCodeStr());
+		assertEquals("<toplevel>", function2.getName().getEscapedCodeStr());
 	}
 
+	/**
+	 * function foo() {}
+	 * true;
+	 */
 	@Test
-	public void testFunctionPlusTopLevel() throws IOException
+	public void testFunctionPlusTopLevel() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "0,AST_METHOD,1\n";
-		nodeStr += "1,type,\n";
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,NULL,,3,,3,2,,,\n";
+		nodeStr += "7,AST_CONST,,5,,1,,,,\n";
+		nodeStr += "8,AST_NAME,NAME_NOT_FQ,5,,0,,,,\n";
+		nodeStr += "9,string,,5,\"true\",0,,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
-		assertTrue(function != null);
 		FunctionDef function2 = extractor.getNextFunction();
-		assertTrue(function2 != null);
 		FunctionDef function3 = extractor.getNextFunction();
+		
+		assertEquals("foo", function.getName().getEscapedCodeStr());
+		assertEquals("<toplevel>", function2.getName().getEscapedCodeStr());
 		assertTrue(function3 == null);
 	}
 
+	/**
+	 * true;
+	 * function foo() {}
+	 * true;
+	 */
 	@Test
-	public void testTopLevelFuncTopLevel() throws IOException
+	public void testTopLevelFuncTopLevel() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "0,type,\n";
-		nodeStr += "1,AST_METHOD,1,foo\n";
-		nodeStr += "2,type,\n";
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_CONST,,3,,0,,,,\n";
+		nodeStr += "3,AST_NAME,NAME_NOT_FQ,3,,0,,,,\n";
+		nodeStr += "4,string,,3,\"true\",0,,,,\n";
+		nodeStr += "5,AST_FUNC_DECL,,5,,1,,5,foo,\n";
+		nodeStr += "6,AST_PARAM_LIST,,5,,0,5,,,\n";
+		nodeStr += "7,NULL,,5,,1,5,,,\n";
+		nodeStr += "8,AST_STMT_LIST,,5,,2,5,,,\n";
+		nodeStr += "9,NULL,,5,,3,5,,,\n";
+		nodeStr += "10,AST_CONST,,7,,2,,,,\n";
+		nodeStr += "11,AST_NAME,NAME_NOT_FQ,7,,0,,,,\n";
+		nodeStr += "12,string,,7,\"true\",0,,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
-		assertTrue(function != null);
 		FunctionDef function2 = extractor.getNextFunction();
-		assertTrue(function2 != null);
 		FunctionDef function3 = extractor.getNextFunction();
-		assertTrue(function3 == null);
 
+		assertEquals("foo", function.getName().getEscapedCodeStr());
+		assertEquals("<toplevel>", function2.getName().getEscapedCodeStr());
+		assertTrue(function3 == null);
 	}
 
+	/**
+	 * function foo() {}
+	 * function bar() {}
+	 */
 	@Test
-	public void testTwoFunctions() throws IOException
+	public void testTwoFunctions() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "0,AST_METHOD,1,foo\n";
-		nodeStr += "1,AST_METHOD,2,bar\n";
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,NULL,,3,,3,2,,,\n";
+		nodeStr += "7,AST_FUNC_DECL,,5,,1,,5,bar,\n";
+		nodeStr += "8,AST_PARAM_LIST,,5,,0,7,,,\n";
+		nodeStr += "9,NULL,,5,,1,7,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,5,,2,7,,,\n";
+		nodeStr += "11,NULL,,5,,3,7,,,\n";
+		
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
 		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+
 		assertEquals("foo", function.getName().getEscapedCodeStr());
 		assertEquals("bar", function2.getName().getEscapedCodeStr());
+		assertEquals("<toplevel>", function3.getName().getEscapedCodeStr());
 	}
+	
+	/**
+	 * function foo() {
+	 *   function bar() {}
+	 * }
+	 */
+	@Test
+	public void testFunctionWithInnerFunction() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,AST_FUNC_DECL,,4,,0,2,4,bar,\n";
+		nodeStr += "7,AST_PARAM_LIST,,4,,0,6,,,\n";
+		nodeStr += "8,NULL,,4,,1,6,,,\n";
+		nodeStr += "9,AST_STMT_LIST,,4,,2,6,,,\n";
+		nodeStr += "10,NULL,,4,,3,6,,,\n";
+		nodeStr += "11,NULL,,3,,3,2,,,\n";
+	
+		nodeReader = new StringReader(nodeStr);
 
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+
+		assertEquals("bar", function.getName().getEscapedCodeStr());
+		assertEquals("foo", function2.getName().getEscapedCodeStr());
+		assertEquals("<toplevel>", function3.getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * function foo() {
+	 *   function bar() {}
+	 * }
+	 * function buz() {}
+	 */
+	@Test
+	public void testTwoFunctionsAndInnerFunction() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,AST_FUNC_DECL,,4,,0,2,4,bar,\n";
+		nodeStr += "7,AST_PARAM_LIST,,4,,0,6,,,\n";
+		nodeStr += "8,NULL,,4,,1,6,,,\n";
+		nodeStr += "9,AST_STMT_LIST,,4,,2,6,,,\n";
+		nodeStr += "10,NULL,,4,,3,6,,,\n";
+		nodeStr += "11,NULL,,3,,3,2,,,\n";
+		nodeStr += "12,AST_FUNC_DECL,,7,,1,,7,buz,\n";
+		nodeStr += "13,AST_PARAM_LIST,,7,,0,12,,,\n";
+		nodeStr += "14,NULL,,7,,1,12,,,\n";
+		nodeStr += "15,AST_STMT_LIST,,7,,2,12,,,\n";
+		nodeStr += "16,NULL,,7,,3,12,,,\n";
+
+	
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+		FunctionDef function4 = extractor.getNextFunction();
+
+		assertEquals("bar", function.getName().getEscapedCodeStr());
+		assertEquals("foo", function2.getName().getEscapedCodeStr());
+		assertEquals("buz", function3.getName().getEscapedCodeStr());
+		assertEquals("<toplevel>", function4.getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * An invalid CSV file which contains a line that refers to a
+	 * funcid that has not previously been declared by a function
+	 * declaration node.
+	 */
+	@Test(expected=InvalidCSVFile.class)
+	public void testInvalidUninitializedFuncId() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		//nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,NULL,,3,,3,2,,,\n";
+		
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		extractor.getNextFunction();
+	}
 }

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -247,6 +247,40 @@ public class TestCSVFunctionExtractor
 	}
 
 	/**
+	 * function foo() {
+	 *   function() {};
+	 * }
+	 */
+	@Test
+	public void testFunctionWithClosure() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,AST_CLOSURE,,4,,0,2,4,{closure},\n";
+		nodeStr += "7,AST_PARAM_LIST,,4,,0,6,,,\n";
+		nodeStr += "8,NULL,,4,,1,6,,,\n";
+		nodeStr += "9,AST_STMT_LIST,,4,,2,6,,,\n";
+		nodeStr += "10,NULL,,4,,3,6,,,\n";
+		nodeStr += "11,NULL,,3,,3,2,,,\n";
+
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+
+		assertEquals("{closure}", function.getName().getEscapedCodeStr());
+		assertEquals("foo", function2.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function3.getName().getEscapedCodeStr());
+	}
+
+	/**
 	 * foo.php
 	 * -------
 	 * function foo() {}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -9,15 +9,17 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 {
 
 	@Override
-	public void handle(KeyedCSVRow row, ASTUnderConstruction ast)
+	public long handle(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		Long startId = Long.parseLong(row.getFieldForKey("START_ID"));
-		Long endId = Long.parseLong(row.getFieldForKey("END_ID"));
+		long startId = Long.parseLong(row.getFieldForKey("START_ID"));
+		long endId = Long.parseLong(row.getFieldForKey("END_ID"));
 
 		ASTNode startNode = ast.getNodeById(startId);
 		ASTNode endNode = ast.getNodeById(endId);
 
 		startNode.addChild(endNode);
+		
+		return startId;
 	}
 
 }

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -11,8 +11,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	@Override
 	public long handle(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		long startId = Long.parseLong(row.getFieldForKey("START_ID"));
-		long endId = Long.parseLong(row.getFieldForKey("END_ID"));
+		long startId = Long.parseLong(row.getFieldForKey(PHPCSVEdgeTypes.START_ID));
+		long endId = Long.parseLong(row.getFieldForKey(PHPCSVEdgeTypes.END_ID));
 
 		ASTNode startNode = ast.getNodeById(startId);
 		ASTNode endNode = ast.getNodeById(endId);

--- a/src/tools/phpast2cfg/PHPCSVEdgeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeTypes.java
@@ -1,0 +1,15 @@
+package tools.phpast2cfg;
+
+public class PHPCSVEdgeTypes
+{
+	/* edge row key types */
+	public static final String START_ID = "START_ID";
+	public static final String END_ID = "END_ID";
+	public static final String TYPE = "TYPE";
+
+	/* edge types */
+	public static final String TYPE_FILE_OF = "FILE_OF";
+	public static final String TYPE_DIRECTORY_OF = "DIRECTORY_OF";
+	public static final String TYPE_AST_PARENT_OF = "PARENT_OF";
+
+}

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
+import ast.php.functionDef.Closure;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
@@ -28,6 +29,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			break;
 		case PHPCSVNodeTypes.TYPE_FUNC_DECL:
 			retval = handleFunction(row, ast);
+			break;
+		case PHPCSVNodeTypes.TYPE_CLOSURE:
+			retval = handleClosure(row, ast);
 			break;
 		case PHPCSVNodeTypes.TYPE_STMT_LIST:
 			retval = handleCompound(row, ast);
@@ -93,6 +97,22 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
+		return id;
+	}
+
+	private static long handleClosure(KeyedCSVRow row,
+			ASTUnderConstruction ast)
+	{
+		Closure newNode = new Closure();
+		Identifier nameNode = new Identifier();
+
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		nameNode.setCodeStr(name);
+		newNode.addChild(nameNode);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
 		return id;
 	}
 

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -20,28 +20,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	public long handle(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		long retval = -1;
-		String type = row.getFieldForKey("type");
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		switch (type)
 		{
-		case "AST_TOPLEVEL":
+		case PHPCSVNodeTypes.TYPE_TOPLEVEL:
 			retval = handleTopLevelFunction(row, ast);
 			break;
-		case "AST_FUNC_DECL":
+		case PHPCSVNodeTypes.TYPE_FUNC_DECL:
 			retval = handleFunction(row, ast);
 			break;
-		case "AST_STMT_LIST":
+		case PHPCSVNodeTypes.TYPE_STMT_LIST:
 			retval = handleCompound(row, ast);
 			break;
-		case "AST_IF":
+		case PHPCSVNodeTypes.TYPE_IF:
 			retval = handleIf(row, ast);
 			break;
-		case "AST_WHILE":
+		case PHPCSVNodeTypes.TYPE_WHILE:
 			retval = handleWhile(row, ast);
 			break;
-		case "AST_DO_WHILE":
+		case PHPCSVNodeTypes.TYPE_DO_WHILE:
 			retval = handleDo(row, ast);
 			break;
-		case "AST_FOR":
+		case PHPCSVNodeTypes.TYPE_FOR:
 			retval = handleFor(row, ast);
 			break;
 

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
+import ast.php.functionDef.TopLevelFunctionDef;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.IfStatement;
@@ -16,46 +17,70 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 {
 
 	@Override
-	public void handle(KeyedCSVRow row, ASTUnderConstruction ast)
+	public long handle(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
+		long retval = -1;
 		String type = row.getFieldForKey("type");
 		switch (type)
 		{
-		case "AST_METHOD":
-			handleFunction(row, ast);
+		case "AST_TOPLEVEL":
+			retval = handleTopLevelFunction(row, ast);
+			break;
+		case "AST_FUNC_DECL":
+			retval = handleFunction(row, ast);
 			break;
 		case "AST_STMT_LIST":
-			handleCompound(row, ast);
+			retval = handleCompound(row, ast);
 			break;
 		case "AST_IF":
-			handleIf(row, ast);
+			retval = handleIf(row, ast);
 			break;
 		case "AST_WHILE":
-			handleWhile(row, ast);
+			retval = handleWhile(row, ast);
 			break;
 		case "AST_DO_WHILE":
-			handleDo(row, ast);
+			retval = handleDo(row, ast);
 			break;
 		case "AST_FOR":
-			handleFor(row, ast);
+			retval = handleFor(row, ast);
 			break;
 
 		default:
-			defaultHandler(row, ast);
+			retval = defaultHandler(row, ast);
 		}
+		
+		return retval;
 	}
 
-	private void defaultHandler(KeyedCSVRow row, ASTUnderConstruction ast)
+	private long defaultHandler(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 
 		ASTNode newNode = new ASTNode();
 		newNode.setProperty(PHPCSVNodeTypes.TYPE, type);
 		ast.addNodeWithId(newNode, id);
+		
+		return id;
 	}
 
-	private static void handleFunction(KeyedCSVRow row,
+	private static long handleTopLevelFunction(KeyedCSVRow row,
+			ASTUnderConstruction ast)
+	{
+		TopLevelFunctionDef newNode = new TopLevelFunctionDef();
+		Identifier nameNode = new Identifier();
+
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		nameNode.setCodeStr(name);
+		newNode.addChild(nameNode);
+		
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+		
+		return id;
+	}
+	
+	private static long handleFunction(KeyedCSVRow row,
 			ASTUnderConstruction ast)
 	{
 		FunctionDef newNode = new FunctionDef();
@@ -65,44 +90,55 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		nameNode.setCodeStr(name);
 		newNode.addChild(nameNode);
 
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
-		ast.setRootNode(newNode);
+		
+		return id;
 	}
 
-	private void handleCompound(KeyedCSVRow row, ASTUnderConstruction ast)
+	private long handleCompound(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		CompoundStatement newNode = new CompoundStatement();
 		ast.addNodeWithId(newNode, id);
+		
+		return id;
 	}
 
-	private void handleIf(KeyedCSVRow row, ASTUnderConstruction ast)
+	private long handleIf(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		IfStatement newNode = new IfStatement();
 		ast.addNodeWithId(newNode, id);
+		
+		return id;
 	}
 
-	private void handleFor(KeyedCSVRow row, ASTUnderConstruction ast)
+	private long handleFor(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ForStatement newNode = new ForStatement();
 		ast.addNodeWithId(newNode, id);
+		
+		return id;
 	}
 
-	private void handleDo(KeyedCSVRow row, ASTUnderConstruction ast)
+	private long handleDo(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		DoStatement newNode = new DoStatement();
 		ast.addNodeWithId(newNode, id);
+		
+		return id;
 	}
 
-	private void handleWhile(KeyedCSVRow row, ASTUnderConstruction ast)
+	private long handleWhile(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		Long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		WhileStatement newNode = new WhileStatement();
 		ast.addNodeWithId(newNode, id);
+		
+		return id;
 	}
 
 }

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -1,11 +1,16 @@
 package tools.phpast2cfg;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class PHPCSVNodeTypes
 {
 
 	public static final String NODE_ID = "id";
 	public static final String NAME = "name";
 	public static final String TYPE = "type";
-	public static String FUNCID = "funcId";
+	public static final String FUNCID = "funcid";
 
+	public static final List<String> funcTypes =
+			Arrays.asList("AST_TOPLEVEL", "AST_FUNC_DECL", "AST_METHOD", "AST_CLOSURE");
 }

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -5,12 +5,37 @@ import java.util.List;
 
 public class PHPCSVNodeTypes
 {
-
+	/* node row keys */
 	public static final String NODE_ID = "id";
 	public static final String NAME = "name";
 	public static final String TYPE = "type";
 	public static final String FUNCID = "funcid";
 
+	/* node types */
+	// directory/file types
+	public static final String TYPE_FILE = "File";
+	public static final String TYPE_DIRECTORY = "Directory";
+	
+	// function declaration nodes
+	public static final String TYPE_TOPLEVEL = "AST_TOPLEVEL"; // artificial
+	public static final String TYPE_FUNC_DECL = "AST_FUNC_DECL";
+	public static final String TYPE_METHOD = "AST_METHOD";
+	public static final String TYPE_CLOSURE = "AST_CLOSURE";
+	
 	public static final List<String> funcTypes =
-			Arrays.asList("AST_TOPLEVEL", "AST_FUNC_DECL", "AST_METHOD", "AST_CLOSURE");
+			Arrays.asList(TYPE_TOPLEVEL, TYPE_FUNC_DECL, TYPE_METHOD, TYPE_CLOSURE);
+	
+	// nodes with an arbitrary number of children
+	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
+	public static final String TYPE_IF = "AST_IF";
+	
+	// nodes with exactly 2 children
+	public static final String TYPE_WHILE = "AST_WHILE";
+	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
+	
+	// nodes with exactly 4 children
+	public static final String TYPE_FOR = "AST_FOR";
+
+
+
 }


### PR DESCRIPTION
The CSVFunctionExtractor was rewritten such as to support actual output of the PHP parser, in particular it is now possible to have several top-level functions, one per file. See comment on commit a36968b52e4684af0db3c859e934b59d635748c5 for detailed information.

We now support three types of functions: pseudo top-level functions corresponding to the global code in a file (`AST_TOPLEVEL`); normal functions declared on top-level (`AST_FUNC_DECL`); and closures (`AST_CLOSURE`).

We are still missing support for methods declared within classes (`AST_METHOD`). Since classes declare their own top-level scope, we need to support classes explicitly in the function extractor (i.e., have them declare their own top-level function). This is up next. :)

What really gives me stomachaches right now, though, is the way function names are currently handled: These are saved as a property of an artificial child which is an object of the class `ast.expressions.Identifier`. This is not the way the PHP ASTs are designed; rather, names of functions in the PHP ASTs are directly stored as a property of the function node, i.e., they should be handled as a key-value pair in the `properties` HashMap of the `FunctionDef` class (more precisely, of the `ASTNode` that it extends.) Otherwise, we will get problems and have to implement all kinds of detours. For instance, since this `Identifier` node is currently the first child of all `FunctionDef` nodes, the `childnum` property of the function node's children will be out of phase. (e.g., usually an `AST_PARAM_LIST` is the first child of a function node and has its childnum set to `0`.) Moreover, I think that from a design perspective it should not be up to the node interpreter to add children nodes or edges. It should generate single nodes only, and they will be connected by the edge interpreter. This would be the path of least resistance.

The problem why I could not realize this is that `FunctionDef` already declares `getName()` and `setName()` methods, but these return (resp. take) an `Identifier` instead of a `String`. Could we maybe simply rename these methods to `getIdentifier()` and `setIdentifier()` respectively in the already existing Joern code, such that the `getName()` and `setName()` method names get free for use in the PHP part of Joern? Plus it would be more intuitive anyway to call a function that returns an Identifier `getIdentifier()`. ;)

Hope you defense went well, by the way! :) Congrats!!


