### PR TITLE
Added support for classes and for methods.

### DIFF
--- a/src/ast/php/functionDef/Method.java
+++ b/src/ast/php/functionDef/Method.java
@@ -1,0 +1,7 @@
+package ast.php.functionDef;
+
+import ast.functionDef.FunctionDef;
+
+public class Method extends FunctionDef
+{
+}

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -54,19 +54,20 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,NULL,,3,,3,2,,,\n";
-		
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
 		FunctionDef function = extractor.getNextFunction();
 		FunctionDef function2 = extractor.getNextFunction();
-		
+
 		assertEquals("foo", function.getName().getEscapedCodeStr());
 		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
 	}
@@ -80,15 +81,16 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,NULL,,3,,3,2,,,\n";
-		nodeStr += "7,AST_CONST,,5,,1,,,,\n";
-		nodeStr += "8,AST_NAME,NAME_NOT_FQ,5,,0,,,,\n";
-		nodeStr += "9,string,,5,\"true\",0,,,,\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+		nodeStr += "8,AST_CONST,,5,,1,1,,,\n";
+		nodeStr += "9,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "10,string,,5,\"true\",0,1,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
@@ -112,18 +114,19 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_CONST,,3,,0,,,,\n";
-		nodeStr += "3,AST_NAME,NAME_NOT_FQ,3,,0,,,,\n";
-		nodeStr += "4,string,,3,\"true\",0,,,,\n";
-		nodeStr += "5,AST_FUNC_DECL,,5,,1,,5,foo,\n";
-		nodeStr += "6,AST_PARAM_LIST,,5,,0,5,,,\n";
-		nodeStr += "7,NULL,,5,,1,5,,,\n";
-		nodeStr += "8,AST_STMT_LIST,,5,,2,5,,,\n";
-		nodeStr += "9,NULL,,5,,3,5,,,\n";
-		nodeStr += "10,AST_CONST,,7,,2,,,,\n";
-		nodeStr += "11,AST_NAME,NAME_NOT_FQ,7,,0,,,,\n";
-		nodeStr += "12,string,,7,\"true\",0,,,,\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_CONST,,3,,0,1,,,\n";
+		nodeStr += "4,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"true\",0,1,,,\n";
+		nodeStr += "6,AST_FUNC_DECL,,5,,1,1,5,foo,\n";
+		nodeStr += "7,AST_PARAM_LIST,,5,,0,6,,,\n";
+		nodeStr += "8,NULL,,5,,1,6,,,\n";
+		nodeStr += "9,AST_STMT_LIST,,5,,2,6,,,\n";
+		nodeStr += "10,NULL,,5,,3,6,,,\n";
+		nodeStr += "11,AST_CONST,,7,,2,1,,,\n";
+		nodeStr += "12,AST_NAME,NAME_NOT_FQ,7,,0,1,,,\n";
+		nodeStr += "13,string,,7,\"true\",0,1,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
@@ -146,18 +149,19 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,NULL,,3,,3,2,,,\n";
-		nodeStr += "7,AST_FUNC_DECL,,5,,1,,5,bar,\n";
-		nodeStr += "8,AST_PARAM_LIST,,5,,0,7,,,\n";
-		nodeStr += "9,NULL,,5,,1,7,,,\n";
-		nodeStr += "10,AST_STMT_LIST,,5,,2,7,,,\n";
-		nodeStr += "11,NULL,,5,,3,7,,,\n";
-		
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+		nodeStr += "8,AST_FUNC_DECL,,5,,1,1,5,bar,\n";
+		nodeStr += "9,AST_PARAM_LIST,,5,,0,8,,,\n";
+		nodeStr += "10,NULL,,5,,1,8,,,\n";
+		nodeStr += "11,AST_STMT_LIST,,5,,2,8,,,\n";
+		nodeStr += "12,NULL,,5,,3,8,,,\n";
+
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
@@ -180,18 +184,19 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,AST_FUNC_DECL,,4,,0,2,4,bar,\n";
-		nodeStr += "7,AST_PARAM_LIST,,4,,0,6,,,\n";
-		nodeStr += "8,NULL,,4,,1,6,,,\n";
-		nodeStr += "9,AST_STMT_LIST,,4,,2,6,,,\n";
-		nodeStr += "10,NULL,,4,,3,6,,,\n";
-		nodeStr += "11,NULL,,3,,3,2,,,\n";
-	
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_FUNC_DECL,,4,,0,3,4,bar,\n";
+		nodeStr += "8,AST_PARAM_LIST,,4,,0,7,,,\n";
+		nodeStr += "9,NULL,,4,,1,7,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,7,,,\n";
+		nodeStr += "11,NULL,,4,,3,7,,,\n";
+		nodeStr += "12,NULL,,3,,3,3,,,\n";
+
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
@@ -215,23 +220,24 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,AST_FUNC_DECL,,4,,0,2,4,bar,\n";
-		nodeStr += "7,AST_PARAM_LIST,,4,,0,6,,,\n";
-		nodeStr += "8,NULL,,4,,1,6,,,\n";
-		nodeStr += "9,AST_STMT_LIST,,4,,2,6,,,\n";
-		nodeStr += "10,NULL,,4,,3,6,,,\n";
-		nodeStr += "11,NULL,,3,,3,2,,,\n";
-		nodeStr += "12,AST_FUNC_DECL,,7,,1,,7,buz,\n";
-		nodeStr += "13,AST_PARAM_LIST,,7,,0,12,,,\n";
-		nodeStr += "14,NULL,,7,,1,12,,,\n";
-		nodeStr += "15,AST_STMT_LIST,,7,,2,12,,,\n";
-		nodeStr += "16,NULL,,7,,3,12,,,\n";
-	
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_FUNC_DECL,,4,,0,3,4,bar,\n";
+		nodeStr += "8,AST_PARAM_LIST,,4,,0,7,,,\n";
+		nodeStr += "9,NULL,,4,,1,7,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,7,,,\n";
+		nodeStr += "11,NULL,,4,,3,7,,,\n";
+		nodeStr += "12,NULL,,3,,3,3,,,\n";
+		nodeStr += "13,AST_FUNC_DECL,,7,,1,1,7,buz,\n";
+		nodeStr += "14,AST_PARAM_LIST,,7,,0,13,,,\n";
+		nodeStr += "15,NULL,,7,,1,13,,,\n";
+		nodeStr += "16,AST_STMT_LIST,,7,,2,13,,,\n";
+		nodeStr += "17,NULL,,7,,3,13,,,\n";
+
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
@@ -256,17 +262,18 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,5,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,AST_CLOSURE,,4,,0,2,4,{closure},\n";
-		nodeStr += "7,AST_PARAM_LIST,,4,,0,6,,,\n";
-		nodeStr += "8,NULL,,4,,1,6,,,\n";
-		nodeStr += "9,AST_STMT_LIST,,4,,2,6,,,\n";
-		nodeStr += "10,NULL,,4,,3,6,,,\n";
-		nodeStr += "11,NULL,,3,,3,2,,,\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_CLOSURE,,4,,0,3,4,{closure},\n";
+		nodeStr += "8,AST_PARAM_LIST,,4,,0,7,,,\n";
+		nodeStr += "9,NULL,,4,,1,7,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,7,,,\n";
+		nodeStr += "11,NULL,,4,,3,7,,,\n";
+		nodeStr += "12,NULL,,3,,3,3,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
@@ -295,19 +302,21 @@ public class TestCSVFunctionExtractor
 		String nodeStr = nodeHeader;
 		nodeStr += "0,Directory,,,,,,,\"foobar\",\n";
 		nodeStr += "1,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "2,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "3,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
