### PR TITLE
Started mapping of PHP ASTs onto Joern ASTs

### DIFF
--- a/src/ast/declarations/ClassDefStatement.java
+++ b/src/ast/declarations/ClassDefStatement.java
@@ -1,26 +1,21 @@
 package ast.declarations;
 
 import ast.ASTNode;
-import ast.ASTNodeProperties;
 import ast.DummyIdentifierNode;
 import ast.expressions.Identifier;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Statement;
-import ast.php.functionDef.TopLevelFunctionDef;
 
 public class ClassDefStatement extends Statement
 {
 
 	public Identifier identifier = new DummyIdentifierNode();
-	public TopLevelFunctionDef toplevelfunc = new TopLevelFunctionDef();
 	public CompoundStatement content = new CompoundStatement();
 
 	public void addChild(ASTNode expression)
 	{
 		if (expression instanceof Identifier)
 			identifier = (Identifier) expression;
-		else if (expression instanceof TopLevelFunctionDef)
-			toplevelfunc = (TopLevelFunctionDef) expression;
 		else
 			super.addChild(expression);
 	}
@@ -28,31 +23,5 @@ public class ClassDefStatement extends Statement
 	public Identifier getIdentifier()
 	{
 		return identifier;
-	}
-
-	public String getName() {
-		return getProperty(ASTNodeProperties.NAME);
-	}
-	
-	public void setName(String name) {
-		setProperty(ASTNodeProperties.NAME, name);
-	}
-	
-	public Identifier getExtends()
-	{
-		return this.identifier;
-	}
-	
-	public TopLevelFunctionDef getTopLevelFunc()
-	{
-		return this.toplevelfunc;
-	}
-	
-	public String getDocComment() {
-		return getProperty(ASTNodeProperties.DOCCOMMENT);
-	}
-	
-	public void setDocComment(String doccomment) {
-		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
 	}
 }

--- a/src/ast/declarations/ClassDefStatement.java
+++ b/src/ast/declarations/ClassDefStatement.java
@@ -1,34 +1,58 @@
 package ast.declarations;
 
 import ast.ASTNode;
+import ast.ASTNodeProperties;
 import ast.DummyIdentifierNode;
 import ast.expressions.Identifier;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Statement;
