### PR TITLE
 Implemented smart edge interpreter

### DIFF
--- a/src/ast/declarations/ClassDefStatement.java
+++ b/src/ast/declarations/ClassDefStatement.java
@@ -16,14 +16,20 @@ public class ClassDefStatement extends Statement
 	public void addChild(ASTNode expression)
 	{
 		if (expression instanceof Identifier)
-			identifier = (Identifier) expression;
-
-		super.addChild(expression);
+			setIdentifier( (Identifier)expression);
+		else
+			super.addChild(expression);
 	}
 
 	public Identifier getIdentifier()
 	{
-		return identifier;
+		return this.identifier;
+	}
+	
+	private void setIdentifier(Identifier identifier)
+	{
+		this.identifier = identifier;
+		super.addChild(identifier);
 	}
 	
 	@Override

--- a/src/ast/declarations/ClassDefStatement.java
+++ b/src/ast/declarations/ClassDefStatement.java
@@ -5,6 +5,7 @@ import ast.DummyIdentifierNode;
 import ast.expressions.Identifier;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Statement;
+import ast.walking.ASTNodeVisitor;
 
 public class ClassDefStatement extends Statement
 {
@@ -23,5 +24,11 @@ public class ClassDefStatement extends Statement
 	public Identifier getIdentifier()
 	{
 		return identifier;
+	}
+	
+	@Override
+	public void accept(ASTNodeVisitor visitor)
+	{
+		visitor.visit(this);
 	}
 }

--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -1,6 +1,7 @@
 package ast.expressions;
 
 import ast.ASTNode;
+import ast.walking.ASTNodeVisitor;
 
 public class Identifier extends Expression
 {
@@ -29,4 +30,9 @@ public class Identifier extends Expression
 		return this.name;
 	}
 
+	@Override
+	public void accept(ASTNodeVisitor visitor)
+	{
+		visitor.visit(this);
+	}
 }

--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -15,15 +15,10 @@ public class Identifier extends Expression
 	{
 		super(name);
 	}
-	
-	public void addChild(ASTNode node)
-	{
-		setNameChild(node);
-		super.addChild(node);
-	}
-	
+
 	public void setNameChild(ASTNode name) {
 		this.name = name;
+		super.addChild(name);
 	}
 	
 	public ASTNode getNameChild() {

--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -13,6 +13,7 @@ public class FunctionDef extends ASTNode
 	private Identifier identifier = new DummyIdentifierNode();
 	private ParameterList parameterList = new ParameterList();
 	private CompoundStatement content = new CompoundStatement();
+	private Identifier returnType = null;
 
 	public void addChild(ASTNode node)
 	{
@@ -22,8 +23,8 @@ public class FunctionDef extends ASTNode
 			setParameterList((ParameterList) node);
 		else if (node instanceof Identifier)
 			setIdentifier((Identifier) node);
-
-		super.addChild(node);
+		else
+			super.addChild(node);
 	}
 	
 	public String getName() {
@@ -44,12 +45,25 @@ public class FunctionDef extends ASTNode
 
 	public CompoundStatement getContent()
 	{
-		return content;
+		return this.content;
 	}
 	
-	public Identifier getReturnTypeIdentifier()
+	public void setContent(CompoundStatement content)
 	{
-		return this.identifier;
+		this.content = content;
+		super.addChild(content);
+	}
+	
+	public Identifier getReturnType()
+	{
+		return this.returnType;
+	}
+	
+	public void setReturnType(ASTNode returnType)
+	{
+		if( returnType instanceof Identifier)
+			this.returnType = (Identifier)returnType;
+		super.addChild(returnType);
 	}
 
 	@Override
@@ -69,11 +83,6 @@ public class FunctionDef extends ASTNode
 		return retval;
 	}
 
-	private void setContent(CompoundStatement functionContent)
-	{
-		this.content = functionContent;
-	}
-
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);
@@ -81,22 +90,24 @@ public class FunctionDef extends ASTNode
 
 	public ParameterList getParameterList()
 	{
-		return parameterList;
+		return this.parameterList;
 	}
 
