### PR TITLE
Support for all properties defined by the PHP ASTs

### DIFF
--- a/src/ast/ASTNode.java
+++ b/src/ast/ASTNode.java
@@ -66,6 +66,14 @@ public class ASTNode
 			return null;
 		return retval;
 	}
+	
+	public void setFlags(String flags) {
+		setProperty(ASTNodeProperties.FLAGS, flags);
+	}
+	
+	public String getFlags() {
+		return getProperty(ASTNodeProperties.FLAGS);
+	}
 
 	public void addChild(ASTNode node)
 	{

--- a/src/ast/ASTNodeProperties.java
+++ b/src/ast/ASTNodeProperties.java
@@ -2,7 +2,7 @@ package ast;
 
 public class ASTNodeProperties
 {
-
+	public static final String NAME = "name";
 	public static final String CODE = "code";
 
 }

--- a/src/ast/ASTNodeProperties.java
+++ b/src/ast/ASTNodeProperties.java
@@ -4,6 +4,7 @@ public class ASTNodeProperties
 {
 	public static final String FLAGS = "flags";
 	public static final String NAME = "name";
+	public static final String DOCCOMMENT = "doccomment";
 	public static final String CODE = "code";
 
 }

--- a/src/ast/ASTNodeProperties.java
+++ b/src/ast/ASTNodeProperties.java
@@ -2,6 +2,7 @@ package ast;
 
 public class ASTNodeProperties
 {
+	public static final String FLAGS = "flags";
 	public static final String NAME = "name";
 	public static final String CODE = "code";
 

--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -1,6 +1,7 @@
 package ast.functionDef;
 
 import ast.ASTNode;
+import ast.ASTNodeProperties;
 import ast.DummyIdentifierNode;
 import ast.expressions.Identifier;
 import ast.logical.statements.CompoundStatement;
@@ -23,6 +24,14 @@ public class FunctionDef extends ASTNode
 			setIdentifier((Identifier) node);
 
 		super.addChild(node);
+	}
+	
+	public String getName() {
+		return getProperty(ASTNodeProperties.NAME);
+	}
+	
+	public void setName(String name) {
+		setProperty(ASTNodeProperties.NAME, name);
 	}
 
 	public CompoundStatement getContent()

--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -33,6 +33,14 @@ public class FunctionDef extends ASTNode
 	public void setName(String name) {
 		setProperty(ASTNodeProperties.NAME, name);
 	}
+	
+	public String getDocComment() {
+		return getProperty(ASTNodeProperties.DOCCOMMENT);
+	}
+	
+	public void setDocComment(String doccomment) {
+		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
+	}
 
 	public CompoundStatement getContent()
 	{

--- a/src/ast/php/functionDef/TopLevelFunctionDef.java
+++ b/src/ast/php/functionDef/TopLevelFunctionDef.java
@@ -15,12 +15,6 @@ public class TopLevelFunctionDef extends FunctionDef
 	}
 
 	@Override
-	public String getFunctionSignature()
-	{
-		return getIdentifier().getEscapedCodeStr();
-	}
-
-	@Override
 	public ParameterList getParameterList()
 	{
 		return null;

--- a/src/inputModules/csv/csv2ast/CSV2AST.java
+++ b/src/inputModules/csv/csv2ast/CSV2AST.java
@@ -76,7 +76,7 @@ public class CSV2AST
 		}
 	}
 
-	private void createASTEdges()
+	private void createASTEdges() throws InvalidCSVFile
 	{
 		KeyedCSVRow keyedRow;
 		while ((keyedRow = reader.getNextRow()) != null)

--- a/src/inputModules/csv/csv2ast/CSVRowInterpreter.java
+++ b/src/inputModules/csv/csv2ast/CSVRowInterpreter.java
@@ -1,8 +1,9 @@
 package inputModules.csv.csv2ast;
 
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 
 public interface CSVRowInterpreter
 {
-	public long handle(KeyedCSVRow row, ASTUnderConstruction ast);
+	public long handle(KeyedCSVRow row, ASTUnderConstruction ast) throws InvalidCSVFile;
 }

--- a/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
+++ b/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
@@ -28,6 +28,7 @@ public class CSVFunctionExtractor
 	Queue<CSVAST> csvFifoQueue = new LinkedList<CSVAST>();
 	Map<CSVAST,Set<String>> csvNodeIds = new HashMap<CSVAST,Set<String>>();
 	CSV2AST csv2ast = new CSV2AST();
+	
 	public void setLanguage(String language)
 	{
 		csv2ast.setLanguage(language);
@@ -42,6 +43,12 @@ public class CSVFunctionExtractor
 		edgeReader.init(edgeStrReader);
 	}
 	
+	/**
+	 * Returns a function node by reading from the node and edge
+	 * readers and extracting and converting the next function.
+	 * 
+	 * @return The next function node, or null if there are none.
+	 */
 	public FunctionDef getNextFunction()
 			throws IOException, InvalidCSVFile
 	{	
@@ -84,10 +91,9 @@ public class CSVFunctionExtractor
 	 *    it looks for that funcId within the stack. In a valid CSV file, this
 	 *    funcId must have been previously declared by a function declaration.
 	 *    a) If it is not found, an exception is thrown.
-	 *    b) If it is found, the line is added to the correct csvAST within the stack.
-	 *       Additionally, we know that we finished scanning at least one function (since
+	 *    b) If it is found, we know that we finished scanning at least one function (since
 	 *       we got back to the "outer" scope). The distance from the top of the stack to