-import ast.walking.ASTNodeVisitor;
+import ast.php.functionDef.TopLevelFunctionDef;
 
 public class ClassDefStatement extends Statement
 {
 
-	public Identifier name = new DummyIdentifierNode();
+	public Identifier identifier = new DummyIdentifierNode();
+	public TopLevelFunctionDef toplevelfunc = new TopLevelFunctionDef();
 	public CompoundStatement content = new CompoundStatement();
 
 	public void addChild(ASTNode expression)
 	{
 		if (expression instanceof Identifier)
-			name = (Identifier) expression;
+			identifier = (Identifier) expression;
+		else if (expression instanceof TopLevelFunctionDef)
+			toplevelfunc = (TopLevelFunctionDef) expression;
 		else
 			super.addChild(expression);
 	}
 
-	public Identifier getName()
+	public Identifier getIdentifier()
 	{
-		return name;
+		return identifier;
 	}
 
-	public void accept(ASTNodeVisitor visitor)
-	{
-		visitor.visit(this);
+	public String getName() {
+		return getProperty(ASTNodeProperties.NAME);
 	}
-
+	
+	public void setName(String name) {
+		setProperty(ASTNodeProperties.NAME, name);
+	}
+	
+	public Identifier getExtends()
+	{
+		return this.identifier;
+	}
+	
+	public TopLevelFunctionDef getTopLevelFunc()
+	{
+		return this.toplevelfunc;
+	}
+	
+	public String getDocComment() {
+		return getProperty(ASTNodeProperties.DOCCOMMENT);
+	}
+	
+	public void setDocComment(String doccomment) {
+		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
+	}
 }

--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -1,10 +1,11 @@
 package ast.expressions;
 
-import ast.walking.ASTNodeVisitor;
+import ast.ASTNode;
 
 public class Identifier extends Expression
 {
-
+	private ASTNode name = new ASTNode();
+	
 	public Identifier()
 	{
 	}
@@ -13,10 +14,19 @@ public class Identifier extends Expression
 	{
 		super(name);
 	}
-
-	public void accept(ASTNodeVisitor visitor)
+	
+	public void addChild(ASTNode node)
 	{
-		visitor.visit(this);
+		setName(node);
+		super.addChild(node);
+	}
+	
+	public void setName(ASTNode name) {
+		this.name = name;
+	}
+	
+	public ASTNode getName() {
+		return this.name;
 	}
 
 }

--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -46,6 +46,11 @@ public class FunctionDef extends ASTNode
 	{
 		return content;
 	}
+	
+	public Identifier getReturnType()
+	{
+		return this.identifier;
+	}
 
 	@Override
 	public String getEscapedCodeStr()

--- a/src/ast/php/declarations/PHPClassDef.java
+++ b/src/ast/php/declarations/PHPClassDef.java
@@ -1,0 +1,51 @@
+package ast.php.declarations;
+
+import ast.ASTNode;
+import ast.ASTNodeProperties;
+import ast.DummyIdentifierNode;
+import ast.declarations.ClassDefStatement;
+import ast.expressions.Identifier;
+import ast.php.functionDef.TopLevelFunctionDef;
+
+public class PHPClassDef extends ClassDefStatement
+{
+
+	public Identifier parent = new DummyIdentifierNode();
+	public TopLevelFunctionDef toplevelfunc = new TopLevelFunctionDef();
+
+	public void addChild(ASTNode node)
+	{
+		if (node instanceof Identifier)
+			parent = (Identifier) node;
+		else if (node instanceof TopLevelFunctionDef)
+			toplevelfunc = (TopLevelFunctionDef) node;
+
+		super.addChild(node);
+	}
+
+	public String getName() {
+		return getProperty(ASTNodeProperties.NAME);
+	}
+	
+	public void setName(String name) {
+		setProperty(ASTNodeProperties.NAME, name);
+	}
+	
+	public Identifier getExtends()
+	{
+		return this.parent;
+	}
+	
+	public TopLevelFunctionDef getTopLevelFunc()
+	{
+		return this.toplevelfunc;
+	}
+	
+	public String getDocComment() {
+		return getProperty(ASTNodeProperties.DOCCOMMENT);
+	}
+	
+	public void setDocComment(String doccomment) {
+		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
+	}
+}

--- a/src/ast/php/functionDef/ClosureVar.java
+++ b/src/ast/php/functionDef/ClosureVar.java
@@ -1,0 +1,22 @@
+package ast.php.functionDef;
+
+import ast.ASTNode;
+
+public class ClosureVar extends ASTNode
+{
+	private ASTNode name = new ASTNode();
+	
+	public void addChild(ASTNode node)
+	{
+		setName(node);
+		super.addChild(node);
+	}
+	
+	public void setName(ASTNode name) {
+		this.name = name;
+	}
+	
+	public ASTNode getName() {
+		return this.name;
+	}
+}

--- a/src/databaseNodes/ClassDefDatabaseNode.java
+++ b/src/databaseNodes/ClassDefDatabaseNode.java
@@ -15,7 +15,7 @@ public class ClassDefDatabaseNode extends DatabaseNode
 	public void initialize(Object obj)
 	{
 		stmt = (ClassDefStatement) obj;
-		name = stmt.name.getEscapedCodeStr();
+		name = stmt.identifier.getEscapedCodeStr();
 	}
 
 	@Override

--- a/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
+++ b/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
@@ -610,7 +610,7 @@ public class FunctionContentBuilder extends ASTNodeBuilder
 			typeName = nodeToRuleContext.get(type);
 		} else if (parentItem instanceof ClassDefStatement)
 		{
-			Identifier name = ((ClassDefStatement) parentItem).getName();
+			Identifier name = ((ClassDefStatement) parentItem).getIdentifier();
 			typeName = nodeToRuleContext.get(name);
 		} else
 			throw new RuntimeException(

--- a/src/languages/c/parsing/Shared/builders/ClassDefBuilder.java
+++ b/src/languages/c/parsing/Shared/builders/ClassDefBuilder.java
@@ -24,14 +24,14 @@ public class ClassDefBuilder extends ASTNodeBuilder
 	// TODO: merge the following two by introducing a wrapper
 	public void setName(Class_nameContext ctx)
 	{
-		thisItem.name = new Identifier();
-		ASTNodeFactory.initializeFromContext(thisItem.name, ctx);
+		thisItem.identifier = new Identifier();
+		ASTNodeFactory.initializeFromContext(thisItem.identifier, ctx);
 	}
 
 	public void setName(languages.c.antlr.FunctionParser.Class_nameContext ctx)
 	{
-		thisItem.name = new Identifier();
-		ASTNodeFactory.initializeFromContext(thisItem.name, ctx);
+		thisItem.identifier = new Identifier();
+		ASTNodeFactory.initializeFromContext(thisItem.identifier, ctx);
 	}
 
 	public void setContent(CompoundStatement content)

--- a/src/outputModules/common/ClassDefExporter.java
+++ b/src/outputModules/common/ClassDefExporter.java
@@ -22,7 +22,7 @@ public abstract class ClassDefExporter extends ASTNodeExporter
 		{
 			ex.printStackTrace();
 			System.err.println("Error adding class to database: "
-					+ ((ClassDefStatement) node).name.getEscapedCodeStr());
+					+ ((ClassDefStatement) node).identifier.getEscapedCodeStr());
 			return;
 		}
 

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -186,7 +186,7 @@ public class TestCSV2AST
 	public void testInvalidTopLevelFuncFlags() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "1,AST_TOPLEVEL,somerandomflags,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,somerandomflags,1,,,,3,\"foo.php\",\n";
 		
 		createASTFromStrings(nodeStr, edgeHeader);
 	}

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -60,7 +60,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -89,7 +89,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,5,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -122,7 +122,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,7,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_CONST,,3,,0,1,,,\n";
 		nodeStr += "4,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