-	private void setParameterList(ParameterList parameterList)
+	public void setParameterList(ParameterList parameterList)
 	{
 		this.parameterList = parameterList;
+		super.addChild(parameterList);
 	}
 
 	public Identifier getIdentifier()
 	{
-		return identifier;
+		return this.identifier;
 	}
 
 	private void setIdentifier(Identifier identifier)
 	{
 		this.identifier = identifier;
+		super.addChild(identifier);
 	}
 
 }

--- a/src/ast/functionDef/Parameter.java
+++ b/src/ast/functionDef/Parameter.java
@@ -16,8 +16,8 @@ public class Parameter extends ASTNode
 			setType((ParameterType) node);
 		else if (node instanceof Identifier)
 			setIdentifier((Identifier) node);
-
-		super.addChild(node);
+		else
+			super.addChild(node);
 	}
 
 	@Override
@@ -33,9 +33,11 @@ public class Parameter extends ASTNode
 		return type;
 	}
 
-	private void setType(ParameterType type)
+	public void setType(ASTNode type)
 	{
-		this.type = type;
+		if( type instanceof ParameterType)
+			this.type = (ParameterType)type;
+		super.addChild(type);
 	}
 
 	// for C ASTs, returns the name
@@ -48,5 +50,6 @@ public class Parameter extends ASTNode
 	private void setIdentifier(Identifier identifier)
 	{
 		this.identifier = identifier;
+		super.addChild(identifier);
 	}
 }

--- a/src/ast/functionDef/ParameterList.java
+++ b/src/ast/functionDef/ParameterList.java
@@ -14,7 +14,8 @@ public class ParameterList extends ASTNode implements Iterable<Parameter>
 	{
 		if (node instanceof Parameter)
 			addParameter((Parameter) node);
-		super.addChild(node);
+		else
+			super.addChild(node);
 	}
 
 	public int size()
@@ -26,9 +27,10 @@ public class ParameterList extends ASTNode implements Iterable<Parameter>
 		return this.parameters.get(i);
 	}
 
-	private void addParameter(Parameter parameter)
+	public void addParameter(Parameter parameter)
 	{
 		this.parameters.add(parameter);
+		super.addChild(parameter);
 	}
 
 	@Override

--- a/src/ast/logical/statements/CompoundStatement.java
+++ b/src/ast/logical/statements/CompoundStatement.java
@@ -22,6 +22,7 @@ public class CompoundStatement extends Statement implements Iterable<ASTNode>
 		return "";
 	}
 
+	@Override
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/ast/php/declarations/PHPClassDef.java
+++ b/src/ast/php/declarations/PHPClassDef.java
@@ -10,18 +10,8 @@ import ast.php.functionDef.TopLevelFunctionDef;
 public class PHPClassDef extends ClassDefStatement
 {
 
-	public Identifier parent = new DummyIdentifierNode();
-	public TopLevelFunctionDef toplevelfunc = new TopLevelFunctionDef();
-
-	public void addChild(ASTNode node)
-	{
-		if (node instanceof Identifier)
-			parent = (Identifier) node;
-		else if (node instanceof TopLevelFunctionDef)
-			toplevelfunc = (TopLevelFunctionDef) node;
-
-		super.addChild(node);
-	}
+	private Identifier parent = new DummyIdentifierNode();
+	private TopLevelFunctionDef toplevelfunc = new TopLevelFunctionDef();
 
 	public String getName() {
 		return getProperty(ASTNodeProperties.NAME);
@@ -31,9 +21,24 @@ public class PHPClassDef extends ClassDefStatement
 		setProperty(ASTNodeProperties.NAME, name);
 	}
 	
+	public String getDocComment() {
+		return getProperty(ASTNodeProperties.DOCCOMMENT);
+	}
+	
+	public void setDocComment(String doccomment) {
+		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
+	}
+	
 	public Identifier getExtends()
 	{
 		return this.parent;
+	}
+	
+	public void setExtends(ASTNode parent)
+	{
+		if( parent instanceof Identifier)
+			this.parent = (Identifier)parent;
+		super.addChild(parent);
 	}
 	
 	public TopLevelFunctionDef getTopLevelFunc()
@@ -41,11 +46,9 @@ public class PHPClassDef extends ClassDefStatement
 		return this.toplevelfunc;
 	}
 	