-	 *       the csvAST that we just added the current line to is the number of functions
+	 *       the csvAST that corresponds to the current funcId is the number of functions
 	 *       that we finished scanning. We pop the csvStack (and the funcIdStack) that many
 	 *       times and put the popped CSVAST's in the csvFifoQueue.
 	 */
@@ -128,8 +134,7 @@ public class CSVFunctionExtractor
 				// create a new top-level function at the bottom of the stack and add current row
 				String topLevelFuncId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.NODE_ID);
 				initCSVAST(topLevelFuncId);
-				csvStack.peek().addNodeRow( currNodeRow.toString());
-				addIdToTopCSVNodeIds(topLevelFuncId);
+				addRowToTopCSVAST(currNodeRow);
 
 				continue;
 			}
@@ -142,25 +147,20 @@ public class CSVFunctionExtractor
 
 			String currFuncId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.FUNCID);
 
-			// the funcid is still the same
-			if( currFuncId.equals( funcIdStack.peek()))
-				addRowAndInitASTForFuncType(currNodeRow, currType);
-			// the funcid changed
-			else {
-				// how many functions did we just finish?
-				int finishedFunctions = funcIdStack.search(currFuncId) - 1;
-				// if currFuncId is not in the stack, fail; this should never happen with a valid CSV file
-				if( finishedFunctions < 1)
-					throw new InvalidCSVFile( "nodeReader, line " + nodeReader.getCurrentLineNumber() + ": "
-							+ "funcid " + currFuncId + " has never been initialized by a function declaration.");
-				// put finished functions into the finished functions queue
-				for( int i = 0; i < finishedFunctions; i++) {
-					csvFifoQueue.add( csvStack.pop());
-					funcIdStack.pop();
-				}
-				// put the current line on the correct CSVAST
-				addRowAndInitASTForFuncType(currNodeRow, currType);
+			// how many functions did we just finish?
+			// (0 = currFuncId corresponds to CSVAST currently on top of stack)
+			int finishedFunctions = funcIdStack.search(currFuncId) - 1;
+			// if currFuncId is not in the stack, fail; this should never happen with a valid CSV file
+			if( finishedFunctions < 0)
+				throw new InvalidCSVFile( "nodeReader, line " + nodeReader.getCurrentLineNumber() + ": "
+						+ "funcid " + currFuncId + " has never been initialized by a function declaration.");
+			// put finished functions into the finished functions queue
+			for( int i = 0; i < finishedFunctions; i++) {
+				csvFifoQueue.add( csvStack.pop());
+				funcIdStack.pop();
 			}
+			// put the current line on the correct CSVAST's
+			addRowAndInitASTForFuncType(currNodeRow);
 		}
 
 		// If we are here, it means one of two things:
@@ -215,7 +215,36 @@ public class CSVFunctionExtractor
 		// We're done with the set of CSVASTs in the current file, let's clean up
 		csvNodeIds.clear();
 	}
+
+	/**
+	 * Adds a row to the CSVAST currently on top of the stack, checks the type
+	 * of the row, inits a new CSVAST if it is a function type, and also adds
+	 * the row onto the newly inited CSVAST (see javadoc of addNodeRowsUntilNextFile())
+	 * 
+	 * @param currNodeRow The row to add.
+	 */
+	private void addRowAndInitASTForFuncType(KeyedCSVRow currNodeRow)
+	{
+		String currId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.NODE_ID);
+		String currType = currNodeRow.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		addRowToTopCSVAST(currNodeRow);
+		if( PHPCSVNodeTypes.funcTypes.contains(currType)) {
+			// if we met a function declaration node, push a new CSVAST atop the stack
+			initCSVAST(currId);
+			// *also* add the declaration onto the newly created CSVAST
+			addRowToTopCSVAST(currNodeRow);
+		}
+	}
 	