@@ -157,7 +157,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,5,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -194,7 +194,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,5,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -232,7 +232,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,7,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -276,7 +276,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,5,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -318,7 +318,7 @@ public class TestCSVFunctionExtractor
 		String nodeStr = nodeHeader;
 		nodeStr += "0,Directory,,,,,,,\"foobar\",\n";
 		nodeStr += "1,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/foo.php\",\n";
+		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foobar/foo.php\",\n";
 		nodeStr += "3,AST_STMT_LIST,,1,,0,2,,,\n";
 		nodeStr += "4,AST_FUNC_DECL,,3,,0,2,3,foo,\n";
 		nodeStr += "5,AST_PARAM_LIST,,3,,0,4,,,\n";
@@ -326,7 +326,7 @@ public class TestCSVFunctionExtractor
 		nodeStr += "7,AST_STMT_LIST,,3,,2,4,,,\n";
 		nodeStr += "8,NULL,,3,,3,4,,,\n";
 		nodeStr += "9,File,,,,,,,\"bar.php\",\n";
-		nodeStr += "10,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/bar.php\",\n";
+		nodeStr += "10,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foobar/bar.php\",\n";
 		nodeStr += "11,AST_STMT_LIST,,1,,0,10,,,\n";
 		nodeStr += "12,AST_FUNC_DECL,,3,,0,10,3,bar,\n";
 		nodeStr += "13,AST_PARAM_LIST,,3,,0,12,,,\n";
@@ -358,7 +358,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_CLASS,,3,,0,1,3,foo,\n";
 		nodeStr += "4,NULL,,3,,0,1,,,\n";
@@ -390,7 +390,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,9,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -450,7 +450,7 @@ public class TestCSVFunctionExtractor
 		String nodeStr = nodeHeader;
 		nodeStr += "0,Directory,,,,,,,\"foobar\",\n";
 		nodeStr += "1,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/foo.php\",\n";
+		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,6,\"foobar/foo.php\",\n";
 		nodeStr += "3,AST_STMT_LIST,,1,,0,2,,,\n";
 		nodeStr += "4,AST_CLASS,,3,,0,2,5,foo,\n";
 		nodeStr += "5,NULL,,3,,0,2,,,\n";
@@ -463,7 +463,7 @@ public class TestCSVFunctionExtractor
 		nodeStr += "12,AST_STMT_LIST,,4,,2,9,,,\n";
 		nodeStr += "13,NULL,,4,,3,9,,,\n";
 		nodeStr += "14,File,,,,,,,\"bar.php\",\n";
-		nodeStr += "15,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/bar.php\",\n";
+		nodeStr += "15,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,5,\"foobar/bar.php\",\n";
 		nodeStr += "16,AST_STMT_LIST,,1,,0,15,,,\n";
 		nodeStr += "17,AST_CLASS,,3,,0,15,5,bar,\n";
 		nodeStr += "18,NULL,,3,,0,15,,,\n";
@@ -581,7 +581,7 @@ public class TestCSVFunctionExtractor
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "0,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foo.php\",\n";
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foo.php\",\n";
 		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
 		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
@@ -625,7 +625,7 @@ public class TestCSVFunctionExtractor
 		String nodeStr = nodeHeader;
 		nodeStr += "0,Directory,,,,,,,\"foobar\",\n";
 		nodeStr += "1,File,,,,,,,\"foo.php\",\n";
-		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/foo.php\",\n";
+		nodeStr += "2,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foobar/foo.php\",\n";
 		nodeStr += "3,AST_STMT_LIST,,1,,0,2,,,\n";
 		nodeStr += "4,AST_FUNC_DECL,,3,,0,2,3,foo,\n";
 		nodeStr += "5,AST_PARAM_LIST,,3,,0,4,,,\n";
@@ -633,7 +633,7 @@ public class TestCSVFunctionExtractor
 		nodeStr += "7,AST_STMT_LIST,,3,,2,4,,,\n";
 		nodeStr += "8,NULL,,3,,3,4,,,\n";
 		nodeStr += "9,File,,,,,,,\"bar.php\",\n";