-	public String getDocComment() {
-		return getProperty(ASTNodeProperties.DOCCOMMENT);
-	}
-	
-	public void setDocComment(String doccomment) {
-		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
+	public void setTopLevelFunc(TopLevelFunctionDef toplevelfunc)
+	{
+		this.toplevelfunc = toplevelfunc;
+		super.addChild(toplevelfunc);
 	}
 }

--- a/src/ast/php/functionDef/Closure.java
+++ b/src/ast/php/functionDef/Closure.java
@@ -1,7 +1,21 @@
 package ast.php.functionDef;
 
+import ast.ASTNode;
 import ast.functionDef.FunctionDef;
 
 public class Closure extends FunctionDef
 {
+	private ClosureUses closureUses = null;
+
+	public ClosureUses getClosureUses()
+	{
+		return this.closureUses;
+	}
+
+	public void setClosureUses(ASTNode closureUses)
+	{
+		if( closureUses instanceof ClosureUses)
+			this.closureUses = (ClosureUses)closureUses;
+		super.addChild(closureUses);
+	}
 }

--- a/src/ast/php/functionDef/ClosureUses.java
+++ b/src/ast/php/functionDef/ClosureUses.java
@@ -1,0 +1,31 @@
+package ast.php.functionDef;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+
+public class ClosureUses extends ASTNode implements Iterable<ClosureVar>
+{
+	private LinkedList<ClosureVar> closurevars = new LinkedList<ClosureVar>();
+
+	public int size()
+	{
+		return this.closurevars.size();
+	}
+	
+	public ClosureVar getClosureVar(int i) {
+		return this.closurevars.get(i);
+	}
+
+	public void addClosureVar(ClosureVar closurevar)
+	{
+		this.closurevars.add(closurevar);
+		super.addChild(closurevar);
+	}
+
+	@Override
+	public Iterator<ClosureVar> iterator() {
+		return this.closurevars.iterator();
+	}
+}

