### PR TITLE
Support for typed CSVKeys

### DIFF
--- a/src/inputModules/csv/KeyedCSV/CSVKey.java
+++ b/src/inputModules/csv/KeyedCSV/CSVKey.java
@@ -4,8 +4,17 @@ public class CSVKey
 {
 	private String name;
 	private String type;
-	private String nodeIndex;
+	public static final String DEFAULT_TYPE = "string";
 
+	public CSVKey(String name) {
+		this(name, DEFAULT_TYPE);
+	}
+
+	public CSVKey(String name, String type) {
+		this.name = name;
+		this.type = type;
+	}
+	
 	public String getName()
 	{
 		return name;
@@ -14,11 +23,6 @@ public class CSVKey
 	public String getType()
 	{
 		return type;
-	}
-
-	public String getNodeIndex()
-	{
-		return nodeIndex;
 	}
 
 	public void setName(String name)
@@ -30,10 +34,28 @@ public class CSVKey
 	{
 		this.type = type;
 	}
-
-	public void setNodeIndex(String nodeIndex)
-	{
-		this.nodeIndex = nodeIndex;
+	
+	@Override
+	public boolean equals(Object obj) {
+		if(!(obj instanceof CSVKey))
+			return false;
+		return this.name.equals(((CSVKey)obj).name) && this.type.equals(((CSVKey)obj).type);
 	}
+	
+	/**
+	 * Needed for HashMap<CSVKey,T>
+	 */
+	@Override
+	public int hashCode() {
+		// see {@link http://stackoverflow.com/a/113600}
+		int result = 1;
+		
+		String[] arr = {this.name, this.type};
+		for( String f : arr) {
+			int c = (null == f) ? 0 : f.hashCode();
+			result = 37 * result + c;
+		}
 
+		return result;
+	}
 }

--- a/src/inputModules/csv/KeyedCSV/CSVKey.java
+++ b/src/inputModules/csv/KeyedCSV/CSVKey.java
@@ -1,5 +1,7 @@
 package inputModules.csv.KeyedCSV;
 
+import java.util.Objects;
+
 public class CSVKey
 {
 	private String name;
@@ -47,15 +49,6 @@ public class CSVKey
 	 */
 	@Override
 	public int hashCode() {
-		// see {@link http://stackoverflow.com/a/113600}
-		int result = 1;
-		
-		String[] arr = {this.name, this.type};
-		for( String f : arr) {
-			int c = (null == f) ? 0 : f.hashCode();
-			result = 37 * result + c;
-		}
-
-		return result;
+		return Objects.hash(this.name, this.type);
 	}
 }

--- a/src/inputModules/csv/KeyedCSV/KeyedCSVReader.java
+++ b/src/inputModules/csv/KeyedCSV/KeyedCSVReader.java
@@ -43,22 +43,13 @@ public class KeyedCSVReader
 
 	}
 
-	public int getCurrentLineNumber()
-	{
-		return currentLineNumber;
-	}
-
 	private CSVKey createKeyFromFields(String field)
-	{
-		CSVKey key = new CSVKey();
-
+	{		
 		String[] keyParts = field.split(":");
-		key.setName(keyParts[0]);
+		CSVKey key = new CSVKey(keyParts[0]);
 		if (keyParts.length > 1)
 			key.setType(keyParts[1]);
-		if (keyParts.length > 2)
-			key.setNodeIndex(keyParts[2]);
-
+		
 		return key;
 	}
 
@@ -80,19 +71,25 @@ public class KeyedCSVReader
 		return keyedRow;
 	}
 
+
+	public boolean hasNextRow()
+	{
+		return iterator.hasNext();
+	}
+	
 	public void deinit() throws IOException
 	{
 		parser.close();
 	}
 
+	public int getCurrentLineNumber()
+	{
+		return currentLineNumber;
+	}
+	
 	public CSVKey[] getKeys()
 	{
 		return keys;
-	}
-
-	public boolean hasNextRow()
-	{
-		return iterator.hasNext();
 	}
 
 	public String getKeyRow()

--- a/src/inputModules/csv/KeyedCSV/KeyedCSVRow.java
+++ b/src/inputModules/csv/KeyedCSV/KeyedCSVRow.java
@@ -9,20 +9,12 @@ import org.apache.commons.csv.CSVRecord;
 public class KeyedCSVRow
 {
 	private CSVKey[] keys;
-	private Map<String, String> values = new HashMap<String, String>();
+	private Map<CSVKey,String> values = new HashMap<CSVKey,String>();
 	private String stringRepr;
 
 	public KeyedCSVRow(CSVKey[] keys)
 	{
 		this.keys = keys;
-	}
-
-	public String getFieldForKey(String key)
-	{
-		String val = values.get(key);
-		if (val == null)
-			return "";
-		return val;
 	}
 
 	public void initFromCSVRecord(CSVRecord record)
@@ -33,8 +25,7 @@ public class KeyedCSVRow
 		while (recIt.hasNext())
 		{
 			String r = recIt.next();
-			String keyStr = keys[i].getName();
-			values.put(keyStr, r);
+			values.put(keys[i], r);
 			stringRepr += r;
 			if (recIt.hasNext())
 				stringRepr += ",";
@@ -42,6 +33,12 @@ public class KeyedCSVRow
 		}
 	}
 
+	public String getFieldForKey(CSVKey key)
+	{
+		String val = values.get(key);
+		return (null == val) ? "" : val;
+	}
+	
 	@Override
 	public String toString()
 	{

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -20,9 +20,7 @@ public class TestCSV2AST
 	// See {@link http://neo4j.com/docs/stable/import-tool-header-format.html} for detailed
 	// information about the header file format
 	String nodeHeader = "id:ID,type,flags:string[],lineno:int,code,childnum:int,funcid:int,endlineno:int,name,doccomment\n";
-	// TODO the edge header contains types, not names, i.e., it should be:
-	//String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
-	String edgeHeader = "START_ID,END_ID,TYPE\n";
+	String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
 
 	@Test
 	public void testFunctionCreation() throws IOException, InvalidCSVFile

--- a/src/tests/inputModules/TestCSVKey.java
+++ b/src/tests/inputModules/TestCSVKey.java
@@ -1,0 +1,54 @@
+package tests.inputModules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import inputModules.csv.KeyedCSV.CSVKey;
+
+public class TestCSVKey
+{
+
+	@Test
+	public void testCSVKeyEquality()
+	{
+		CSVKey key1 = new CSVKey("foo", "bar");
+		CSVKey key2 = new CSVKey("foo", "bar");
+
+		assertEquals(key1, key2);
+	}
+	
+	@Test
+	public void testCSVKeyInEquality()
+	{
+		CSVKey key1 = new CSVKey("foo", "bar");
+		CSVKey key2 = new CSVKey("foo", "buz");
+		CSVKey key3 = new CSVKey("qux", "bar");
+
+		assertNotEquals(key1, key2);
+		assertNotEquals(key1, key3);
+		assertNotEquals(key2, key3);
+	}
+
+	@Test
+	public void testCSVKeyHashMap()
+	{
+		HashMap<CSVKey,String> values = new HashMap<CSVKey,String>();
+		CSVKey key1 = new CSVKey("foo", "bar");
+		CSVKey key2 = new CSVKey("foo", "bar");
+		CSVKey key3 = new CSVKey("foo", "buz");
+		
+		values.put(key1, "one");
+		values.put(key2, "two");
+		values.put(key3, "three");
+
+		assertEquals(values.size(), 2);
+		assertEquals(values.get(key1), "two");
+		assertEquals(values.get(key2), "two");
+		assertEquals(values.get(key3), "three");
+	}
+	
+}

--- a/src/tests/inputModules/TestKeyedCSVReader.java
+++ b/src/tests/inputModules/TestKeyedCSVReader.java
@@ -17,7 +17,9 @@ public class TestKeyedCSVReader
 	@Test
 	public void testSimpleHeaderParsing() throws IOException
 	{
-		KeyedCSVReader csvReader = initReaderWithString("foo,bar\n1,2");
+		String csvStr = "foo,bar\n";
+		csvStr += "1,2";
+		KeyedCSVReader csvReader = initReaderWithString(csvStr);
 		CSVKey[] keys = csvReader.getKeys();
 		assertEquals(keys.length, 2);
 		assertEquals("foo", keys[0].getName());
@@ -27,37 +29,40 @@ public class TestKeyedCSVReader
 	@Test
 	public void testHeaderWithTypeParsing() throws IOException
 	{
-		KeyedCSVReader csvReader = initReaderWithString("foo:type,bar\n1,2");
+		String csvStr = "foo:type,bar\n";
+		csvStr += "1,2";
+		KeyedCSVReader csvReader = initReaderWithString(csvStr);
 		CSVKey[] keys = csvReader.getKeys();
 		assertEquals("foo", keys[0].getName());
 		assertEquals("type", keys[0].getType());
-	}
-
-	@Test
-	public void testHeaderWithTypeAndIndexParsing() throws IOException
-	{
-		KeyedCSVReader csvReader = initReaderWithString(
-				"foo:type:nodeIndex,bar\n1,2");
-		CSVKey[] keys = csvReader.getKeys();
-		assertEquals("foo", keys[0].getName());
-		assertEquals("type", keys[0].getType());
-		assertEquals("nodeIndex", keys[0].getNodeIndex());
+		assertEquals("bar", keys[1].getName());
+		assertEquals("string", keys[1].getType());
 	}
 
 	@Test
 	public void testFieldRetrieval() throws IOException
 	{
-		KeyedCSVReader csvReader = initReaderWithString("foo,bar\n1,2");
+		String csvStr = "foo,bar:int,:unnamedtype\n";
+		csvStr += "1,2,3";
+		KeyedCSVReader csvReader = initReaderWithString(csvStr);
 		KeyedCSVRow row = csvReader.getNextRow();
 
-		String field = row.getFieldForKey("foo");
+		String field = row.getFieldForKey(new CSVKey("foo"));
+		String samefield = row.getFieldForKey(new CSVKey("foo", "string"));
+		String field2 = row.getFieldForKey(new CSVKey("bar", "int"));
+		String field3 = row.getFieldForKey(new CSVKey("", "unnamedtype"));
+
 		assertEquals("1", field);
+		assertEquals("1", samefield);
+		assertEquals("2", field2);
+		assertEquals("3", field3);
 	}
 
 	@Test
 	public void testEOF() throws IOException
 	{
-		KeyedCSVReader csvReader = initReaderWithString("foo,bar");
+		String csvStr = "foo,bar";
+		KeyedCSVReader csvReader = initReaderWithString(csvStr);
 		KeyedCSVRow row = csvReader.getNextRow();
 		assertEquals(row, null);
 	}
@@ -65,17 +70,23 @@ public class TestKeyedCSVReader
 	@Test
 	public void testQuoting() throws IOException
 	{
-		KeyedCSVReader csvReader = initReaderWithString("foo,bar\n\"1\",2");
+		String csvStr = "foo,bar\n";
+		csvStr += "\"1\",2";
+
+		KeyedCSVReader csvReader = initReaderWithString(csvStr);
 		KeyedCSVRow row = csvReader.getNextRow();
-		assertEquals("1", row.getFieldForKey("foo"));
+		assertEquals("1", row.getFieldForKey(new CSVKey("foo")));
 	}
 
 	@Test
 	public void testQuoteInQuote() throws IOException
 	{
-		KeyedCSVReader csvReader = initReaderWithString("foo,bar\n\"\\\"1\",2");
+		String csvStr = "foo,bar\n";
+		csvStr += "\"\\\"1\",2";
+		
+		KeyedCSVReader csvReader = initReaderWithString(csvStr);
 		KeyedCSVRow row = csvReader.getNextRow();
-		assertEquals("\"1", row.getFieldForKey("foo"));
+		assertEquals("\"1", row.getFieldForKey(new CSVKey("foo")));
 	}
 
 	private KeyedCSVReader initReaderWithString(String str) throws IOException

--- a/src/tools/phpast2cfg/PHPCSVEdgeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeTypes.java
@@ -1,11 +1,13 @@
 package tools.phpast2cfg;
 
+import inputModules.csv.KeyedCSV.CSVKey;
+
 public class PHPCSVEdgeTypes
 {
 	/* edge row key types */
-	public static final String START_ID = "START_ID";
-	public static final String END_ID = "END_ID";
-	public static final String TYPE = "TYPE";
+	public static final CSVKey START_ID = new CSVKey("", "START_ID");
+	public static final CSVKey END_ID = new CSVKey("", "END_ID");
+	public static final CSVKey TYPE = new CSVKey("", "TYPE");
 
 	/* edge types */
 	public static final String TYPE_FILE_OF = "FILE_OF";

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -66,7 +66,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 
 		ASTNode newNode = new ASTNode();
-		newNode.setProperty(PHPCSVNodeTypes.TYPE, type);
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		ast.addNodeWithId(newNode, id);
 		
 		return id;

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -3,14 +3,16 @@ package tools.phpast2cfg;
 import java.util.Arrays;
 import java.util.List;
 
+import inputModules.csv.KeyedCSV.CSVKey;
+
 public class PHPCSVNodeTypes
 {
 	/* node row keys */
-	public static final String NODE_ID = "id";
-	public static final String TYPE = "type";
-	public static final String FLAGS = "flags";
-	public static final String FUNCID = "funcid";
-	public static final String NAME = "name";
+	public static final CSVKey NODE_ID = new CSVKey("id","ID");
+	public static final CSVKey TYPE = new CSVKey("type");
+	public static final CSVKey FLAGS = new CSVKey("flags","string[]");
+	public static final CSVKey FUNCID =new CSVKey("funcid","int");
+	public static final CSVKey NAME = new CSVKey("name");
 
 	/* node types */
 	// directory/file types


### PR DESCRIPTION
CSV keys such as `type:flags[]` or `funcid:int` are not only identified by their name, but by their name as well as their type.

Sometimes this is important. In particular, the header format used by the edge files consists of type specifications rather than names. It is

    :START_ID,:END_ID,:TYPE

and *not*

    START_ID,END_ID,TYPE

See http://neo4j.com/docs/stable/import-tool-header-format.html as well as http://neo4j.com/docs/stable/import-tool-examples.html.

The previous architecture did not allow us to import such unnamed-but-typed fields from CSV files.

Therefore I had to change the class `KeyedCSVRow` to maintain a `HashMap<CSVKey,String>` of values instead of a `HashMap<String,String>`. This feels "cleaner" anyway. :-) After all, the CSVKey is the key, as the name of the class itself says...

For this to work properly, the `CSVKey` class has to override the standard `equals(Object)` and `hashCode()` methods. Some tests have additionally been added in a new class `TestCSVKey`. Some other classes had to be changed accordingly as well.

The `TestCSV2AST` class is also of interest here, since it is now able to use the proper header format, and in particular `testSimpleEdgeImport()` works.

All of this will allow us to parse edge CSV files exactly as output by the phpjoern parser. In particular, the foundation is laid for the `CSVFunctionExtractor` to be able to import edges as well (note that it currently only imports nodes, but never connects them, as it never even reads from the edges CSV file, except for the header line). I'm working on this now; once this is done, the CSVFunctionExtractor will be finished.