-		nodeStr += "10,AST_TOPLEVEL,TOPLEVEL_FILE,,,,,,\"foobar/bar.php\",\n";
+		nodeStr += "10,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foobar/bar.php\",\n";
 		nodeStr += "11,AST_STMT_LIST,,1,,0,10,,,\n";
 		nodeStr += "12,AST_FUNC_DECL,,3,,0,10,3,bar,\n";
 		nodeStr += "13,AST_PARAM_LIST,,3,,0,12,,,\n";

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import ast.ASTNode;
 import ast.expressions.Identifier;
+import ast.php.functionDef.ClosureVar;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
@@ -53,6 +54,9 @@ public class TestPHPCSVNodeInterpreter
 		while ((keyedRow = edgeReader.getNextRow()) != null)
 			edgeInterpreter.handle(keyedRow, ast);
 	}
+	
+	
+	/* special nodes */	
 	
 	/**
 	 * Any AST_NAME node has exactly one child which is of type "string".
@@ -98,5 +102,48 @@ public class TestPHPCSVNodeInterpreter
 		assertEquals( "bar", ((Identifier)node).getName().getEscapedCodeStr());
 		assertThat( node2, instanceOf(Identifier.class));
 		assertEquals( "buz", ((Identifier)node2).getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * AST_CLOSURE_VAR nodes are special nodes holding variables that
+	 * occur within the 'use' language construct of closure declarations.
+	 * 
+	 * This test checks the names 'foo' and 'bar' in the following PHP code:
+	 * 
+	 * function() use ($foo,$bar) {};
+	 */
+	@Test
+	public void testClosureVarCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CLOSURE,,3,,0,1,3,{closure},\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,AST_CLOSURE_USES,,3,,1,3,,,\n";
+		nodeStr += "6,AST_CLOSURE_VAR,,3,,0,3,,,\n";
+		nodeStr += "7,string,,3,\"foo\",0,3,,,\n";
+		nodeStr += "8,AST_CLOSURE_VAR,,3,,1,3,,,\n";
+		nodeStr += "9,string,,3,\"bar\",0,3,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "11,NULL,,3,,3,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "5,8,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,10,PARENT_OF\n";
+		edgeStr += "3,11,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)6);
+		ASTNode node2 = ast.getNodeById((long)8);
+		
+		assertThat( node, instanceOf(ClosureVar.class));
+		assertEquals( "foo", ((ClosureVar)node).getName().getEscapedCodeStr());
+		assertThat( node2, instanceOf(ClosureVar.class));
+		assertEquals( "bar", ((ClosureVar)node2).getName().getEscapedCodeStr());
 	}
 }

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -1,0 +1,102 @@
+package tests.inputModules;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ast.ASTNode;
+import ast.expressions.Identifier;
+import inputModules.csv.KeyedCSV.KeyedCSVReader;
+import inputModules.csv.KeyedCSV.KeyedCSVRow;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
+import inputModules.csv.csv2ast.ASTUnderConstruction;
+import tools.phpast2cfg.PHPCSVEdgeInterpreter;
+import tools.phpast2cfg.PHPCSVNodeInterpreter;
+
+public class TestPHPCSVNodeInterpreter
+{
+	PHPCSVNodeInterpreter nodeInterpreter = new PHPCSVNodeInterpreter();
+	PHPCSVEdgeInterpreter edgeInterpreter = new PHPCSVEdgeInterpreter();
+	
+	ASTUnderConstruction ast;
+	KeyedCSVReader nodeReader;
+	KeyedCSVReader edgeReader;
+	
+	// See {@link http://neo4j.com/docs/stable/import-tool-header-format.html} for detailed
+	// information about the header file format
+	String nodeHeader = "id:ID,type,flags:string[],lineno:int,code,childnum:int,funcid:int,endlineno:int,name,doccomment\n";
+	String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
+
+	@Before
+	public void init()
+	{
+		ast = new ASTUnderConstruction();	
+		nodeReader = new KeyedCSVReader();
+		edgeReader = new KeyedCSVReader();
+	}
+	
+	private void handle(String nodeStr, String edgeStr)
+			throws IOException, InvalidCSVFile
+	{
+		nodeReader.init(new StringReader(nodeStr));
+		edgeReader.init(new StringReader(edgeStr));
+		
+		KeyedCSVRow keyedRow;
+		while ((keyedRow = nodeReader.getNextRow()) != null)
+			nodeInterpreter.handle(keyedRow, ast);
+		while ((keyedRow = edgeReader.getNextRow()) != null)
+			edgeInterpreter.handle(keyedRow, ast);
+	}
+	
+	/**
+	 * Any AST_NAME node has exactly one child which is of type "string".
+	 * 
+	 * AST_NAME nodes are used to identify certain names in PHP code,
+	 * such as for example the name of a class that a class declaration extends,
+	 * or the name of an interface that a class declaration implements.
+	 * Other examples include names of called functions/methods, class
+	 * names associated with 'new' or 'instanceof' operators, etc.
+	 * 
+	 * This test checks the names 'bar' and 'buz' in the following PHP code:
+	 * 
+	 * class foo extends bar implements buz {}
+	 */
+	@Test
+	public void testNameCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;	
+		nodeStr += "3,AST_CLASS,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"bar\",0,1,,,\n";
+		nodeStr += "6,AST_NAME_LIST,,3,,1,1,,,\n";
+		nodeStr += "7,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "8,string,,3,\"buz\",0,1,,,\n";
+		nodeStr += "9,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,1,3,\"foo\",\n";
+		nodeStr += "10,AST_STMT_LIST,,3,,0,9,,,\n";
+		
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "3,9,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)4);
+		ASTNode node2 = ast.getNodeById((long)7);
+		
+		assertThat( node, instanceOf(Identifier.class));
+		assertEquals( "bar", ((Identifier)node).getName().getEscapedCodeStr());
+		assertThat( node2, instanceOf(Identifier.class));
+		assertEquals( "buz", ((Identifier)node2).getName().getEscapedCodeStr());
+	}
+}

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -12,7 +12,12 @@ import org.junit.Test;
 
 import ast.ASTNode;
 import ast.expressions.Identifier;