+	/**
+	 * Puts a new CSVAST on top of the stack, with the usual key rows.
+	 * Accordingly pushes the functionNodeId parameter on top of the
+	 * funcIdStack.
+	 * 
+	 * @param functionNodeId The node id to push on top of the funcIdStack.
+	 *                       We expect this node id to be the node id of
+	 *                       a function declaration row.
+	 */
 	private void initCSVAST(String functionNodeId)
 	{
 		CSVAST csvAST = new CSVAST();
@@ -224,32 +253,25 @@ public class CSVFunctionExtractor
 		csvStack.push(csvAST);
 		funcIdStack.push(functionNodeId);
 	}
-
-	private void addRowAndInitASTForFuncType(KeyedCSVRow currNodeRow, String currType)
-	{
-		String currId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.NODE_ID);
-		csvStack.peek().addNodeRow( currNodeRow.toString());
-		addIdToTopCSVNodeIds(currId);
-		if( PHPCSVNodeTypes.funcTypes.contains(currType)) {
-			// if we met a function declaration node, push a new CSVAST atop the stack
-			initCSVAST(currId);
-			// *also* add the declaration onto the newly created CSVAST
-			// (see javadoc of getNextFunction())
-			csvStack.peek().addNodeRow( currNodeRow.toString());
-			addIdToTopCSVNodeIds(currId);
-		}
-	}
 	
 	/**
-	 * Adds a given nodeId to the set of nodes for the CSVAST currently
-	 * on top of the stack. Initializes a new Set if it has not been
-	 * initialized yet.
+	 * Adds a row to the CSVAST currently on top of the stack, and
+	 * adds the row's node id to the set of nodes for this CSVAST.
+	 * Initializes a new Set if it has not been initialized yet.
+	 * 
+	 * @param currNodeRow The row to add.
 	 */
-	private void addIdToTopCSVNodeIds(String nodeId) {
+	private void addRowToTopCSVAST(KeyedCSVRow currNodeRow) {
+
+		// add row to CSVAST on top of stack
 		CSVAST csvAST = csvStack.peek();
+		csvAST.addNodeRow( currNodeRow.toString());
+
+		// add id to list of ids of the CSVAST on top of stack
+		String currId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.NODE_ID);
 		if( !csvNodeIds.containsKey(csvAST))
 			csvNodeIds.put(csvAST, new HashSet<String>());
 		Set<String> nodeSet = csvNodeIds.get(csvAST);
-		nodeSet.add(nodeId);
+		nodeSet.add(currId);
 	}
 }

--- a/src/languages/c/parsing/CodeLocation.java
+++ b/src/languages/c/parsing/CodeLocation.java
@@ -6,6 +6,7 @@ public class CodeLocation
 	final public static int NOT_SET = -1;
 
 	public int startLine = NOT_SET;
+	public int endLine = NOT_SET;
 	public int startPos = NOT_SET;
 	public int startIndex = NOT_SET;
 	public int stopIndex = NOT_SET;

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -88,6 +88,44 @@ public class TestCSV2AST
 	 * }
 	 */
 	@Test
+	public void testCodeStr() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
+		nodeStr += "3,AST_PARAM_LIST,,3,,0,2,,,\n";
+		nodeStr += "4,NULL,,3,,1,2,,,\n";
+		nodeStr += "5,AST_STMT_LIST,,3,,2,2,,,\n";
+		nodeStr += "6,AST_ASSIGN,,4,,0,2,,,\n";
+		nodeStr += "7,AST_VAR,,4,,0,2,,,\n";
+		nodeStr += "8,string,,4,\"a\",0,2,,,\n";
+		nodeStr += "9,integer,,4,3,1,2,,,\n";
+		nodeStr += "10,NULL,,3,,3,2,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "2,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "2,5,PARENT_OF\n";
+		edgeStr += "2,10,PARENT_OF\n";
+
+		FunctionDef func = createASTFromStrings(nodeStr, edgeStr);
+		CompoundStatement content = func.getContent();
+
+		// TODO: well this is gonna look a lot nicer once we mapped all PHP AST constructs
+		// and have an inherent understanding of their structure. But for now this shows it works ;)
+		assertEquals("a", content.getStatements().get(0).getChild(0).getChild(0).getEscapedCodeStr());
+		assertEquals("3", content.getStatements().get(0).getChild(1).getEscapedCodeStr());
+	}
+	
+	/**
+	 * function foo() {
+	 *   $a = 3;
+	 * }
+	 */
+	@Test
 	public void testSimpleEdgeImport() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -75,11 +75,12 @@ public class TestCSV2AST
 	public void testMethodLocation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,6,bar,\n";