-		nodeStr += "5,NULL,,3,,1,3,,,\n";
-		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
-		nodeStr += "7,NULL,,3,,3,3,,,\n";
-		nodeStr += "8,File,,,,,,,\"bar.php\",\n";
-		nodeStr += "9,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "10,AST_FUNC_DECL,,3,,0,,3,bar,\n";
-		nodeStr += "11,AST_PARAM_LIST,,3,,0,10,,,\n";
-		nodeStr += "12,NULL,,3,,1,10,,,\n";
-		nodeStr += "13,AST_STMT_LIST,,3,,2,10,,,\n";
-		nodeStr += "14,NULL,,3,,3,10,,,\n";
+		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/foo.php\",\n";
+		nodeStr += "3,AST_STMT_LIST,,1,,0,2,,,\n";
+		nodeStr += "4,AST_FUNC_DECL,,3,,0,2,3,foo,\n";
+		nodeStr += "5,AST_PARAM_LIST,,3,,0,4,,,\n";
+		nodeStr += "6,NULL,,3,,1,4,,,\n";
+		nodeStr += "7,AST_STMT_LIST,,3,,2,4,,,\n";
+		nodeStr += "8,NULL,,3,,3,4,,,\n";
+		nodeStr += "9,File,,,,,,,\"bar.php\",\n";
+		nodeStr += "10,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/bar.php\",\n";
+		nodeStr += "11,AST_STMT_LIST,,1,,0,10,,,\n";
+		nodeStr += "12,AST_FUNC_DECL,,3,,0,10,3,bar,\n";
+		nodeStr += "13,AST_PARAM_LIST,,3,,0,12,,,\n";
+		nodeStr += "14,NULL,,3,,1,12,,,\n";
+		nodeStr += "15,AST_STMT_LIST,,3,,2,12,,,\n";
+		nodeStr += "16,NULL,,3,,3,12,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
@@ -318,26 +327,167 @@ public class TestCSVFunctionExtractor
 		FunctionDef function4 = extractor.getNextFunction();
 
 		assertEquals("foo", function.getName().getEscapedCodeStr());