+import ast.functionDef.FunctionDef;
+import ast.logical.statements.CompoundStatement;
+import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureVar;
+import ast.php.functionDef.Method;
+import ast.php.functionDef.TopLevelFunctionDef;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
@@ -59,13 +64,13 @@ public class TestPHPCSVNodeInterpreter
 	/* special nodes */	
 	
 	/**
-	 * Any AST_NAME node has exactly one child which is of type "string".
-	 * 
 	 * AST_NAME nodes are used to identify certain names in PHP code,
 	 * such as for example the name of a class that a class declaration extends,
 	 * or the name of an interface that a class declaration implements.
 	 * Other examples include names of called functions/methods, class
 	 * names associated with 'new' or 'instanceof' operators, etc.
+	 * 
+	 * Any AST_NAME node has exactly one child which is of type "string".
 	 * 
 	 * This test checks the names 'bar' and 'buz' in the following PHP code:
 	 * 
@@ -108,6 +113,8 @@ public class TestPHPCSVNodeInterpreter
 	 * AST_CLOSURE_VAR nodes are special nodes holding variables that
 	 * occur within the 'use' language construct of closure declarations.
 	 * 
+	 * Any AST_CLOSURE_VAR node has exactly one child which is of type "string".
+	 * 
 	 * This test checks the names 'foo' and 'bar' in the following PHP code:
 	 * 
 	 * function() use ($foo,$bar) {};
@@ -146,4 +153,194 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node2, instanceOf(ClosureVar.class));
 		assertEquals( "bar", ((ClosureVar)node2).getName().getEscapedCodeStr());
 	}
+	
+	
+	/* declaration nodes */	
+	
+	/**
+	 * AST_TOPLEVEL nodes are artificial function-declaring nodes for
+	 * the top-level context of files and classes. We give such nodes the
+	 * name "<path/to/file>" under file nodes, and "[classname]" under class nodes. 
+	 * 
+	 * Any AST_TOPLEVEL node has exactly one child which is of type AST_STMT_LIST.
+	 * 
+	 * This test checks the name '<foo.php>' of the toplevel node of a file foo.php
+	 * and the name '[bar]' of a class bar in the following PHP code:
+	 * 
+	 * class bar {}
+	 */
+	@Test
+	public void testTopLevelFuncCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,3,\"foo.php\",\n";
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_CLASS,,3,,0,1,3,bar,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "5,NULL,,3,,1,1,,,\n";
+		nodeStr += "6,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,1,3,\"bar\",\n";
+		nodeStr += "7,AST_STMT_LIST,,3,,0,6,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "1,2,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)1);
+		ASTNode node2 = ast.getNodeById((long)6);
+		
+		assertThat( node, instanceOf(TopLevelFunctionDef.class));
+		assertEquals( "<foo.php>", ((TopLevelFunctionDef)node).getName());
+		assertThat( ((TopLevelFunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
+		
+		assertThat( node2, instanceOf(TopLevelFunctionDef.class));
+		assertEquals( "[bar]", ((TopLevelFunctionDef)node2).getName());
+		assertThat( ((TopLevelFunctionDef)node2).getContent(), instanceOf(CompoundStatement.class));
+	}
+	
+	/**
+	 * AST_FUNC_DECL nodes are function-declaring nodes for top-level functions
+	 * (as opposed to methods declared within a class scope.) 
+	 * 
+	 * Any AST_FUNC_DECL node has exactly four children:
+	 * 1) AST_PARAM_LIST
+	 * 2) NULL, for structural compatibility with AST_CLOSURE
+	 * 3) AST_STMT_LIST
+	 * 4) AST_NAME or NULL, indicating the return type
+	 * 
+	 * This test checks a function's name and children in the following PHP code:
+	 * 
+	 * function foo() : int {}
+	 */
+	@Test
+	public void testFunctionDefCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_NAME,NAME_NOT_FQ,3,,3,3,,,\n";
+		nodeStr += "8,string,,3,\"int\",0,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "3,7,PARENT_OF\n";
+		
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(FunctionDef.class));
+		assertEquals( "foo", ((FunctionDef)node).getName());
+		// TODO map AST_PARAM_LIST to ParameterList and check here
+		assertThat( ((FunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
+		assertThat( ((FunctionDef)node).getReturnType(), instanceOf(Identifier.class));
+		assertEquals( "int", ((Identifier)((FunctionDef)node).getReturnType()).getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * AST_CLOSURE nodes are function-declaring nodes for closures (anonymous functions).
+	 * We always give them the artificial name "{closure}".
+	 * 
+	 * Any AST_CLOSURE node has exactly four children:
+	 * 1) AST_PARAM_LIST
+	 * 2) AST_CLOSURE_USES or NULL
+	 * 3) AST_STMT_LIST
+	 * 4) AST_NAME or NULL, indicating the return type
+	 * 
+	 * This test checks a closure's pseudo-name and children in the following PHP code:
+	 * 
+	 * function() use ($foo) : int {};
+	 */
+	@Test
+	public void testClosureCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;	
+		nodeStr += "3,AST_CLOSURE,,3,,0,1,3,{closure},\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,AST_CLOSURE_USES,,3,,1,3,,,\n";
+		nodeStr += "6,AST_CLOSURE_VAR,,3,,0,3,,,\n";
+		nodeStr += "7,string,,3,\"foo\",0,3,,,\n";
+		nodeStr += "8,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "9,AST_NAME,NAME_NOT_FQ,3,,3,3,,,\n";
+		nodeStr += "10,string,,3,\"int\",0,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,8,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "3,9,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(Closure.class));
+		assertEquals( "{closure}", ((Closure)node).getName());
+		// TODO map AST_PARAM_LIST to ParameterList and check here
+		// TODO map AST_CLOSURE_USES to ClosureUses and check here
+		assertThat( ((FunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
+		assertThat( ((FunctionDef)node).getReturnType(), instanceOf(Identifier.class));
+		assertEquals( "int", ((Identifier)((Closure)node).getReturnType()).getName().getEscapedCodeStr());
+	}
+	
+	/**
+	 * AST_METHOD nodes are function-declaring nodes for class-level functions
+	 * (as opposed to functions declared within a top-level scope.) 
+	 * 
+	 * Any AST_METHOD node has exactly four children:
+	 * 1) AST_PARAM_LIST
+	 * 2) NULL, for structural compatibility with AST_CLOSURE
+	 * 3) AST_STMT_LIST
+	 * 4) AST_NAME or NULL, indicating the return type
+	 * 
+	 * This test checks a method's name and children in the following PHP code:
+	 * 
+	 * class bar {
+	 *   function foo() : int {}
+	 * }
+	 */
+	@Test
+	public void testMethodCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "8,AST_METHOD,MODIFIER_PUBLIC,4,,0,6,4,foo,\n";
+		nodeStr += "9,AST_PARAM_LIST,,4,,0,8,,,\n";
+		nodeStr += "10,NULL,,4,,1,8,,,\n";
+		nodeStr += "11,AST_STMT_LIST,,4,,2,8,,,\n";
+		nodeStr += "12,AST_NAME,NAME_NOT_FQ,4,,3,8,,,\n";
+		nodeStr += "13,string,,4,\"int\",0,8,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "8,10,PARENT_OF\n";
+		edgeStr += "8,11,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "8,12,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)8);
+		
+		assertThat( node, instanceOf(Method.class));
+		assertEquals( "foo", ((Method)node).getName());
+		// TODO map AST_PARAM_LIST to ParameterList and check here
+		assertThat( ((Method)node).getContent(), instanceOf(CompoundStatement.class));
+		assertThat( ((Method)node).getReturnType(), instanceOf(Identifier.class));
+		assertEquals( "int", ((Identifier)((Method)node).getReturnType()).getName().getEscapedCodeStr());
+	}
+	
 }

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -11,10 +11,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.ASTNode;
-import ast.declarations.ClassDefStatement;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
+import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
@@ -382,13 +382,13 @@ public class TestPHPCSVNodeInterpreter
 
 		ASTNode node = ast.getNodeById((long)3);
 		