+		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,36,bar,\n";
 		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertEquals("bar", func.getName());
 		assertEquals(6, func.getLocation().startLine);
+		assertEquals(36, func.getLocation().endLine);
 	}
 	
 	/**

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -59,6 +59,17 @@ public class TestCSV2AST
 		
 		assertEquals("", func.getName());
 	}
+	
+	@Test
+	public void testMethodFlags() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,6,bar,\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		
+		assertEquals("bar", func.getName());
+		assertEquals("MODIFIER_PUBLIC", func.getFlags());
+	}
 
 	/**
 	 * function foo() {
@@ -103,6 +114,18 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		
+		createASTFromStrings(nodeStr, edgeHeader);
+	}
+	
+	/**
+	 * An invalid CSV file that contains a toplevel node with invalid flags.
+	 */
+	@Test
+	public void testInvalidTopLevelFuncFlags() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "1,AST_TOPLEVEL,somerandomflags,,,,,,\"foo.php\",\n";
 		
 		createASTFromStrings(nodeStr, edgeHeader);
 	}

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -83,6 +83,17 @@ public class TestCSV2AST
 		assertEquals(36, func.getLocation().endLine);
 	}
 	
+	@Test
+	public void testDocComment() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FUNC_DECL,,4,,0,1,4,foo,\"/** This is a doccomment */\"\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		
+		assertEquals("foo", func.getName());
+		assertEquals("/** This is a doccomment */", func.getDocComment());
+	}
+	
 	/**
 	 * function foo() {
 	 *   $a = 3;

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -171,7 +171,7 @@ public class TestCSV2AST
 	/**
 	 * An invalid CSV file that contains a toplevel node with invalid flags.
 	 */
-	@Test
+	@Test(expected=InvalidCSVFile.class)
 	public void testInvalidTopLevelFuncFlags() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -71,6 +71,17 @@ public class TestCSV2AST
 		assertEquals("MODIFIER_PUBLIC", func.getFlags());
 	}
 
+	@Test
+	public void testMethodLocation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,6,bar,\n";
+		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		
+		assertEquals("bar", func.getName());
+		assertEquals(6, func.getLocation().startLine);
+	}
+	
 	/**
 	 * function foo() {
 	 *   $a = 3;

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -687,8 +687,7 @@ public class TestCSVFunctionExtractor
 	}
 	
 	/**
-	 * An invalid CSV file which contains a toplevel node of a file
-	 * before the previous file has been cleared by a new File node.
+	 * An invalid CSV file which contains an invalid edge type.
 	 */
 	@Test(expected=InvalidCSVFile.class)
 	public void testInvalidEdgeType() throws IOException, InvalidCSVFile

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -75,8 +75,8 @@ public class TestCSVFunctionExtractor
 		FunctionDef function2 = extractor.getNextFunction();
 		FunctionDef function3 = extractor.getNextFunction();
 
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function2.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("<foo.php>", function2.getName());
 		assertEquals(null, function3);
 	}
 
@@ -107,8 +107,8 @@ public class TestCSVFunctionExtractor
 		FunctionDef function2 = extractor.getNextFunction();
 		FunctionDef function3 = extractor.getNextFunction();
 		
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function2.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("<foo.php>", function2.getName());
 		assertEquals(null, function3);
 	}
 
@@ -143,8 +143,8 @@ public class TestCSVFunctionExtractor
 		FunctionDef function2 = extractor.getNextFunction();
 		FunctionDef function3 = extractor.getNextFunction();
 
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function2.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("<foo.php>", function2.getName());
 		assertEquals(null, function3);
 	}
 
@@ -178,9 +178,9 @@ public class TestCSVFunctionExtractor
 		FunctionDef function3 = extractor.getNextFunction();
 		FunctionDef function4 = extractor.getNextFunction();
 
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("bar", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function3.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("bar", function2.getName());
+		assertEquals("<foo.php>", function3.getName());
 		assertEquals(null, function4);
 	}
 	
@@ -215,9 +215,9 @@ public class TestCSVFunctionExtractor
 		FunctionDef function3 = extractor.getNextFunction();
 		FunctionDef function4 = extractor.getNextFunction();
 
