### PR TITLE
Renamed getName() and setName() in Identifier to getNameChild() and s…

### DIFF
--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -17,15 +17,15 @@ public class Identifier extends Expression
 	
 	public void addChild(ASTNode node)
 	{
-		setName(node);
+		setNameChild(node);
 		super.addChild(node);
 	}
 	
-	public void setName(ASTNode name) {
+	public void setNameChild(ASTNode name) {
 		this.name = name;
 	}
 	
-	public ASTNode getName() {
+	public ASTNode getNameChild() {
 		return this.name;
 	}
 

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -105,9 +105,9 @@ public class TestPHPCSVNodeInterpreter
 		ASTNode node2 = ast.getNodeById((long)7);
 		
 		assertThat( node, instanceOf(Identifier.class));
-		assertEquals( "bar", ((Identifier)node).getName().getEscapedCodeStr());
+		assertEquals( "bar", ((Identifier)node).getNameChild().getEscapedCodeStr());
 		assertThat( node2, instanceOf(Identifier.class));
-		assertEquals( "buz", ((Identifier)node2).getName().getEscapedCodeStr());
+		assertEquals( "buz", ((Identifier)node2).getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -246,7 +246,7 @@ public class TestPHPCSVNodeInterpreter
 		// TODO map AST_PARAM_LIST to ParameterList and check here
 		assertThat( ((FunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
 		assertThat( ((FunctionDef)node).getReturnType(), instanceOf(Identifier.class));
-		assertEquals( "int", ((Identifier)((FunctionDef)node).getReturnType()).getName().getEscapedCodeStr());
+		assertEquals( "int", ((Identifier)((FunctionDef)node).getReturnType()).getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -295,7 +295,7 @@ public class TestPHPCSVNodeInterpreter
 		// TODO map AST_CLOSURE_USES to ClosureUses and check here
 		assertThat( ((FunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
 		assertThat( ((FunctionDef)node).getReturnType(), instanceOf(Identifier.class));
-		assertEquals( "int", ((Identifier)((Closure)node).getReturnType()).getName().getEscapedCodeStr());
+		assertEquals( "int", ((Identifier)((Closure)node).getReturnType()).getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -341,7 +341,7 @@ public class TestPHPCSVNodeInterpreter
 		// TODO map AST_PARAM_LIST to ParameterList and check here
 		assertThat( ((Method)node).getContent(), instanceOf(CompoundStatement.class));
 		assertThat( ((Method)node).getReturnType(), instanceOf(Identifier.class));
-		assertEquals( "int", ((Identifier)((Method)node).getReturnType()).getName().getEscapedCodeStr());
+		assertEquals( "int", ((Identifier)((Method)node).getReturnType()).getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -385,7 +385,7 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node, instanceOf(PHPClassDef.class));
 		assertEquals( "foo", ((PHPClassDef)node).getName());
 		assertThat( ((PHPClassDef)node).getExtends(), instanceOf(Identifier.class));
-		assertEquals( "bar", ((PHPClassDef)node).getExtends().getName().getEscapedCodeStr());
+		assertEquals( "bar", ((PHPClassDef)node).getExtends().getNameChild().getEscapedCodeStr());
 		// TODO map AST_NAME_LIST to IdentifierList and check here
 		assertThat( ((PHPClassDef)node).getTopLevelFunc(), instanceOf(TopLevelFunctionDef.class));
 		assertEquals( "[foo]", ((PHPClassDef)node).getTopLevelFunc().getName());


### PR DESCRIPTION
…etNameChild().

This is for consistency with getName() and setName() methods in other AST classes which operate on Strings stored in the properties table, while getNameChild() and setNameChild() operate on ASTNodes.