-		assertThat( node, instanceOf(ClassDefStatement.class));
-		assertEquals( "foo", ((ClassDefStatement)node).getName());
-		assertThat( ((ClassDefStatement)node).getExtends(), instanceOf(Identifier.class));
-		assertEquals( "bar", ((ClassDefStatement)node).getExtends().getName().getEscapedCodeStr());
+		assertThat( node, instanceOf(PHPClassDef.class));
+		assertEquals( "foo", ((PHPClassDef)node).getName());
+		assertThat( ((PHPClassDef)node).getExtends(), instanceOf(Identifier.class));
+		assertEquals( "bar", ((PHPClassDef)node).getExtends().getName().getEscapedCodeStr());
 		// TODO map AST_NAME_LIST to IdentifierList and check here
-		assertThat( ((ClassDefStatement)node).getTopLevelFunc(), instanceOf(TopLevelFunctionDef.class));
-		assertEquals( "[foo]", ((ClassDefStatement)node).getTopLevelFunc().getName());
+		assertThat( ((PHPClassDef)node).getTopLevelFunc(), instanceOf(TopLevelFunctionDef.class));
+		assertEquals( "[foo]", ((PHPClassDef)node).getTopLevelFunc().getName());
 	}
 	
 }

--- a/src/tests/parseTreeToAST/ModuleBuildersTest.java
+++ b/src/tests/parseTreeToAST/ModuleBuildersTest.java
@@ -34,8 +34,8 @@ public class ModuleBuildersTest
 				.getStatements().get(0);
 
 		assertTrue(codeItems.size() == 1);