-		assertEquals("bar", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("foo", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function3.getIdentifier().getEscapedCodeStr());
+		assertEquals("bar", function.getName());
+		assertEquals("foo", function2.getName());
+		assertEquals("<foo.php>", function3.getName());
 		assertEquals(null, function4);
 	}
 	
@@ -259,10 +259,10 @@ public class TestCSVFunctionExtractor
 		FunctionDef function4 = extractor.getNextFunction();
 		FunctionDef function5 = extractor.getNextFunction();
 
-		assertEquals("bar", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("foo", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("buz", function3.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function4.getIdentifier().getEscapedCodeStr());
+		assertEquals("bar", function.getName());
+		assertEquals("foo", function2.getName());
+		assertEquals("buz", function3.getName());
+		assertEquals("<foo.php>", function4.getName());
 		assertEquals(null, function5);
 	}
 
@@ -297,9 +297,9 @@ public class TestCSVFunctionExtractor
 		FunctionDef function3 = extractor.getNextFunction();
 		FunctionDef function4 = extractor.getNextFunction();
 
-		assertEquals("{closure}", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("foo", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function3.getIdentifier().getEscapedCodeStr());
+		assertEquals("{closure}", function.getName());
+		assertEquals("foo", function2.getName());
+		assertEquals("<foo.php>", function3.getName());
 		assertEquals(null, function4);
 	}
 
@@ -343,10 +343,10 @@ public class TestCSVFunctionExtractor
 		FunctionDef function4 = extractor.getNextFunction();
 		FunctionDef function5 = extractor.getNextFunction();
 
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foobar/foo.php>", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("bar", function3.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foobar/bar.php>", function4.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("<foobar/foo.php>", function2.getName());
+		assertEquals("bar", function3.getName());
+		assertEquals("<foobar/bar.php>", function4.getName());
 		assertEquals(null, function5);
 	}
 	
@@ -373,8 +373,8 @@ public class TestCSVFunctionExtractor
 		FunctionDef function2 = extractor.getNextFunction();
 		FunctionDef function3 = extractor.getNextFunction();
 
-		assertEquals("[foo]", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function2.getIdentifier().getEscapedCodeStr());
+		assertEquals("[foo]", function.getName());
+		assertEquals("<foo.php>", function2.getName());
 		assertEquals(null, function3);
 	}
 	