--- a/src/ast/php/functionDef/ClosureVar.java
+++ b/src/ast/php/functionDef/ClosureVar.java
@@ -6,14 +6,9 @@ public class ClosureVar extends ASTNode
 {
 	private ASTNode name = new ASTNode();
 	
-	public void addChild(ASTNode node)
-	{
-		setNameChild(node);
-		super.addChild(node);
-	}
-	
 	public void setNameChild(ASTNode name) {
 		this.name = name;
+		super.addChild(name);
 	}
 	
 	public ASTNode getNameChild() {

--- a/src/ast/php/functionDef/PHPParameter.java
+++ b/src/ast/php/functionDef/PHPParameter.java
@@ -10,36 +10,39 @@ public class PHPParameter extends Parameter
 	private ASTNode name = null;
 	private ASTNode defaultvalue = null;
 
-	public void addChild(ASTNode node)
-	{	
-		// Note: 3 children for PHP ASTs: Identifier and two plain ASTNode's.
-		// (TODO which I want to make into ast.php.expressions.PlainType sometime,
-		//  but that's a whole other story...)
-		// The Identifier is the type, *not* the name of the parameter!
-		// The two plain ASTNode's correspond to 'name' and 'default', respectively.
-		// Here we can only distinguish the two by the order in which they are added.
-		if( node instanceof Identifier)
-			this.type = (Identifier)node;
-		else if( null == this.name)
-				this.name = node;
-		else
-			this.defaultvalue = node;
-
-		super.addChild(node);
-	}
-
 	@Override
 	public Identifier getType()
 	{
 		return this.type;
 	}
 	
-	public ASTNode getNameChild() {
+	@Override
+	public void setType(ASTNode type)
+	{
+		if( type instanceof Identifier)
+			this.type = (Identifier)type;
+		super.addChild(type);
+	}
+	
+	public ASTNode getNameChild()
+	{
 		return this.name;
+	}
+	
+	public void setNameChild(ASTNode name)
+	{
+		this.name = name;
+		super.addChild(name);
 	}
 	
 	public ASTNode getDefault()
 	{
 		return this.defaultvalue;
+	}
+	
+	public void setDefault(ASTNode defaultvalue)
+	{
+		this.defaultvalue = defaultvalue;
+		super.addChild(defaultvalue);
 	}
 }

--- a/src/ast/php/functionDef/TopLevelFunctionDef.java
+++ b/src/ast/php/functionDef/TopLevelFunctionDef.java
@@ -4,18 +4,9 @@ import ast.ASTNode;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
-import ast.logical.statements.CompoundStatement;
 
 public class TopLevelFunctionDef extends FunctionDef
 {
-
-	public void addChild(ASTNode node)
-	{
-		// only allow CompoundStatements as children
-		if (node instanceof CompoundStatement)
-			super.addChild(node);
-	}
-
 	@Override
 	public ParameterList getParameterList()
 	{
@@ -23,8 +14,18 @@ public class TopLevelFunctionDef extends FunctionDef
 	}
 	
 	@Override
-	public Identifier getReturnTypeIdentifier()
+	public void setParameterList(ParameterList parameterList)
+	{
+	}
+	
+	@Override
+	public Identifier getReturnType()
 	{
 		return null;
+	}
+	
+	@Override
+	public void setReturnType(ASTNode returnType)
+	{
 	}
 }

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -30,7 +30,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import tools.phpast2cfg.PHPCSVEdgeInterpreter;
 import tools.phpast2cfg.PHPCSVNodeInterpreter;
 
-public class TestPHPCSVNodeInterpreter
+public class TestPHPCSVASTBuilder
 {
 	PHPCSVNodeInterpreter nodeInterpreter = new PHPCSVNodeInterpreter();
 	PHPCSVEdgeInterpreter edgeInterpreter = new PHPCSVEdgeInterpreter();
@@ -263,9 +263,9 @@ public class TestPHPCSVNodeInterpreter
 		assertEquals( 4, node.getChildCount());
 		assertEquals( ast.getNodeById((long)4), ((FunctionDef)node).getParameterList());
 		assertEquals( ast.getNodeById((long)6), ((FunctionDef)node).getContent());
-		assertEquals( ast.getNodeById((long)7), ((FunctionDef)node).getReturnTypeIdentifier());
-		assertEquals( ast.getNodeById((long)8), ((FunctionDef)node).getReturnTypeIdentifier().getNameChild());
-		assertEquals( "int", ((FunctionDef)node).getReturnTypeIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)7), ((FunctionDef)node).getReturnType());
+		assertEquals( ast.getNodeById((long)8), ((FunctionDef)node).getReturnType().getNameChild());
+		assertEquals( "int", ((FunctionDef)node).getReturnType().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -314,9 +314,9 @@ public class TestPHPCSVNodeInterpreter
 		assertEquals( ast.getNodeById((long)4), ((Closure)node).getParameterList());
 		// TODO map AST_CLOSURE_USES to ClosureUses and check here
 		assertEquals( ast.getNodeById((long)8), ((Closure)node).getContent());
-		assertEquals( ast.getNodeById((long)9), ((Closure)node).getReturnTypeIdentifier());
-		assertEquals( ast.getNodeById((long)10), ((Closure)node).getReturnTypeIdentifier().getNameChild());
-		assertEquals( "int", ((Closure)node).getReturnTypeIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)9), ((Closure)node).getReturnType());
+		assertEquals( ast.getNodeById((long)10), ((Closure)node).getReturnType().getNameChild());
+		assertEquals( "int", ((Closure)node).getReturnType().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -362,9 +362,9 @@ public class TestPHPCSVNodeInterpreter
 		assertEquals( 4, node.getChildCount());
 		assertEquals( ast.getNodeById((long)9), ((Method)node).getParameterList());
 		assertEquals( ast.getNodeById((long)11), ((Method)node).getContent());
-		assertEquals( ast.getNodeById((long)12), ((Method)node).getReturnTypeIdentifier());
-		assertEquals( ast.getNodeById((long)13), ((Method)node).getReturnTypeIdentifier().getNameChild());
-		assertEquals( "int", ((Method)node).getReturnTypeIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)12), ((Method)node).getReturnType());
+		assertEquals( ast.getNodeById((long)13), ((Method)node).getReturnType().getNameChild());
+		assertEquals( "int", ((Method)node).getReturnType().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**
@@ -424,10 +424,10 @@ public class TestPHPCSVNodeInterpreter
 	 * AST_PARAM nodes are used for function parameters.
 	 * 
 	 * Any AST_PARAM node has exactly three children:
-	 * 1) AST_NAME, representing the parameter's type
+	 * 1) AST_NAME or NULL, representing the parameter's type
 	 * 2) string, indicating the parameter's name
 	 * 3) various possible child types, representing the default value
