### PR TITLE
Support for parameters and parameter lists

### DIFF
--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -47,7 +47,7 @@ public class FunctionDef extends ASTNode
 		return content;
 	}
 	
-	public Identifier getReturnType()
+	public Identifier getReturnTypeIdentifier()
 	{
 		return this.identifier;
 	}

--- a/src/ast/functionDef/Parameter.java
+++ b/src/ast/functionDef/Parameter.java
@@ -7,14 +7,15 @@ import ast.walking.ASTNodeVisitor;
 public class Parameter extends ASTNode
 {
 	private ParameterType type = new ParameterType();
-	private Identifier name = new Identifier();
+	private Identifier identifier = new Identifier();
 
 	public void addChild(ASTNode node)
 	{
+		// Note: 2 children for C ASTs: ParameterType and Identifier.
 		if (node instanceof ParameterType)
 			setType((ParameterType) node);
 		else if (node instanceof Identifier)
-			setName((Identifier) node);
+			setIdentifier((Identifier) node);
 
 		super.addChild(node);
 	}
@@ -25,7 +26,9 @@ public class Parameter extends ASTNode
 		visitor.visit(this);
 	}
 
-	public ParameterType getType()
+	// for C ASTs, this returns a ParameterType
+	// for PHP ASTs, this returns an Identifier
+	public ASTNode getType()
 	{
 		return type;
 	}
@@ -35,13 +38,15 @@ public class Parameter extends ASTNode
 		this.type = type;
 	}
 
-	public Identifier getName()
+	// for C ASTs, returns the name
+	// for PHP ASTs, undefined: we use getNameChild() instead, see PHPParameter class
+	public Identifier getIdentifier()
 	{
-		return name;
+		return identifier;
 	}
 
-	private void setName(Identifier name)
+	private void setIdentifier(Identifier identifier)
 	{
-		this.name = name;
+		this.identifier = identifier;
 	}
 }

--- a/src/ast/functionDef/ParameterList.java
+++ b/src/ast/functionDef/ParameterList.java
@@ -6,8 +6,9 @@ import java.util.LinkedList;
 import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
-public class ParameterList extends ASTNode
+public class ParameterList extends ASTNode implements Iterable<Parameter>
 {
+	private LinkedList<Parameter> parameters = new LinkedList<Parameter>();
 
 	public void addChild(ASTNode node)
 	{
@@ -16,20 +17,19 @@ public class ParameterList extends ASTNode
 		super.addChild(node);
 	}
 
-	// TODO: we don't want to give back a reference to the list,
-	// we need to provide iterators for type and name
-
-	public LinkedList<Parameter> getParameters()
+	public int size()
 	{
-		return parameters;
+		return this.parameters.size();
+	}
+	
+	public Parameter getParameter(int i) {
+		return this.parameters.get(i);
 	}
 
-	private void addParameter(Parameter aParam)
+	private void addParameter(Parameter parameter)
 	{
-		parameters.add(aParam);
+		this.parameters.add(parameter);
 	}
-
-	private LinkedList<Parameter> parameters = new LinkedList<Parameter>();
 
 	@Override
 	public String getEscapedCodeStr()
@@ -59,5 +59,10 @@ public class ParameterList extends ASTNode
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);
+	}
+
+	@Override
+	public Iterator<Parameter> iterator() {
+		return this.parameters.iterator();
 	}
 }

--- a/src/ast/logical/statements/CompoundStatement.java
+++ b/src/ast/logical/statements/CompoundStatement.java
@@ -1,20 +1,20 @@
 package ast.logical.statements;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
-public class CompoundStatement extends Statement
+public class CompoundStatement extends Statement implements Iterable<ASTNode>
 {
 	protected static final List<ASTNode> emptyList = new LinkedList<ASTNode>();
 
+	// TODO would it not be better to expose only the iterator instead?
 	public List<ASTNode> getStatements()
 	{
-		if (children == null)
-			return emptyList;
-		return children;
+		return null == children ? emptyList : children;
 	}
 
 	public String getEscapedCodeStr()
@@ -25,5 +25,10 @@ public class CompoundStatement extends Statement
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);
+	}
+
+	@Override
+	public Iterator<ASTNode> iterator() {
+		return getStatements().iterator();
 	}
 }