@@ -423,11 +423,11 @@ public class TestCSVFunctionExtractor
 		FunctionDef function5 = extractor.getNextFunction();
 		FunctionDef function6 = extractor.getNextFunction();
 
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("bar", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("[foo]", function3.getIdentifier().getEscapedCodeStr());
-		assertEquals("[buz]", function4.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foo.php>", function5.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("bar", function2.getName());
+		assertEquals("[foo]", function3.getName());
+		assertEquals("[buz]", function4.getName());
+		assertEquals("<foo.php>", function5.getName());
 		assertEquals(null, function6);
 	}
 	
@@ -486,12 +486,12 @@ public class TestCSVFunctionExtractor
 		FunctionDef function5 = extractor.getNextFunction();
 		FunctionDef function6 = extractor.getNextFunction();
 
-		assertEquals("foo", function.getIdentifier().getEscapedCodeStr());
-		assertEquals("[foo]", function2.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foobar/foo.php>", function3.getIdentifier().getEscapedCodeStr());
-		assertEquals("bar", function4.getIdentifier().getEscapedCodeStr());
-		assertEquals("[bar]", function5.getIdentifier().getEscapedCodeStr());
-		assertEquals("<foobar/bar.php>", function6.getIdentifier().getEscapedCodeStr());
+		assertEquals("foo", function.getName());
+		assertEquals("[foo]", function2.getName());
+		assertEquals("<foobar/foo.php>", function3.getName());
+		assertEquals("bar", function4.getName());
+		assertEquals("[bar]", function5.getName());
+		assertEquals("<foobar/bar.php>", function6.getName());
 	}
 
 	/**
@@ -605,13 +605,8 @@ public class TestCSVFunctionExtractor
 		FunctionDef function = extractor.getNextFunction();
 		FunctionDef function2 = extractor.getNextFunction();
 
-		// TODO should be 5, not 4
-		// We have 5 here because currently every FunctionDef node
-		// has an unwanted child (Identifier). Remove that.
-		assertEquals(5, function.getChildCount());
-		// TODO equally, for toplevel functions, it should be 1, not 2
-		assertEquals(2, function2.getChildCount());
-		
+		assertEquals(4, function.getChildCount());
+		assertEquals(1, function2.getChildCount());
 		assertEquals(1, function2.getContent().getChildCount());
 	}
 	
@@ -673,12 +668,10 @@ public class TestCSVFunctionExtractor
 		FunctionDef function3 = extractor.getNextFunction();
 		FunctionDef function4 = extractor.getNextFunction();
 
-		// TODO again, it should be 4 instead of 5 for normal functions,
-		// and 1 instead of 2 for toplevel functions
-		assertEquals(5, function.getChildCount());
-		assertEquals(2, function2.getChildCount());
-		assertEquals(5, function3.getChildCount());
-		assertEquals(2, function4.getChildCount());
+		assertEquals(4, function.getChildCount());
+		assertEquals(1, function2.getChildCount());
+		assertEquals(4, function3.getChildCount());
+		assertEquals(1, function4.getChildCount());
 		
 		assertEquals(0, function.getContent().getChildCount());
 		assertEquals(1, function2.getContent().getChildCount());

--- a/src/tests/inputModules/TestKeyedCSVReader.java
+++ b/src/tests/inputModules/TestKeyedCSVReader.java
@@ -14,6 +14,14 @@ import inputModules.csv.KeyedCSV.KeyedCSVRow;
 public class TestKeyedCSVReader
 {
 
+	private KeyedCSVReader initReaderWithString(String str) throws IOException
+	{
+		KeyedCSVReader csvReader = new KeyedCSVReader();
+		StringReader reader = new StringReader(str);
+		csvReader.init(reader);
+		return csvReader;
+	}
+	
 	@Test
 	public void testSimpleHeaderParsing() throws IOException
 	{
@@ -88,13 +96,4 @@ public class TestKeyedCSVReader
 		KeyedCSVRow row = csvReader.getNextRow();
 		assertEquals("\"1", row.getFieldForKey(new CSVKey("foo")));
 	}
-
-	private KeyedCSVReader initReaderWithString(String str) throws IOException
-	{
-		KeyedCSVReader csvReader = new KeyedCSVReader();
-		StringReader reader = new StringReader(str);
-		csvReader.init(reader);
-		return csvReader;
-	}
-
 }

--- a/src/tools/phpast2cfg/PHPCSVEdgeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeTypes.java
@@ -4,7 +4,7 @@ import inputModules.csv.KeyedCSV.CSVKey;
 
 public class PHPCSVEdgeTypes
 {
-	/* edge row key types */
+	/* edge row keys */
 	public static final CSVKey START_ID = new CSVKey("", "START_ID");
 	public static final CSVKey END_ID = new CSVKey("", "END_ID");
 	public static final CSVKey TYPE = new CSVKey("", "TYPE");

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -91,10 +91,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
+		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
 			newNode.setName("<" + name + ">");
@@ -118,10 +120,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
+		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		newNode.setName(name);
 
@@ -139,10 +143,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
+		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		newNode.setName(name);
 
@@ -160,10 +166,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
+		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		newNode.setName(name);
 

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -14,6 +14,7 @@ import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
+import languages.c.parsing.CodeLocation;
 
 public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 {
@@ -66,9 +67,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -82,9 +87,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		TopLevelFunctionDef newNode = new TopLevelFunctionDef();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
 			newNode.setName("<" + name + ">");
 		else if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS))
@@ -105,9 +114,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		FunctionDef newNode = new FunctionDef();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
@@ -122,9 +135,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		Method newNode = new Method();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
@@ -139,9 +156,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		Closure newNode = new Closure();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
@@ -155,8 +176,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		CompoundStatement newNode = new CompoundStatement();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -169,8 +194,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		IfStatement newNode = new IfStatement();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -183,8 +212,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		ForStatement newNode = new ForStatement();
 		
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -197,8 +230,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		DoStatement newNode = new DoStatement();
 		
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -211,8 +248,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		WhileStatement newNode = new WhileStatement();
 		
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		
 		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -90,18 +90,20 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
-		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
-		codeloc.startLine = Integer.parseInt(lineno);
-		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
 			newNode.setName("<" + name + ">");
-		else if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS))
+		else if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS)) {
+			// TODO: define startLine and endLine for toplevel nodes of files also
+			codeloc.startLine = Integer.parseInt(lineno);
+			codeloc.endLine = Integer.parseInt(endlineno);
 			newNode.setName("[" + name + "]");
+		}
 		else
 			throw new InvalidCSVFile("While trying to handle row " + row.toString() + ": "
 					+ "Invalid toplevel flags " + flags + ".");