-		assertTrue(yClass.getName().getEscapedCodeStr().equals("y"));
-		assertTrue(zClass.getName().getEscapedCodeStr().equals("z"));
+		assertTrue(yClass.getIdentifier().getEscapedCodeStr().equals("y"));
+		assertTrue(zClass.getIdentifier().getEscapedCodeStr().equals("z"));
 	}
 
 	@Test
@@ -44,7 +44,7 @@ public class ModuleBuildersTest
 		String input = "struct foo{};";
 		List<ASTNode> codeItems = parseInput(input);
 		ClassDefStatement codeItem = (ClassDefStatement) codeItems.get(0);
-		assertTrue(codeItem.name.getEscapedCodeStr().equals("foo"));
+		assertTrue(codeItem.identifier.getEscapedCodeStr().equals("foo"));
 	}
 
 	@Test
@@ -53,7 +53,7 @@ public class ModuleBuildersTest
 		String input = "struct {int x; } a;";
 		List<ASTNode> codeItems = parseInput(input);
 		ClassDefStatement codeItem = (ClassDefStatement) codeItems.get(0);
-		assertTrue(codeItem.name.getEscapedCodeStr().equals("<unnamed>"));
+		assertTrue(codeItem.identifier.getEscapedCodeStr().equals("<unnamed>"));
 	}
 
 	@Test
@@ -113,7 +113,7 @@ public class ModuleBuildersTest
 		IdentifierDecl decl = (IdentifierDecl) identifierCodeItem
 				.getIdentifierDeclList().get(0);
 