--- a/src/ast/php/functionDef/ClosureVar.java
+++ b/src/ast/php/functionDef/ClosureVar.java
@@ -8,15 +8,15 @@ public class ClosureVar extends ASTNode
 	
 	public void addChild(ASTNode node)
 	{
-		setName(node);
+		setNameChild(node);
 		super.addChild(node);
 	}
 	
-	public void setName(ASTNode name) {
+	public void setNameChild(ASTNode name) {
 		this.name = name;
 	}
 	
-	public ASTNode getName() {
+	public ASTNode getNameChild() {
 		return this.name;
 	}
 }

--- a/src/ast/php/functionDef/PHPParameter.java
+++ b/src/ast/php/functionDef/PHPParameter.java
@@ -1,0 +1,45 @@
+package ast.php.functionDef;
+
+import ast.ASTNode;
+import ast.expressions.Identifier;
+import ast.functionDef.Parameter;
+
+public class PHPParameter extends Parameter
+{
+	private Identifier type = null;
+	private ASTNode name = null;
+	private ASTNode defaultvalue = null;
+
+	public void addChild(ASTNode node)
+	{	
+		// Note: 3 children for PHP ASTs: Identifier and two plain ASTNode's.
+		// (TODO which I want to make into ast.php.expressions.PlainType sometime,
+		//  but that's a whole other story...)
+		// The Identifier is the type, *not* the name of the parameter!
+		// The two plain ASTNode's correspond to 'name' and 'default', respectively.
+		// Here we can only distinguish the two by the order in which they are added.
+		if( node instanceof Identifier)
+			this.type = (Identifier)node;
+		else if( null == this.name)
+				this.name = node;
+		else
+			this.defaultvalue = node;
+
+		super.addChild(node);
+	}
+
+	@Override
+	public Identifier getType()
+	{
+		return this.type;
+	}
+	
+	public ASTNode getNameChild() {
+		return this.name;
+	}
+	
+	public ASTNode getDefault()
+	{
+		return this.defaultvalue;
+	}
+}

--- a/src/ast/php/functionDef/TopLevelFunctionDef.java
+++ b/src/ast/php/functionDef/TopLevelFunctionDef.java
@@ -1,16 +1,18 @@
 package ast.php.functionDef;
 
 import ast.ASTNode;
+import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
+import ast.logical.statements.CompoundStatement;
 
 public class TopLevelFunctionDef extends FunctionDef
 {
 
 	public void addChild(ASTNode node)
 	{
-		// do not allow ParameterList's in top-level functions
-		if (!(node instanceof ParameterList))
+		// only allow CompoundStatements as children
+		if (node instanceof CompoundStatement)
 			super.addChild(node);
 	}
 
@@ -19,5 +21,10 @@ public class TopLevelFunctionDef extends FunctionDef
 	{
 		return null;
 	}
-
+	
+	@Override
+	public Identifier getReturnTypeIdentifier()
+	{
+		return null;
+	}
 }

--- a/src/inputModules/csv/csv2ast/ASTUnderConstruction.java
+++ b/src/inputModules/csv/csv2ast/ASTUnderConstruction.java
@@ -15,18 +15,30 @@ public class ASTUnderConstruction
 		return rootNode;
 	}
 
+	public void setRootNode(FunctionDef node)
+	{
+		rootNode = node;
+	}
+	
+	// TODO:
+	// - Make ASTUnderConstruction implement Map.
+	// - Accordingly, rename addNodeWithId() to put() and getNodeById() to get();
+	//    this makes the class more familiar to use for Java programmers anyhow.
+	// - Throw an exception if trying to put() a Node that already exists
+	//    in the map but with a different id.
+	// - The previous point makes the map bijective. Implement a method getIdForNode()
+	//    that gives us the unique id of a given node, or -1 if it is not contained.
 	public void addNodeWithId(ASTNode newNode, Long id)
 	{
 		idToNode.put(id, newNode);
 	}
 