@@ -119,8 +121,8 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
-		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
@@ -142,8 +144,8 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
-		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
@@ -165,8 +167,8 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
-		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -123,6 +123,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
@@ -130,6 +131,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		newNode.setName(name);
+		newNode.setDocComment(doccomment);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -146,6 +148,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
@@ -153,6 +156,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		newNode.setName(name);
+		newNode.setDocComment(doccomment);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -169,6 +173,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 		
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
@@ -176,6 +181,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
 		newNode.setName(name);
+		newNode.setDocComment(doccomment);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -1,7 +1,6 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
-import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
 import ast.php.functionDef.Closure;
@@ -76,16 +75,15 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			ASTUnderConstruction ast)
 	{
 		TopLevelFunctionDef newNode = new TopLevelFunctionDef();
-		Identifier nameNode = new Identifier();
 
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		
 		if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
-			nameNode.setCodeStr("<" + name + ">");
+			newNode.setName("<" + name + ">");
 		else if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS))
-			nameNode.setCodeStr("[" + name + "]");
+			newNode.setName("[" + name + "]");
 		// TODO: else throw exception?
-		newNode.addChild(nameNode);
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -97,11 +95,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			ASTUnderConstruction ast)
 	{
 		FunctionDef newNode = new FunctionDef();
-		Identifier nameNode = new Identifier();
 
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
-		nameNode.setCodeStr(name);
-		newNode.addChild(nameNode);
+		
+		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -113,11 +110,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			ASTUnderConstruction ast)
 	{
 		Method newNode = new Method();
-		Identifier nameNode = new Identifier();
 
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
-		nameNode.setCodeStr(name);
-		newNode.addChild(nameNode);
+		
+		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -129,11 +125,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			ASTUnderConstruction ast)
 	{
 		Closure newNode = new Closure();
-		Identifier nameNode = new Identifier();
 
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
-		nameNode.setCodeStr(name);
-		newNode.addChild(nameNode);
+		
+		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -11,6 +11,7 @@ import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.IfStatement;
 import ast.statements.blockstarters.WhileStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 
@@ -18,7 +19,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 {
 
 	@Override
-	public long handle(KeyedCSVRow row, ASTUnderConstruction ast)
+	public long handle(KeyedCSVRow row, ASTUnderConstruction ast) throws InvalidCSVFile
 	{
 		long retval = -1;
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
@@ -61,29 +62,36 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long defaultHandler(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
-		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
-
 		ASTNode newNode = new ASTNode();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
 		return id;
 	}
 
 	private static long handleTopLevelFunction(KeyedCSVRow row,
-			ASTUnderConstruction ast)
+			ASTUnderConstruction ast) throws InvalidCSVFile
 	{
 		TopLevelFunctionDef newNode = new TopLevelFunctionDef();
 
-		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
+		newNode.setFlags(flags);
 		if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
 			newNode.setName("<" + name + ">");
 		else if( flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS))
 			newNode.setName("[" + name + "]");
-		// TODO: else throw exception?
+		else
+			throw new InvalidCSVFile("While trying to handle row " + row.toString() + ": "
+					+ "Invalid toplevel flags " + flags + ".");
 		
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -96,8 +104,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		FunctionDef newNode = new FunctionDef();
 
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
+		newNode.setFlags(flags);
 		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
@@ -111,8 +121,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		Method newNode = new Method();
 
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
+		newNode.setFlags(flags);
 		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
@@ -126,8 +138,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		Closure newNode = new Closure();
 
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		
+		newNode.setFlags(flags);
 		newNode.setName(name);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
@@ -138,8 +152,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long handleCompound(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		CompoundStatement newNode = new CompoundStatement();
+
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		
+		newNode.setFlags(flags);
+		
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
 		return id;
@@ -147,8 +166,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long handleIf(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		IfStatement newNode = new IfStatement();
+
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		
+		newNode.setFlags(flags);
+		
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
 		return id;
@@ -156,8 +180,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long handleFor(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ForStatement newNode = new ForStatement();
+		
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		
+		newNode.setFlags(flags);
+		
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
 		return id;
@@ -165,8 +194,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long handleDo(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		DoStatement newNode = new DoStatement();
+		
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		
+		newNode.setFlags(flags);
+		
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
 		return id;
@@ -174,8 +208,13 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long handleWhile(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		WhileStatement newNode = new WhileStatement();
+		
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		
+		newNode.setFlags(flags);
+		
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
 		
 		return id;

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -68,12 +68,14 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
 
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setCodeStr(code);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -18,6 +18,7 @@ public class PHPCSVNodeTypes
 	// in {@link https://github.com/nikic/php-ast}
 	public static final CSVKey ENDLINENO = new CSVKey("endlineno","int");
 	public static final CSVKey NAME = new CSVKey("name");
+	public static final CSVKey DOCCOMMENT = new CSVKey("doccomment");
 	// meta-properties
 	public static final CSVKey CODE = new CSVKey("code");
 	public static final CSVKey CHILDNUM = new CSVKey("childnum","int");

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -9,10 +9,15 @@ public class PHPCSVNodeTypes
 {
 	/* node row keys */
 	public static final CSVKey NODE_ID = new CSVKey("id","ID");
+	// node properties shared by all nodes (cf. ast\Node specification
+	// in {@link https://github.com/nikic/php-ast})
 	public static final CSVKey TYPE = new CSVKey("type");
 	public static final CSVKey FLAGS = new CSVKey("flags","string[]");
-	public static final CSVKey FUNCID =new CSVKey("funcid","int");
+	// node properties for declaration nodes  (cf. ast\Node\Decl specification
+	// in {@link https://github.com/nikic/php-ast}
 	public static final CSVKey NAME = new CSVKey("name");
+	// meta-properties
+	public static final CSVKey FUNCID = new CSVKey("funcid","int");
 
 	/* node types */
 	// directory/file types

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -19,6 +19,7 @@ public class PHPCSVNodeTypes
 	public static final CSVKey NAME = new CSVKey("name");
 	// meta-properties
 	public static final CSVKey CODE = new CSVKey("code");
+	public static final CSVKey CHILDNUM = new CSVKey("childnum","int");
 	public static final CSVKey FUNCID = new CSVKey("funcid","int");
 
 	/* node types */

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -13,6 +13,7 @@ public class PHPCSVNodeTypes
 	// in {@link https://github.com/nikic/php-ast})
 	public static final CSVKey TYPE = new CSVKey("type");
 	public static final CSVKey FLAGS = new CSVKey("flags","string[]");
+	public static final CSVKey LINENO = new CSVKey("lineno","int");
 	// node properties for declaration nodes  (cf. ast\Node\Decl specification
 	// in {@link https://github.com/nikic/php-ast}
 	public static final CSVKey NAME = new CSVKey("name");

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -18,6 +18,7 @@ public class PHPCSVNodeTypes
 	// in {@link https://github.com/nikic/php-ast}
 	public static final CSVKey NAME = new CSVKey("name");
 	// meta-properties
+	public static final CSVKey CODE = new CSVKey("code");
 	public static final CSVKey FUNCID = new CSVKey("funcid","int");
 
 	/* node types */

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -16,6 +16,7 @@ public class PHPCSVNodeTypes
 	public static final CSVKey LINENO = new CSVKey("lineno","int");
 	// node properties for declaration nodes  (cf. ast\Node\Decl specification
 	// in {@link https://github.com/nikic/php-ast}
+	public static final CSVKey ENDLINENO = new CSVKey("endlineno","int");
 	public static final CSVKey NAME = new CSVKey("name");
 	// meta-properties
 	public static final CSVKey CODE = new CSVKey("code");


### PR DESCRIPTION
This PR encompasses several improvements:
* I refactorized & cleaned up `CSVFunctionExtractor` to make it more concise and readable. Mostly cosmetic really. But it is now finished. :smiley: 
* I "introduced" `getName()` and `setName()` methods in `ASTNode`. See PRs #68 and #71 .
* All properties pertaining to the PHP ASTs and exported by phpjoern are now supported and correctly added to the `ASTNode`'s: flags, starting/ending line numbers, code, and doccomments.

I'm happy. :relieved:   Now the CSV files output by phpjoern are all parsed correctly, and all properties are imported -- nothing falls "under the table" any more. I can finally start mapping the PHP node types onto the internal Joern representation, which is up next!

Here's another small request:

In order to add support for starting/ending line numbers I used the `CodeLocation` class, which I assume is meant just for that. However, it belongs to the package `languages.c.parsing`, and if feels really weird to include a package from `languages.c` into the `PHPCSVNodeInterpreter`. PHP has locations too. :wink:
* Could we move it into another package?
* Or else, can we have a `CodeLocation` superclass from which some classes `CCodeLocation` and `PHPCodeLocation` inherit? (Though I think a common class should be perfectly fine.)

Anyhow, the `ASTNode` class currently imports `languages.c.parsing.CodeLocation`, which is also not so nice since the `ASTNode`'s are supposed to be language-independent, to the extent possible. Oh, and I was so blunt as to add a new property `endLine` to `CodeLocation`. The PHP ASTs do not contain all the position information that Joern generates for C, but only (starting) lines. In exchange, for function and class declarations, an ending line is additionally exported.