-		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
+		assertEquals("<foobar/foo.php>", function2.getName().getEscapedCodeStr());
 		assertEquals("bar", function3.getName().getEscapedCodeStr());
-		assertEquals("<bar.php>", function4.getName().getEscapedCodeStr());
+		assertEquals("<foobar/bar.php>", function4.getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * class foo {}
+	 */
+	@Test
+	public void testSingleClass() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_CLASS,,3,,0,1,3,foo,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "5,NULL,,3,,1,1,,,\n";
+		nodeStr += "6,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,1,3,\"foo\",\n";
+		nodeStr += "7,AST_STMT_LIST,,3,,0,6,,,\n";
+
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+
+		assertEquals("[foo]", function.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function2.getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * function foo() {}
+	 * class foo {
+	 *   function bar() {}
+	 * }
+	 * class buz {}
+	 */
+	@Test
+	public void testFunctionAndTwoClassesWithMethod() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+		nodeStr += "8,AST_CLASS,,5,,1,1,7,foo,\n";
+		nodeStr += "9,NULL,,5,,0,1,,,\n";
+		nodeStr += "10,NULL,,5,,1,1,,,\n";
+		nodeStr += "11,AST_TOPLEVEL,TOPLEVEL_CLASS,5,,2,1,7,\"foo\",\n";
+		nodeStr += "12,AST_STMT_LIST,,5,,0,11,,,\n";
+		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,6,bar,\n";
+		nodeStr += "14,AST_PARAM_LIST,,6,,0,13,,,\n";
+		nodeStr += "15,NULL,,6,,1,13,,,\n";
+		nodeStr += "16,AST_STMT_LIST,,6,,2,13,,,\n";
+		nodeStr += "17,NULL,,6,,3,13,,,\n";
+		nodeStr += "18,AST_CLASS,,9,,2,1,9,buz,\n";
+		nodeStr += "19,NULL,,9,,0,1,,,\n";
+		nodeStr += "20,NULL,,9,,1,1,,,\n";
+		nodeStr += "21,AST_TOPLEVEL,TOPLEVEL_CLASS,9,,2,1,9,\"buz\",\n";
+		nodeStr += "22,AST_STMT_LIST,,9,,0,21,,,\n";
+
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+		FunctionDef function4 = extractor.getNextFunction();
+		FunctionDef function5 = extractor.getNextFunction();
+
+		assertEquals("foo", function.getName().getEscapedCodeStr());
+		assertEquals("bar", function2.getName().getEscapedCodeStr());
+		assertEquals("[foo]", function3.getName().getEscapedCodeStr());
+		assertEquals("[buz]", function4.getName().getEscapedCodeStr());
+		assertEquals("<foo.php>", function5.getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * foo.php
+	 * -------
+	 * class foo {
+	 *   function foo() {}
+	 * }
+	 *
+	 * bar.php
+	 * -------
+	 * class bar {
+	 *   function bar() {}
+	 * }
+	 */
+	@Test
+	public void testTwoFilesWithClassesAndMethods() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,Directory,,,,,,,\"foobar\",\n";
+		nodeStr += "1,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/foo.php\",\n";
+		nodeStr += "3,AST_STMT_LIST,,1,,0,2,,,\n";
+		nodeStr += "4,AST_CLASS,,3,,0,2,5,foo,\n";
+		nodeStr += "5,NULL,,3,,0,2,,,\n";
+		nodeStr += "6,NULL,,3,,1,2,,,\n";
+		nodeStr += "7,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,2,5,\"foo\",\n";
+		nodeStr += "8,AST_STMT_LIST,,3,,0,7,,,\n";
+		nodeStr += "9,AST_METHOD,MODIFIER_PUBLIC,4,,0,7,4,foo,\n";
+		nodeStr += "10,AST_PARAM_LIST,,4,,0,9,,,\n";
+		nodeStr += "11,NULL,,4,,1,9,,,\n";
+		nodeStr += "12,AST_STMT_LIST,,4,,2,9,,,\n";
+		nodeStr += "13,NULL,,4,,3,9,,,\n";
+		nodeStr += "14,File,,,,,,,\"bar.php\",\n";
+		nodeStr += "15,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/bar.php\",\n";
+		nodeStr += "16,AST_STMT_LIST,,1,,0,15,,,\n";
+		nodeStr += "17,AST_CLASS,,3,,0,15,5,bar,\n";
+		nodeStr += "18,NULL,,3,,0,15,,,\n";
+		nodeStr += "19,NULL,,3,,1,15,,,\n";
+		nodeStr += "20,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,15,5,\"bar\",\n";
+		nodeStr += "21,AST_STMT_LIST,,3,,0,20,,,\n";
+		nodeStr += "22,AST_METHOD,MODIFIER_PUBLIC,4,,0,20,4,bar,\n";
+		nodeStr += "23,AST_PARAM_LIST,,4,,0,22,,,\n";
+		nodeStr += "24,NULL,,4,,1,22,,,\n";
+		nodeStr += "25,AST_STMT_LIST,,4,,2,22,,,\n";
+		nodeStr += "26,NULL,,4,,3,22,,,\n";
+
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		FunctionDef function = extractor.getNextFunction();
+		FunctionDef function2 = extractor.getNextFunction();
+		FunctionDef function3 = extractor.getNextFunction();
+		FunctionDef function4 = extractor.getNextFunction();
+		FunctionDef function5 = extractor.getNextFunction();
+		FunctionDef function6 = extractor.getNextFunction();
+
+		assertEquals("foo", function.getName().getEscapedCodeStr());
+		assertEquals("[foo]", function2.getName().getEscapedCodeStr());
+		assertEquals("<foobar/foo.php>", function3.getName().getEscapedCodeStr());
+		assertEquals("bar", function4.getName().getEscapedCodeStr());
+		assertEquals("[bar]", function5.getName().getEscapedCodeStr());
+		assertEquals("<foobar/bar.php>", function6.getName().getEscapedCodeStr());
 	}
 
 	/**
-	 * An invalid CSV file which contains no file node to
+	 * An invalid CSV file which contains no toplevel node of a file to
 	 * initialize top-level code.
 	 */
 	@Test(expected=InvalidCSVFile.class)
 	public void testInvalidNoFileNode() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		//nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,NULL,,3,,3,2,,,\n";
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		//nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
 
 		nodeReader = new StringReader(nodeStr);
 
@@ -355,12 +505,38 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_STMT_LIST,,1,,0,,,,\n";
-		//nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
-		nodeStr += "4,NULL,,3,,1,2,,,\n";
-		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
-		nodeStr += "6,NULL,,3,,3,2,,,\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		//nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+		
+		nodeReader = new StringReader(nodeStr);
+
+		extractor.initialize(nodeReader, edgeReader);
+		extractor.getNextFunction();
+	}
+	
+	/**
+	 * An invalid CSV file which contains a toplevel node of a file
+	 * before the previous file has been cleared by a new File node.
+	 */
+	@Test(expected=InvalidCSVFile.class)
+	public void testInvalidToplevelNodeWithoutFileNode() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+		//nodeStr += "8,File,,,,,,,\"bar.php\",\n";
+		nodeStr += "9,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"bar.php\",\n";
 		
 		nodeReader = new StringReader(nodeStr);
 

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -7,9 +7,10 @@ public class PHPCSVNodeTypes
 {
 	/* node row keys */
 	public static final String NODE_ID = "id";
-	public static final String NAME = "name";
 	public static final String TYPE = "type";
+	public static final String FLAGS = "flags";
 	public static final String FUNCID = "funcid";
+	public static final String NAME = "name";
 
 	/* node types */
 	// directory/file types
@@ -36,6 +37,10 @@ public class PHPCSVNodeTypes
 	// nodes with exactly 4 children
 	public static final String TYPE_FOR = "AST_FOR";
 
+	/* node flags */
+	// flags for toplevel nodes
+	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial
+	public static final String FLAG_TOPLEVEL_CLASS = "TOPLEVEL_CLASS"; // artificial
 
 
 }


### PR DESCRIPTION
I changed the phpjoern exporter so as to export artificial top-level function nodes for files and for classes.

More precisely, for these node types the exporter *now* exports:

    File --[FILE_OF]--> AST_TOPLEVEL --[PARENT_OF]--> AST_STMT_LIST
    AST_CLASS --[PARENT_OF]--> (extends)
              --[PARENT_OF]--> (implements)
              --[PARENT_OF]--> AST_TOPLEVEL --[PARENT_OF]--> AST_STMT_LIST

while *before* it exported:

    File --[FILE_OF]--> AST_STMT_LIST
    AST_CLASS --[PARENT_OF]--> (extends)
              --[PARENT_OF]--> (implements)
              --[PARENT_OF]--> AST_STMT_LIST

This allowed me to add support for classes and methods in the function extractor easily. In some places the code could even be somewhat simplified, since the function extractor does not need to insert its own artificial top-level nodes anymore.

Finally, all "function-declaring" nodes are handled correctly! :-)