-	public void setRootNode(FunctionDef node)
-	{
-		rootNode = node;
-	}
-
 	public ASTNode getNodeById(Long id)
 	{
 		return idToNode.get(id);
+	}
+	
+	public boolean containsValue(ASTNode node) {
+		return idToNode.containsValue(node);
 	}
 }

--- a/src/languages/c/cfg/CCFGFactory.java
+++ b/src/languages/c/cfg/CCFGFactory.java
@@ -392,7 +392,7 @@ public class CCFGFactory extends CFGFactory
 		try
 		{
 			CFG parameterListBlock = newInstance();
-			for (Parameter parameter : paramList.getParameters())
+			for (Parameter parameter : paramList)
 			{
 				parameterListBlock.appendCFG(convert(parameter));
 			}

--- a/src/languages/c/parsing/Functions/builder/ParameterListBuilder.java
+++ b/src/languages/c/parsing/Functions/builder/ParameterListBuilder.java
@@ -7,6 +7,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import ast.ASTNodeBuilder;
 import ast.functionDef.Parameter;
 import ast.functionDef.ParameterList;
+import ast.functionDef.ParameterType;
 import languages.c.antlr.ModuleParser.Parameter_declContext;
 import languages.c.antlr.ModuleParser.Parameter_idContext;
 import languages.c.parsing.ASTNodeFactory;
@@ -36,8 +37,8 @@ public class ParameterListBuilder extends ASTNodeBuilder
 				.childTokenString(ctx.param_decl_specifiers());
 		String completeType = determineCompleteType(parameter_id, baseType);
 
-		param.getType().setBaseType(baseType);
-		param.getType().setCompleteType(completeType);
+		((ParameterType)param.getType()).setBaseType(baseType);
+		((ParameterType)param.getType()).setCompleteType(completeType);
 
 		thisItem.addChild(param);
 	}

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import ast.ASTNode;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
-import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureVar;
@@ -106,8 +105,11 @@ public class TestPHPCSVNodeInterpreter
 		ASTNode node2 = ast.getNodeById((long)7);
 		
 		assertThat( node, instanceOf(Identifier.class));
+		assertEquals( ast.getNodeById((long)5), ((Identifier)node).getNameChild());
 		assertEquals( "bar", ((Identifier)node).getNameChild().getEscapedCodeStr());
+		
 		assertThat( node2, instanceOf(Identifier.class));
+		assertEquals( ast.getNodeById((long)8), ((Identifier)node2).getNameChild());
 		assertEquals( "buz", ((Identifier)node2).getNameChild().getEscapedCodeStr());
 	}
 	
@@ -151,8 +153,11 @@ public class TestPHPCSVNodeInterpreter
 		ASTNode node2 = ast.getNodeById((long)8);
 		
 		assertThat( node, instanceOf(ClosureVar.class));
+		assertEquals( ast.getNodeById((long)7), ((ClosureVar)node).getNameChild());
 		assertEquals( "foo", ((ClosureVar)node).getNameChild().getEscapedCodeStr());
+		
 		assertThat( node2, instanceOf(ClosureVar.class));
+		assertEquals( ast.getNodeById((long)9), ((ClosureVar)node2).getNameChild());
 		assertEquals( "bar", ((ClosureVar)node2).getNameChild().getEscapedCodeStr());
 	}
 	
@@ -198,11 +203,11 @@ public class TestPHPCSVNodeInterpreter
 		
 		assertThat( node, instanceOf(TopLevelFunctionDef.class));
 		assertEquals( "<foo.php>", ((TopLevelFunctionDef)node).getName());