-		assertTrue(classCodeItem.name.getEscapedCodeStr().equals("foo"));
+		assertTrue(classCodeItem.identifier.getEscapedCodeStr().equals("foo"));
 		assertTrue(decl.getName().getEscapedCodeStr().equals("x"));
 	}
 

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,10 +6,10 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
-import ast.declarations.ClassDefStatement;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
+import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
@@ -251,7 +251,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	
 	private static long handleClass(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		ClassDefStatement newNode = new ClassDefStatement();
+		PHPClassDef newNode = new PHPClassDef();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -10,6 +10,7 @@ import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
 import ast.php.functionDef.Closure;
+import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.statements.blockstarters.DoStatement;
@@ -31,6 +32,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// special nodes
 			case PHPCSVNodeTypes.TYPE_NAME:
 				retval = handleName(row, ast);
+				break;
+
+			case PHPCSVNodeTypes.TYPE_CLOSURE_VAR:
+				retval = handleClosureVar(row, ast);
 				break;
 			
 			// declaration nodes
@@ -103,6 +108,24 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleName(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Identifier newNode = new Identifier();
+
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleClosureVar(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ClosureVar newNode = new ClosureVar();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -33,7 +33,6 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_NAME:
 				retval = handleName(row, ast);
 				break;
-
 			case PHPCSVNodeTypes.TYPE_CLOSURE_VAR:
 				retval = handleClosureVar(row, ast);
 				break;
@@ -45,11 +44,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_FUNC_DECL:
 				retval = handleFunction(row, ast);
 				break;
-			case PHPCSVNodeTypes.TYPE_METHOD:
-				retval = handleMethod(row, ast);
-				break;
 			case PHPCSVNodeTypes.TYPE_CLOSURE:
 				retval = handleClosure(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_METHOD:
+				retval = handleMethod(row, ast);
 				break;
 
 			// nodes with exactly 2 children

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,6 +6,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
+import ast.declarations.ClassDefStatement;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
@@ -49,6 +50,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_METHOD:
 				retval = handleMethod(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLASS:
+				retval = handleClass(row, ast);
 				break;
 
 			// nodes with exactly 2 children
@@ -224,6 +228,30 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private static long handleMethod(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Method newNode = new Method();
+
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
+		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
+		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
+
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		codeloc.endLine = Integer.parseInt(endlineno);
+		newNode.setLocation(codeloc);
+		newNode.setName(name);
+		newNode.setDocComment(doccomment);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private static long handleClass(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ClassDefStatement newNode = new ClassDefStatement();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -97,16 +97,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		newNode.setLocation(codeloc);
+		codeloc.startLine = Integer.parseInt(lineno);
+		codeloc.endLine = Integer.parseInt(endlineno);
 		if (flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
 			newNode.setName("<" + name + ">");
 		else if (flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS))
-		{
-			// TODO: define startLine and endLine for toplevel nodes of files
-			// also
-			codeloc.startLine = Integer.parseInt(lineno);
-			codeloc.endLine = Integer.parseInt(endlineno);
 			newNode.setName("[" + name + "]");
-		}
 		else
 			throw new InvalidCSVFile("While trying to handle row "
 					+ row.toString() + ": " + "Invalid toplevel flags " + flags

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -42,6 +42,8 @@ public class PHPCSVNodeTypes
 	public static final List<String> funcTypes =
 			Arrays.asList(TYPE_TOPLEVEL, TYPE_FUNC_DECL, TYPE_METHOD, TYPE_CLOSURE);
 	
+	public static final String TYPE_CLASS = "AST_CLASS";
+
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -29,7 +29,10 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_FILE = "File";
 	public static final String TYPE_DIRECTORY = "Directory";
 	
-	// function declaration nodes
+	// special nodes
+	public static final String TYPE_NAME = "AST_NAME";
+	
+	// declaration nodes
 	public static final String TYPE_TOPLEVEL = "AST_TOPLEVEL"; // artificial
 	public static final String TYPE_FUNC_DECL = "AST_FUNC_DECL";
 	public static final String TYPE_METHOD = "AST_METHOD";
@@ -38,10 +41,6 @@ public class PHPCSVNodeTypes
 	public static final List<String> funcTypes =
 			Arrays.asList(TYPE_TOPLEVEL, TYPE_FUNC_DECL, TYPE_METHOD, TYPE_CLOSURE);
 	
-	// nodes with an arbitrary number of children
-	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
-	public static final String TYPE_IF = "AST_IF";
-	
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
@@ -49,6 +48,10 @@ public class PHPCSVNodeTypes
 	// nodes with exactly 4 children
 	public static final String TYPE_FOR = "AST_FOR";
 
+	// nodes with an arbitrary number of children
+	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
+	public static final String TYPE_IF = "AST_IF";
+	
 	/* node flags */
 	// flags for toplevel nodes
 	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -31,7 +31,8 @@ public class PHPCSVNodeTypes
 	
 	// special nodes
 	public static final String TYPE_NAME = "AST_NAME";
-	
+	public static final String TYPE_CLOSURE_VAR = "AST_CLOSURE_VAR";
+
 	// declaration nodes
 	public static final String TYPE_TOPLEVEL = "AST_TOPLEVEL"; // artificial
 	public static final String TYPE_FUNC_DECL = "AST_FUNC_DECL";


### PR DESCRIPTION
All "special" nodes are now correctly mapped onto the Joern ASTs. These are:
* `AST_NAME` and `AST_CLOSURE_VAR` nodes
* Function declaration nodes: `AST_TOPLEVEL`, `AST_FUNC_DECL`, `AST_CLOSURE`, `AST_METHOD`
* Class declaration nodes: `AST_CLASS`

See individual commits for details. Note that I had to change some previously existing Joern code: Namely, `getName()` and `setName()` for `ClassDefStatement`'s had to be renamed into `getIdentifier()` and `setIdentifier()`, as you had already done for `FunctionDef` nodes.

Have a nice evening. :smiley: 