-	 *    (e.g., node type could be "string", "integer", but also AST_CONST, etc.)
+	 *    (e.g., node type could be "NULL", "string", "integer", but also AST_CONST, etc.)
 	 * 
 	 * This test checks a parameter's children in the following PHP code:
 	 * 

--- a/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
+++ b/src/tests/inputModules/TestPHPCSVNodeInterpreter.java
@@ -261,7 +261,7 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node, instanceOf(FunctionDef.class));
 		assertEquals( "foo", ((FunctionDef)node).getName());
 		assertEquals( 4, node.getChildCount());
-		// TODO map AST_PARAM_LIST to ParameterList and check here
+		assertEquals( ast.getNodeById((long)4), ((FunctionDef)node).getParameterList());
 		assertEquals( ast.getNodeById((long)6), ((FunctionDef)node).getContent());
 		assertEquals( ast.getNodeById((long)7), ((FunctionDef)node).getReturnTypeIdentifier());
 		assertEquals( ast.getNodeById((long)8), ((FunctionDef)node).getReturnTypeIdentifier().getNameChild());
@@ -311,7 +311,7 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node, instanceOf(Closure.class));
 		assertEquals( "{closure}", ((Closure)node).getName());
 		assertEquals( 4, node.getChildCount());
-		// TODO map AST_PARAM_LIST to ParameterList and check here
+		assertEquals( ast.getNodeById((long)4), ((Closure)node).getParameterList());
 		// TODO map AST_CLOSURE_USES to ClosureUses and check here
 		assertEquals( ast.getNodeById((long)8), ((Closure)node).getContent());
 		assertEquals( ast.getNodeById((long)9), ((Closure)node).getReturnTypeIdentifier());
@@ -360,7 +360,7 @@ public class TestPHPCSVNodeInterpreter
 		assertThat( node, instanceOf(Method.class));
 		assertEquals( "foo", ((Method)node).getName());
 		assertEquals( 4, node.getChildCount());
-		// TODO map AST_PARAM_LIST to ParameterList and check here
+		assertEquals( ast.getNodeById((long)9), ((Method)node).getParameterList());
 		assertEquals( ast.getNodeById((long)11), ((Method)node).getContent());
 		assertEquals( ast.getNodeById((long)12), ((Method)node).getReturnTypeIdentifier());
 		assertEquals( ast.getNodeById((long)13), ((Method)node).getReturnTypeIdentifier().getNameChild());

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1,7 +1,18 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
+import ast.expressions.Identifier;
+import ast.functionDef.FunctionDef;
+import ast.functionDef.ParameterList;
+import ast.logical.statements.CompoundStatement;
+import ast.php.declarations.PHPClassDef;
+import ast.php.functionDef.Closure;
+import ast.php.functionDef.ClosureVar;
+import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPParameter;
+import ast.php.functionDef.TopLevelFunctionDef;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 
@@ -10,16 +21,279 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	@Override
 	public long handle(KeyedCSVRow row, ASTUnderConstruction ast)