-		assertThat( ((TopLevelFunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
+		assertEquals( ast.getNodeById((long)2), ((TopLevelFunctionDef)node).getContent());
 		
 		assertThat( node2, instanceOf(TopLevelFunctionDef.class));
 		assertEquals( "[bar]", ((TopLevelFunctionDef)node2).getName());
-		assertThat( ((TopLevelFunctionDef)node2).getContent(), instanceOf(CompoundStatement.class));
+		assertEquals( ast.getNodeById((long)7), ((TopLevelFunctionDef)node2).getContent());
 	}
 	
 	/**
@@ -245,9 +250,10 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node, instanceOf(FunctionDef.class));
 		assertEquals( "foo", ((FunctionDef)node).getName());
 		// TODO map AST_PARAM_LIST to ParameterList and check here
-		assertThat( ((FunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
-		assertThat( ((FunctionDef)node).getReturnType(), instanceOf(Identifier.class));
-		assertEquals( "int", ((Identifier)((FunctionDef)node).getReturnType()).getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)6), ((FunctionDef)node).getContent());
+		assertEquals( ast.getNodeById((long)7), ((FunctionDef)node).getReturnTypeIdentifier());
+		assertEquals( ast.getNodeById((long)8), ((FunctionDef)node).getReturnTypeIdentifier().getNameChild());
+		assertEquals( "int", ((FunctionDef)node).getReturnTypeIdentifier().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -294,9 +300,10 @@ public class TestPHPCSVNodeInterpreter
 		assertEquals( "{closure}", ((Closure)node).getName());
 		// TODO map AST_PARAM_LIST to ParameterList and check here
 		// TODO map AST_CLOSURE_USES to ClosureUses and check here
-		assertThat( ((FunctionDef)node).getContent(), instanceOf(CompoundStatement.class));
-		assertThat( ((FunctionDef)node).getReturnType(), instanceOf(Identifier.class));
-		assertEquals( "int", ((Identifier)((Closure)node).getReturnType()).getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)8), ((Closure)node).getContent());
+		assertEquals( ast.getNodeById((long)9), ((Closure)node).getReturnTypeIdentifier());
+		assertEquals( ast.getNodeById((long)10), ((Closure)node).getReturnTypeIdentifier().getNameChild());
+		assertEquals( "int", ((Closure)node).getReturnTypeIdentifier().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -340,9 +347,10 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node, instanceOf(Method.class));
 		assertEquals( "foo", ((Method)node).getName());
 		// TODO map AST_PARAM_LIST to ParameterList and check here
-		assertThat( ((Method)node).getContent(), instanceOf(CompoundStatement.class));
-		assertThat( ((Method)node).getReturnType(), instanceOf(Identifier.class));
-		assertEquals( "int", ((Identifier)((Method)node).getReturnType()).getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)11), ((Method)node).getContent());
+		assertEquals( ast.getNodeById((long)12), ((Method)node).getReturnTypeIdentifier());
+		assertEquals( ast.getNodeById((long)13), ((Method)node).getReturnTypeIdentifier().getNameChild());
+		assertEquals( "int", ((Method)node).getReturnTypeIdentifier().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -385,11 +393,12 @@ public class TestPHPCSVNodeInterpreter
 		
 		assertThat( node, instanceOf(PHPClassDef.class));
 		assertEquals( "foo", ((PHPClassDef)node).getName());
-		assertThat( ((PHPClassDef)node).getExtends(), instanceOf(Identifier.class));
+		assertEquals( ast.getNodeById((long)4), ((PHPClassDef)node).getExtends());
+		assertEquals( ast.getNodeById((long)5), ((PHPClassDef)node).getExtends().getNameChild());
 		assertEquals( "bar", ((PHPClassDef)node).getExtends().getNameChild().getEscapedCodeStr());
 		// TODO map AST_NAME_LIST to IdentifierList and check here
-		assertThat( ((PHPClassDef)node).getTopLevelFunc(), instanceOf(TopLevelFunctionDef.class));
+		assertEquals( ast.getNodeById((long)9), ((PHPClassDef)node).getTopLevelFunc());
 		assertEquals( "[foo]", ((PHPClassDef)node).getTopLevelFunc().getName());
+		assertEquals( ast.getNodeById((long)10), ((PHPClassDef)node).getTopLevelFunc().getContent());
 	}
-	
 }

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -67,7 +67,8 @@ public class TestPHPCSVNodeInterpreter
 	/**
 	 * AST_NAME nodes are used to identify certain names in PHP code,
 	 * such as for example the name of a class that a class declaration extends,
-	 * or the name of an interface that a class declaration implements.
+	 * the name of an interface that a class declaration implements,
+	 * or the name of a type returned by a function.
 	 * Other examples include names of called functions/methods, class
 	 * names associated with 'new' or 'instanceof' operators, etc.
 	 * 
@@ -150,9 +151,9 @@ public class TestPHPCSVNodeInterpreter
 		ASTNode node2 = ast.getNodeById((long)8);
 		
 		assertThat( node, instanceOf(ClosureVar.class));
-		assertEquals( "foo", ((ClosureVar)node).getName().getEscapedCodeStr());
+		assertEquals( "foo", ((ClosureVar)node).getNameChild().getEscapedCodeStr());
 		assertThat( node2, instanceOf(ClosureVar.class));
-		assertEquals( "bar", ((ClosureVar)node2).getName().getEscapedCodeStr());
+		assertEquals( "bar", ((ClosureVar)node2).getNameChild().getEscapedCodeStr());
 	}
 	
 	

--- a/src/tests/parseTreeToAST/ModuleBuildersTest.java
+++ b/src/tests/parseTreeToAST/ModuleBuildersTest.java
@@ -165,8 +165,7 @@ public class ModuleBuildersTest
 		String input = "int foo(char *myParam, myType x){}";
 		List<ASTNode> codeItems = parseInput(input);
 		FunctionDef codeItem = (FunctionDef) codeItems.get(0);
-		Parameter parameter = codeItem.getParameterList().getParameters()
-				.get(0);
+		Parameter parameter = codeItem.getParameterList().getParameter(0);
 		String codeStr = parameter.getEscapedCodeStr();
 		System.out.println(codeStr);
 		assertTrue(codeStr.equals("char * myParam"));
@@ -178,8 +177,7 @@ public class ModuleBuildersTest
 		String input = "int foo(myType myParam){}";
 		List<ASTNode> codeItems = parseInput(input);
 		FunctionDef codeItem = (FunctionDef) codeItems.get(0);
-		Identifier name = codeItem.getParameterList().getParameters()
-				.get(0).getName();
+		Identifier name = codeItem.getParameterList().getParameter(0).getIdentifier();
 		assertTrue(name.getEscapedCodeStr().equals("myParam"));
 	}
 
@@ -189,8 +187,7 @@ public class ModuleBuildersTest
 		String input = "int foo(char *myParam){}";
 		List<ASTNode> codeItems = parseInput(input);
 		FunctionDef codeItem = (FunctionDef) codeItems.get(0);
-		ParameterType type = codeItem.getParameterList().getParameters()
-				.get(0).getType();
+		ParameterType type = (ParameterType)codeItem.getParameterList().getParameter(0).getType();
 		System.out.println(type.getEscapedCodeStr());
 		assertTrue(type.getEscapedCodeStr().equals("char *"));
 	}
@@ -221,7 +218,7 @@ public class ModuleBuildersTest
 		String input = "int foo(){}";
 		List<ASTNode> codeItems = parseInput(input);
 		FunctionDef codeItem = (FunctionDef) codeItems.get(0);
-		assertTrue(codeItem.getParameterList().getParameters().size() == 0);
+		assertTrue(codeItem.getParameterList().size() == 0);
 	}
 
 	private List<ASTNode> parseInput(String input)

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -8,11 +8,13 @@ import ast.ASTNode;
 import ast.CodeLocation;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
+import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
@@ -63,6 +65,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				retval = handleDo(row, ast);
 				break;
 
+			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_PARAM:
+				retval = handleParameter(row, ast);
+				break;
+
 			// nodes with exactly 4 children
 			case PHPCSVNodeTypes.TYPE_FOR:
 				retval = handleFor(row, ast);
@@ -74,6 +81,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_IF:
 				retval = handleIf(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
+				retval = handleParameterList(row, ast);
 				break;
 
 			default:
@@ -311,6 +321,27 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		return id;
 	}
+
+
+	/* nodes with exactly 3 children */
+
+	private long handleParameter(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPParameter newNode = new PHPParameter();
+
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 	
 	
 	/* nodes with exactly 4 children */
@@ -357,6 +388,24 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleIf(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		IfStatement newNode = new IfStatement();
+
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleParameterList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ParameterList newNode = new ParameterList();
 
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -28,7 +28,7 @@ public class PHPCSVNodeTypes
 	// directory/file types
 	public static final String TYPE_FILE = "File";
 	public static final String TYPE_DIRECTORY = "Directory";
-	
+
 	// special nodes
 	public static final String TYPE_NAME = "AST_NAME";
 	public static final String TYPE_CLOSURE_VAR = "AST_CLOSURE_VAR";
@@ -38,27 +38,29 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_FUNC_DECL = "AST_FUNC_DECL";
 	public static final String TYPE_METHOD = "AST_METHOD";
 	public static final String TYPE_CLOSURE = "AST_CLOSURE";
-	
+
 	public static final List<String> funcTypes =
 			Arrays.asList(TYPE_TOPLEVEL, TYPE_FUNC_DECL, TYPE_METHOD, TYPE_CLOSURE);
-	
+
 	public static final String TYPE_CLASS = "AST_CLASS";
 
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
-	
+
+	// nodes with exactly 3 children
+	public static final String TYPE_PARAM = "AST_PARAM";
+
 	// nodes with exactly 4 children
 	public static final String TYPE_FOR = "AST_FOR";
 
 	// nodes with an arbitrary number of children
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";
-	
+	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
+
 	/* node flags */
 	// flags for toplevel nodes
 	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial
 	public static final String FLAG_TOPLEVEL_CLASS = "TOPLEVEL_CLASS"; // artificial
-
-
 }


### PR DESCRIPTION
Support for parameters was not completely trivial. This is because, basically:
* For C ASTs, Joern uses a `Parameter` class with two children:
    1. A `ParameterType` representing the type
    2. An `Identifier` representing the name
* For PHP ASTs, we use a `PHPParameter` class (that extends `Parameter`) with three children:
    1. An `Identifier` representing the type
    2. A plain `ASTNode` representing the name
    3. A plain `ASTNode` representing the default value

In particular, both use exactly one `Identifier` child, but for different purposes. This easily leads to confusion and incompatibilities. Thus the base class `Parameter` now declares a `getType()` method that returns an `ASTNode` (and not a `ParameterType`). Code dealing with C has to downcast this to a `ParameterType` and this works fine. Of course, it would be cleaner to have a single *abstract* common base class that has a method `getType()` which returns an `ASTNode`, and two classes `CParameter` and `PHPParameter` that extend it, with the former returning a `ParameterType` and the latter returning an `Identifier`. Actually, this is now almost the case, except that this `CParameter` class is missing (and so code dealing with C has to use a downcast from `ASTNode` to `ParameterType` when calling `getType()`), but I did not want to touch the C part of Joern any more than absolutely necessary. The problem here is basically that we cannot always use the "C implementation" as the base class, and the "PHP implementation" extend this C-implementation base class. Rather, we want a base implementation that abstracts away both languages, and then C- resp. PHP-aware implementations that extend it.

One more note. You might think it weird that the type of a parameter in PHP ASTs is represented using an `Identifier`, while the name of a parameter is simply represented as a plain type. There is actually sense to this. The reason is that PHP ASTs always need an `AST_NAME` node (= `Identifier`) instead of a simple plain type node whenever what that node represents could be namespaced: That is, we need `AST_NAME`'s iff we require namespace-awareness. For example, when we have PHP code such as `new foo()`, `bar instanceof foo`, or `function somefunction(foo varname, ...)`, then `foo` could be namespaced in all these cases: All these examples could also use `some\namespace\foo` instead of simply `foo`, and that would be perfectly valid PHP code. However, in these examples, `bar` and `varname` are simple variable names, and as such of course cannot be namespaced.

Additionally to this, there were some other small improvements, such as:
* Improved tests for all test cases in `TestPHPCSVNodeInterpreter`;
* Have `CompoundStatement` implement `Iterable`;
* Have `ParameterList` implement `Iterable`;
* Start to have `ASTUnderConstruction` implement `Map`.