+		throws InvalidCSVFile
 	{
 		long startId = Long.parseLong(row.getFieldForKey(PHPCSVEdgeTypes.START_ID));
 		long endId = Long.parseLong(row.getFieldForKey(PHPCSVEdgeTypes.END_ID));
 
 		ASTNode startNode = ast.getNodeById(startId);
 		ASTNode endNode = ast.getNodeById(endId);
+		
+		// TODO put childnum property into edges file instead of nodes file,
+		// then do not add the childnum property to ASTNodes in node interpreter any longer
+		//int childnum = Integer.parseInt(row.getFieldForKey(PHPCSVEdgeTypes.CHILDNUM));
+		int childnum = Integer.parseInt(endNode.getProperty(PHPCSVNodeTypes.CHILDNUM.getName()));
 
-		startNode.addChild(endNode);
+		int errno = 0;
+		String type = startNode.getProperty(PHPCSVNodeTypes.TYPE.getName());
+		switch (type)
+		{
+			// special nodes
+			case PHPCSVNodeTypes.TYPE_NAME:
+				errno = handleName((Identifier)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLOSURE_VAR:
+				errno = handleClosureVar((ClosureVar)startNode, endNode, childnum);
+				break;
+				
+			// declaration nodes
+			case PHPCSVNodeTypes.TYPE_TOPLEVEL:
+				errno = handleTopLevelFunction((TopLevelFunctionDef)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_FUNC_DECL:
+				errno = handleFunction((FunctionDef)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLOSURE:
+				errno = handleClosure((Closure)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_METHOD:
+				errno = handleMethod((Method)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLASS:
+				errno = handleClass((PHPClassDef)startNode, endNode, childnum);
+				break;
+				
+			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_PARAM:
+				errno = handleParameter((PHPParameter)startNode, endNode, childnum);
+				break;
+				
+			// nodes with an arbitrary number of children
+			case PHPCSVNodeTypes.TYPE_STMT_LIST:
+				errno = handleCompound((CompoundStatement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
+				errno = handleParameterList((ParameterList)startNode, endNode, childnum);
+				break;
+				
+			default:
+				errno = defaultHandler(startNode, endNode, childnum);
+		}
+
+		if( 1 == errno)
+			throw new InvalidCSVFile("While trying to handle row "
+					+ row.toString() + ": Invalid childnum " + childnum
+					+ " for start node type " + type + ".");
+		
 		
 		return startId;
 	}
+	
+	private int defaultHandler( ASTNode startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addChild(endNode);
+		
+		return 0;
+	}
+	
+	
+	/* special nodes */
+	
+	private int handleName( Identifier startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
 
+		switch (childnum)
+		{
+			case 0: // name child
+				startNode.setNameChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleClosureVar( ClosureVar startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child
+				startNode.setNameChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	
+	/* declaration nodes */
+
+	private int handleTopLevelFunction( TopLevelFunctionDef startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // stmts child
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+
+	private int handleFunction( FunctionDef startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // params child
+				startNode.setParameterList((ParameterList)endNode);
+				break;
+			case 1: // NULL child
+				startNode.addChild(endNode);
+				break;
+			case 2: // stmts child
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+			case 3: // returnType child: either Identifier or NULL node
+				startNode.setReturnType(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleClosure( Closure startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // params child
+				startNode.setParameterList((ParameterList)endNode);
+				break;
+			case 1: // uses child: either ClosureUses or NULL node
+				startNode.addChild(endNode); // TODO introduce ClosureUses and setClosureUses
+				break;
+			case 2: // stmts child
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+			case 3: // returnType child: either Identifier or NULL node
+				startNode.setReturnType(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+
+	private int handleMethod( Method startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // params child
+				startNode.setParameterList((ParameterList)endNode);
+				break;
+			case 1: // NULL child
+				startNode.addChild(endNode);
+				break;
+			case 2: // stmts child
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+			case 3: // returnType child: either Identifier or NULL node
+				startNode.setReturnType(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleClass( PHPClassDef startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // extends child: either Identifier or NULL node
+				startNode.setExtends(endNode);
+				break;
+			case 1: // implements child
+				startNode.addChild(endNode); // TODO introduce IdentifierList and setImplements
+				break;
+			case 2: // toplevel child
+				startNode.setTopLevelFunc((TopLevelFunctionDef)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	
+	/* nodes with exactly 3 children */
+	
+	private int handleParameter( PHPParameter startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // type child: either Identifier or NULL node
+				startNode.setType(endNode);
+				break;
+			case 1: // name child: plain node
+				startNode.setNameChild(endNode);
+				break;
+			case 2: // default child: either plain or NULL node
+				startNode.setDefault(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+
+	/* nodes with an arbitrary number of children */
+	
+	private int handleCompound( CompoundStatement startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addChild(endNode);
+
+		return 0;
+	}
+	
+	private int handleParameterList( ParameterList startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addParameter((PHPParameter)endNode);
+
+		return 0;
+	}
 }

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -7,6 +7,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
+import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
@@ -74,6 +75,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
 				errno = handleParameterList((ParameterList)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLOSURE_USES:
+				errno = handleClosureUses((ClosureUses)startNode, endNode, childnum);
 				break;
 				
 			default:
@@ -189,7 +193,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setParameterList((ParameterList)endNode);
 				break;
 			case 1: // uses child: either ClosureUses or NULL node
-				startNode.addChild(endNode); // TODO introduce ClosureUses and setClosureUses
+				startNode.setClosureUses(endNode);
 				break;
 			case 2: // stmts child
 				startNode.setContent((CompoundStatement)endNode);
@@ -293,6 +297,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleParameterList( ParameterList startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addParameter((PHPParameter)endNode);
+
+		return 0;
+	}
+	
+	private int handleClosureUses( ClosureUses startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addClosureVar((ClosureVar)endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -12,6 +12,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
+import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
@@ -84,6 +85,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
 				retval = handleParameterList(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLOSURE_USES:
+				retval = handleClosureUses(row, ast);
 				break;
 
 			default:
@@ -460,6 +464,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleParameterList(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ParameterList newNode = new ParameterList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleClosureUses(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ClosureUses newNode = new ClosureUses();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -101,6 +101,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
@@ -108,6 +109,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
 		newNode.setCodeStr(code);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -122,13 +124,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		Identifier newNode = new Identifier();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -140,13 +146,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		ClosureVar newNode = new ClosureVar();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -162,16 +172,20 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		TopLevelFunctionDef newNode = new TopLevelFunctionDef();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
-		newNode.setLocation(codeloc);
 		codeloc.startLine = Integer.parseInt(lineno);
 		codeloc.endLine = Integer.parseInt(endlineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 		if (flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_FILE))
 			newNode.setName("<" + name + ">");
 		else if (flags.contains(PHPCSVNodeTypes.FLAG_TOPLEVEL_CLASS))
@@ -191,17 +205,21 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		FunctionDef newNode = new FunctionDef();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 		newNode.setName(name);
 		newNode.setDocComment(doccomment);
 
@@ -215,17 +233,21 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		Closure newNode = new Closure();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 		newNode.setName(name);
 		newNode.setDocComment(doccomment);
 
@@ -239,17 +261,21 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		Method newNode = new Method();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 		newNode.setName(name);
 		newNode.setDocComment(doccomment);
 
@@ -263,17 +289,21 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		PHPClassDef newNode = new PHPClassDef();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 		String endlineno = row.getFieldForKey(PHPCSVNodeTypes.ENDLINENO);
 		String name = row.getFieldForKey(PHPCSVNodeTypes.NAME);
 		String doccomment = row.getFieldForKey(PHPCSVNodeTypes.DOCCOMMENT);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		codeloc.endLine = Integer.parseInt(endlineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 		newNode.setName(name);
 		newNode.setDocComment(doccomment);
 
@@ -290,13 +320,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		WhileStatement newNode = new WhileStatement();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -308,13 +342,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		DoStatement newNode = new DoStatement();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -329,13 +367,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		PHPParameter newNode = new PHPParameter();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -350,13 +392,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		ForStatement newNode = new ForStatement();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -371,13 +417,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		CompoundStatement newNode = new CompoundStatement();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -389,13 +439,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		IfStatement newNode = new IfStatement();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);
@@ -407,13 +461,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	{
 		ParameterList newNode = new ParameterList();
 
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
 		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -58,6 +58,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
+	public static final String TYPE_CLOSURE_USES = "AST_CLOSURE_USES";
 
 	/* node flags */
 	// flags for toplevel nodes


### PR DESCRIPTION
Before, the logic for adding childs was implemented entirely in the different kinds of nodes (classes extending `ASTNode`) itself (e.g., in `PHPParameter`: "Am I adding a parameter type? Or a parameter name? Or a parameter default value?"), within the `addChild()` method. This will work fine provided that for each kind of node, it holds that the node's children all have pairwise distinct node types. Then, the `addChild()` method can always call the appropriate handler by looking at the child's type.

For PHP ASTs, this is not always given. There are cases where a particular kind of node can have different children of the same kind. An example of this is the `AST_PARAM` node with its 'name' and 'default' children. When this occurs, the only way that the `addChild()` method can *halfway* reliably distinguish what handler to call is by the order in which these children were added. But this assumes that the `addChild()` will be called a certain number of times with different parameters *in a particular, undocumented order* (it requires that the edges in the edges file appear in a certain order.) This feels like a hack, and it's error-prone.

Thinking about this, I realized that this logic belongs into the edge interpreter. The edge interpreter knows the AST, it knows the start node id and the end node id (and, thus, the start node and the end node itself), it can look at the `childnum` property, and it knows exactly what kind of child it is adding. Once this dawned on me, it became plain as day: The node interpreter knows what kind of nodes it is adding, and the edge interpreter knows what kind of edges it is adding. Thus I implemented a smart edge interpreter which does exactly that, and directly calls a node's appropriate handlers instead of generically calling the `addChild()` method. Additionally, thereby the PHP AST structure is (/will) now be documented in these two central files: the `PHPCSVNodeInterpreter` and the `PHPCSVEdgeInterpreter`. The only case where the `addChild()` method still makes sense for PHP ASTs is in those kind of nodes which have an arbitrary number of children, such as `CompoundStatement` or `ParameterList`.

(Conversely, a particular child of a PHP AST node can have different kinds. For instance, a "return type" child of a function node can be either an Identifier node if the corresponding PHP function returns something, or a "null" node if it is a void function. Such a null node, i.e., an `ASTNode` with its type set to NULL, should be added to the function node's children and count towards the children count, but it is not an Identifier. Hence in such a case, `FunctionDef.getReturnType()` can only return the null value instead of the null node itself, which is fine. The point is that the previous architecture behaved in the same way, but did so in a kind of implicit, somewhat hidden way; the new architecture makes this reasoning more explicit.)

Note that though technically possible, it would not be a good idea to have the logic that calls handlers according to their `childnum` property in the `addChild()` methods of the different `ASTNode`'s. The `childnum` property is not an inherent property of a PHP AST node: Rather, like `funcid`, it is a meta-property pertaining to the CSV files. Therefore, even though the `childnum` property is currently read from CSV and saved to any new `ASTNode` by the node interpreter, the `addChild()` method of an `ASTNode` should not "know" about it. In fact, the `childnum` property rather belongs in the edges file, not in the nodes file, and in time I will modify the phpjoern exporter to do just that. Then, the `childnum` property will no longer be added to the `ASTNode`'s created by the node interpreter (just like the `funcid` isn't, either). Additionally, it would get very ugly if we tried to consolidate an `ASTNode`'s `addChild()` method for both C and PHP ASTs by having it look first whether the `childnum` property is defined (-> we are in PHP world) and call the appropriate handlers according to that, or if it is not defined (-> we are in C world), look at the child's type and call the appropriate handlers according to that, or something like that.

It was worth doing this, since it will ease work a lot in the future. Before it was always kind of a headache trying to consolidate the `addChild()` method for both C and PHP ASTs, which use different children for different purposes. A prominent recent example is the `Identifier` child of a `Parameter`, which represents the parameter's name in C world and the parameter's type in PHP world. Another such example is a `FunctionDef`'s `Identifier` child, which represents the function's name in C world and the function's return type in PHP world. Consolidating the `addChild()` method for both worlds will now no longer be necessary. I can leave the `addChild()` method more or less untouched, as I do not need it any more. I am saying "more or less" because I do need the `addChild()` method of the super-class `ASTNode` that adds any child to a node's linked list of children, but this super-method is now always directly called from the appropriate handlers; in order to avoid double addition, the `addChild()` methods of the different classes extending `ASTNode` now only call the super-method `addChild()` if an appropriate handler method has not been called, since the handler method already called the super-method `addChild()`. Hence, for the C world everything remains as before, but it is now also possible to call the handler methods directly, and that is what the PHP edge interpreter is doing.

Putting the logic for distinguishing children in the `addChild()` methods might be good for C ASTs, what with the node visitor and tree walking and all that (I assume), but for PHP, where we read the data out of CSV files, it is not the right approach.