### PR TITLE
Support for AST_NAME_LIST, AST_WHILE, AST_DO_WHILE

### DIFF
--- a/src/ast/expressions/IdentifierList.java
+++ b/src/ast/expressions/IdentifierList.java
@@ -1,0 +1,31 @@
+package ast.expressions;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+
+public class IdentifierList extends ASTNode implements Iterable<Identifier>
+{
+	private LinkedList<Identifier> identifiers = new LinkedList<Identifier>();
+
+	public int size()
+	{
+		return this.identifiers.size();
+	}
+	
+	public Identifier getIdentifier(int i) {
+		return this.identifiers.get(i);
+	}
+
+	public void addIdentifier(Identifier identifier)
+	{
+		this.identifiers.add(identifier);
+		super.addChild(identifier);
+	}
+
+	@Override
+	public Iterator<Identifier> iterator() {
+		return this.identifiers.iterator();
+	}
+}

--- a/src/ast/logical/statements/BlockStarter.java
+++ b/src/ast/logical/statements/BlockStarter.java
@@ -4,27 +4,42 @@ import ast.ASTNode;
 
 public class BlockStarter extends Statement
 {
+	protected ASTNode condition = null;
 	protected Statement statement = null;
-	protected Condition condition = null;
 
+	public ASTNode getCondition()
+	{
+		return this.condition;
+	}
+
+	public void setCondition(ASTNode expression)
+	{
+		this.condition = expression;
+		super.addChild(expression);
+	}
+	
+	// for C, getStatement() and setStatement()
 	public Statement getStatement()
 	{
-		return statement;
+		return this.statement;
 	}
-
-	public Condition getCondition()
+	
+	public void setStatement(Statement statement)
 	{
-		return condition;
+		this.statement = statement;
+		super.addChild(statement);
 	}
-
-	protected void setStatement(Statement aStatement)
+	
+	// for PHP, getContent() and setContent()
+	public CompoundStatement getContent()
 	{
-		statement = aStatement;
+		return (CompoundStatement)this.statement;
 	}
-
-	protected void setCondition(Condition expression)
+	
+	public void setContent(CompoundStatement content)
 	{
-		condition = expression;
+		this.statement = content;
+		super.addChild(content);
 	}
 
 	@Override
@@ -34,7 +49,8 @@ public class BlockStarter extends Statement
 			setCondition((Condition) node);
 		else if (node instanceof Statement)
 			setStatement((Statement) node);
-		super.addChild(node);
+		else
+			super.addChild(node);
 	}
 
 }

--- a/src/ast/php/declarations/PHPClassDef.java
+++ b/src/ast/php/declarations/PHPClassDef.java
@@ -2,16 +2,17 @@ package ast.php.declarations;
 
 import ast.ASTNode;
 import ast.ASTNodeProperties;
-import ast.DummyIdentifierNode;
 import ast.declarations.ClassDefStatement;
 import ast.expressions.Identifier;
+import ast.expressions.IdentifierList;
 import ast.php.functionDef.TopLevelFunctionDef;
 
 public class PHPClassDef extends ClassDefStatement
 {
 
-	private Identifier parent = new DummyIdentifierNode();
-	private TopLevelFunctionDef toplevelfunc = new TopLevelFunctionDef();
+	private Identifier parent = null;
+	private IdentifierList interfaces = null;
+	private TopLevelFunctionDef toplevelfunc = null;
 
 	public String getName() {
 		return getProperty(ASTNodeProperties.NAME);
@@ -39,6 +40,18 @@ public class PHPClassDef extends ClassDefStatement
 		if( parent instanceof Identifier)
 			this.parent = (Identifier)parent;
 		super.addChild(parent);
+	}
+	
+	public IdentifierList getImplements()
+	{
+		return this.interfaces;
+	}
+	
+	public void setImplements(ASTNode interfaces)
+	{
+		if( interfaces instanceof IdentifierList)
+			this.interfaces = (IdentifierList)interfaces;
+		super.addChild(interfaces);
 	}
 	
 	public TopLevelFunctionDef getTopLevelFunc()

--- a/src/ast/statements/blockstarters/DoStatement.java
+++ b/src/ast/statements/blockstarters/DoStatement.java
@@ -5,6 +5,7 @@ import ast.walking.ASTNodeVisitor;
 
 public class DoStatement extends BlockStarter
 {
+	@Override
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/ast/statements/blockstarters/WhileStatement.java
+++ b/src/ast/statements/blockstarters/WhileStatement.java
@@ -5,6 +5,7 @@ import ast.walking.ASTNodeVisitor;
 
 public class WhileStatement extends BlockStarter
 {
+	@Override
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -25,6 +25,7 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.WhileStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
@@ -513,6 +514,95 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node4.getChildCount());
 		assertEquals( ast.getNodeById((long)19), ((WhileStatement)node4).getCondition());
 		assertEquals( ast.getNodeById((long)23), ((WhileStatement)node4).getContent());
+	}
+
+	/**
+	 * AST_DO_WHILE nodes are used to declare do-while loops.
+	 * 
+	 * Any AST_DO_WHILE node has exactly two children:
+	 * 1) AST_STMT_LIST, representing the statements executed in the loop's body
+	 * 2) various possible types, representing the expression in the loop's guard,
+	 *    also known as "condition" or "predicate"
+	 *    (e.g., could be AST_VAR, AST_CONST, AST_CALL, AST_BINARY_OP, etc...)
+	 * 
+	 * This test checks a few while loops' children in the following PHP code:
+	 * 
+	 * do {} while($foo);
+	 * do {} while(true);
+	 * do {} while(somecall());
+	 * do {} while($var === 1);
+	 */
+	@Test
+	public void testDoCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_DO_WHILE,,3,,0,1,,,\n";
+		nodeStr += "4,AST_STMT_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_VAR,,3,,1,1,,,\n";
+		nodeStr += "6,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "7,AST_DO_WHILE,,4,,1,1,,,\n";
+		nodeStr += "8,AST_STMT_LIST,,4,,0,1,,,\n";
+		nodeStr += "9,AST_CONST,,4,,1,1,,,\n";
+		nodeStr += "10,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "11,string,,4,\"true\",0,1,,,\n";
+		nodeStr += "12,AST_DO_WHILE,,5,,2,1,,,\n";
+		nodeStr += "13,AST_STMT_LIST,,5,,0,1,,,\n";
+		nodeStr += "14,AST_CALL,,5,,1,1,,,\n";
+		nodeStr += "15,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "16,string,,5,\"somecall\",0,1,,,\n";
+		nodeStr += "17,AST_ARG_LIST,,5,,1,1,,,\n";
+		nodeStr += "18,AST_DO_WHILE,,6,,3,1,,,\n";
+		nodeStr += "19,AST_STMT_LIST,,6,,0,1,,,\n";
+		nodeStr += "20,AST_BINARY_OP,BINARY_IS_IDENTICAL,6,,1,1,,,\n";
+		nodeStr += "21,AST_VAR,,6,,0,1,,,\n";
+		nodeStr += "22,string,,6,\"var\",0,1,,,\n";
+		nodeStr += "23,integer,,6,1,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "7,9,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "15,16,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "14,17,PARENT_OF\n";
+		edgeStr += "12,14,PARENT_OF\n";
+		edgeStr += "18,19,PARENT_OF\n";
+		edgeStr += "21,22,PARENT_OF\n";
+		edgeStr += "20,21,PARENT_OF\n";
+		edgeStr += "20,23,PARENT_OF\n";
+		edgeStr += "18,20,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)7);
+		ASTNode node3 = ast.getNodeById((long)12);
+		ASTNode node4 = ast.getNodeById((long)18);
+		
+		assertThat( node, instanceOf(DoStatement.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((DoStatement)node).getContent());
+		assertEquals( ast.getNodeById((long)5), ((DoStatement)node).getCondition());
+
+		assertThat( node2, instanceOf(DoStatement.class));
+		assertEquals( 2, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)8), ((DoStatement)node2).getContent());
+		assertEquals( ast.getNodeById((long)9), ((DoStatement)node2).getCondition());
+		
+		assertThat( node3, instanceOf(DoStatement.class));
+		assertEquals( 2, node3.getChildCount());
+		assertEquals( ast.getNodeById((long)13), ((DoStatement)node3).getContent());
+		assertEquals( ast.getNodeById((long)14), ((DoStatement)node3).getCondition());
+		
+		assertThat( node4, instanceOf(DoStatement.class));
+		assertEquals( 2, node4.getChildCount());
+		assertEquals( ast.getNodeById((long)19), ((DoStatement)node4).getContent());
+		assertEquals( ast.getNodeById((long)20), ((DoStatement)node4).getCondition());
 	}
 
 

--- a/src/tests/parseTreeToAST/CodeNestingTest.java
+++ b/src/tests/parseTreeToAST/CodeNestingTest.java
@@ -11,6 +11,7 @@ import ast.expressions.Argument;
 import ast.expressions.ArgumentList;
 import ast.expressions.AssignmentExpr;
 import ast.expressions.CallExpression;
+import ast.logical.statements.Condition;
 import ast.logical.statements.BlockStarter;
 import ast.logical.statements.CompoundStatement;
 import ast.statements.ExpressionStatement;
@@ -57,7 +58,7 @@ public class CodeNestingTest
 		CompoundStatement item = (CompoundStatement) FunctionContentTestUtil
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) item.getStatements().get(0);
-		AssignmentExpr condition = (AssignmentExpr) starter.getCondition()
+		AssignmentExpr condition = (AssignmentExpr) ((Condition)starter.getCondition())
 				.getExpression();
 		System.out.println(condition.getEscapedCodeStr());
 		assertTrue(condition.getEscapedCodeStr().equals("foo = bar"));
@@ -91,7 +92,7 @@ public class CodeNestingTest
 		ForStatement forItem = (ForStatement) contentItem.getStatements()
 				.get(0);
 
-		String condExprString = forItem.getCondition().getExpression()
+		String condExprString = ((Condition)forItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		System.out.println(condExprString);
 		assertTrue(condExprString.equals("i < 10"));
@@ -109,7 +110,7 @@ public class CodeNestingTest
 
 		System.out.println(forItem.getChildCount());
 
-		String condExprString = forItem.getCondition().getExpression()
+		String condExprString = ((Condition)forItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		assertTrue(condExprString.equals("i < 10"));
 

--- a/src/tests/parseTreeToAST/DoWhileTests.java
+++ b/src/tests/parseTreeToAST/DoWhileTests.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import ast.logical.statements.CompoundStatement;
+import ast.logical.statements.Condition;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.IfStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -20,7 +21,7 @@ public class DoWhileTests
 				.parseAndWalk(input);
 		DoStatement doItem = (DoStatement) contentItem.getStatements().get(0);
 
-		String condExprString = doItem.getCondition().getExpression()
+		String condExprString = ((Condition)doItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		assertTrue(condExprString.equals("bar"));
 
@@ -39,7 +40,7 @@ public class DoWhileTests
 		WhileStatement whileStatement = (WhileStatement) doCompound.getChild(0);
 		assertTrue(whileStatement.getCondition() != null);
 
-		String condExprString = doItem.getCondition().getExpression()
+		String condExprString = ((Condition)doItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		assertTrue(condExprString.equals("bar"));
 
@@ -53,7 +54,7 @@ public class DoWhileTests
 				.parseAndWalk(input);
 		DoStatement doItem = (DoStatement) contentItem.getStatements().get(0);
 
-		String condExprString = doItem.getCondition().getExpression()
+		String condExprString = ((Condition)doItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		assertTrue(condExprString.equals("bar"));
 	}
@@ -69,7 +70,7 @@ public class DoWhileTests
 				.get(0);
 		DoStatement doItem = (DoStatement) ifStatement.getStatement();
 
-		String condExprString = doItem.getCondition().getExpression()
+		String condExprString = ((Condition)doItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		assertTrue(condExprString.equals("bar"));
 	}
@@ -82,7 +83,7 @@ public class DoWhileTests
 				.parseAndWalk(input);
 		DoStatement doItem = (DoStatement) contentItem.getStatements().get(0);
 
-		String condExprString = doItem.getCondition().getExpression()
+		String condExprString = ((Condition)doItem.getCondition()).getExpression()
 				.getEscapedCodeStr();
 		assertTrue(condExprString.equals("bar"));
 	}

--- a/src/tests/parseTreeToAST/ExpressionParsingTest.java
+++ b/src/tests/parseTreeToAST/ExpressionParsingTest.java
@@ -21,6 +21,7 @@ import ast.expressions.RelationalExpression;
 import ast.expressions.ShiftExpression;
 import ast.logical.statements.BlockStarter;
 import ast.logical.statements.CompoundStatement;
+import ast.logical.statements.Condition;
 import ast.statements.ExpressionStatement;
 import ast.statements.IdentifierDeclStatement;
 
@@ -138,7 +139,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		BitAndExpression expr = (BitAndExpression) starter.getCondition()
+		BitAndExpression expr = (BitAndExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 	}
@@ -151,7 +152,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		EqualityExpression expr = (EqualityExpression) starter.getCondition()
+		EqualityExpression expr = (EqualityExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 	}
@@ -164,8 +165,8 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		RelationalExpression expr = (RelationalExpression) starter
-				.getCondition().getExpression();
+		RelationalExpression expr = (RelationalExpression) ((Condition)starter
+				.getCondition()).getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 	}
 
@@ -177,7 +178,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		ShiftExpression expr = (ShiftExpression) starter.getCondition()
+		ShiftExpression expr = (ShiftExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 	}
@@ -190,7 +191,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		AdditiveExpression expr = (AdditiveExpression) starter.getCondition()
+		AdditiveExpression expr = (AdditiveExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 	}
@@ -203,8 +204,8 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		MultiplicativeExpression expr = (MultiplicativeExpression) starter
-				.getCondition().getExpression();
+		MultiplicativeExpression expr = (MultiplicativeExpression) ((Condition)starter
+				.getCondition()).getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 	}
 
@@ -216,7 +217,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		CastExpression expr = (CastExpression) starter.getCondition()
+		CastExpression expr = (CastExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		assertTrue(
 				expr.getCastTarget().getEscapedCodeStr().equals("some_type"));
@@ -230,7 +231,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) contentItem.getStatements()
 				.get(0);
-		CallExpression expr = (CallExpression) starter.getCondition()
+		CallExpression expr = (CallExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		assertTrue(expr.getTarget().getEscapedCodeStr().equals("foo"));
 	}

--- a/src/tests/parseTreeToAST/IfNestingTests.java
+++ b/src/tests/parseTreeToAST/IfNestingTests.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import ast.expressions.Expression;
 import ast.logical.statements.BlockStarter;
 import ast.logical.statements.CompoundStatement;
+import ast.logical.statements.Condition;
 import ast.statements.blockstarters.ElseStatement;
 import ast.statements.blockstarters.IfStatement;
 
@@ -51,7 +52,7 @@ public class IfNestingTests
 		CompoundStatement item = (CompoundStatement) FunctionContentTestUtil
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) item.getStatements().get(0);
-		Expression condition = starter.getCondition().getExpression();
+		Expression condition = ((Condition)starter.getCondition()).getExpression();
 		assertTrue(condition.getEscapedCodeStr().equals("foo"));
 	}
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -13,6 +13,7 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.WhileStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
@@ -70,6 +71,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// nodes with exactly 2 children
 			case PHPCSVNodeTypes.TYPE_WHILE:
 				errno = handleWhile((WhileStatement)startNode, endNode, childnum);
+				break;
+				
+			case PHPCSVNodeTypes.TYPE_DO_WHILE:
+				errno = handleDo((DoStatement)startNode, endNode, childnum);
 				break;
 
 			// nodes with exactly 3 children
@@ -286,6 +291,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // stmts child
 				startNode.setContent((CompoundStatement)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleDo( DoStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // stmts child
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+			case 1: // cond child
+				startNode.setCondition(endNode);
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BlockStarter.condition to be an Expression instead
+				// of a generic ASTNode, and getCondition() and setCondition() accordingly
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -2,6 +2,7 @@ package tools.phpast2cfg;
 
 import ast.ASTNode;
 import ast.expressions.Identifier;
+import ast.expressions.IdentifierList;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
@@ -78,6 +79,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLOSURE_USES:
 				errno = handleClosureUses((ClosureUses)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_NAME_LIST:
+				errno = handleIdentifierList((IdentifierList)startNode, endNode, childnum);
 				break;
 				
 			default:
@@ -244,8 +248,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // extends child: either Identifier or NULL node
 				startNode.setExtends(endNode);
 				break;
-			case 1: // implements child
-				startNode.addChild(endNode); // TODO introduce IdentifierList and setImplements
+			case 1: // implements child: either IdentifierList or NULL node
+				startNode.setImplements(endNode);
 				break;
 			case 2: // toplevel child
 				startNode.setTopLevelFunc((TopLevelFunctionDef)endNode);
@@ -304,6 +308,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleClosureUses( ClosureUses startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addClosureVar((ClosureVar)endNode);
+
+		return 0;
+	}
+	
+	private int handleIdentifierList( IdentifierList startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addIdentifier((Identifier)endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -7,6 +7,7 @@ import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
 import ast.expressions.Identifier;
+import ast.expressions.IdentifierList;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
@@ -88,6 +89,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLOSURE_USES:
 				retval = handleClosureUses(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_NAME_LIST:
+				retval = handleIdentifierList(row, ast);
 				break;
 
 			default:
@@ -486,6 +490,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleClosureUses(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ClosureUses newNode = new ClosureUses();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleIdentifierList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		IdentifierList newNode = new IdentifierList();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -59,6 +59,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_IF = "AST_IF";
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
 	public static final String TYPE_CLOSURE_USES = "AST_CLOSURE_USES";
+	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";
 
 	/* node flags */
 	// flags for toplevel nodes


### PR DESCRIPTION
As usual, a few notes.

*Concerning `AST_NAME_LIST` (= `IdentifierList`)*

1. I put the new class `IdentifierList` in the `ast.expressions` package (instead of the `ast.php.expressions` package) because I felt that the concept is general enough to be useful for other langages as well. For instance, if we want to implement support for Java sometime, then `IdentifierList`'s might be equally useful for storing a list of interfaces implemented by a class (as is the case for PHP).

    However, do feel free to move it to `ast.php.expressions` if you prefer. :smiley:

*Concerning `AST_WHILE` (= `WhileStatement`) and `AST_DO_WHILE` (= `DoStatement`)*

2. I had to change the type of the field `BlockStarter.condition` from `Condition` to a generic `ASTNode` for now (and adapt `getCondition()` and `setCondition()` accordingly).
This is because there are so many PHP AST node types that can occur in a while loop's guard that are not (yet) mapped for now that we cannot at the moment cast these nodes to `Condition`, lest we get `ClassCastException`'s.

    This implies that I had to change some C test cases in `tests.parseTreeToAST.*` to downcast the `ASTNode` returned by `getCondition()` to a `Condition`, similarly as I had to do earlier for `Parameter` whose `getType()` method I had to change to return an `ASTNode` instead of a `ParameterType`.

    In time (once all the mapping is finished), we should be able to make the `getCondition()` and `setCondition()` methods more "precise" again. I'm not sure whether we will want them to return `Condition`'s again or rather `Expression`'s; but we will see about that then, one step at a time. :smiley:

3. Conversely, I introduced `getContent()` and `setContent()` methods in `ast.statements.blockstarters.BlockStarter` that do pretty much the same thing as `getStatement()` and `setStatement()`, but are *more* precise than `getStatement()` and `setStatement()` in that they take, resp. return a `CompoundStatement` (which extends `Statement`) instead of `Statement`. Indeed, for PHP ASTs, we know that the second child of an `AST_WHILE` (resp. first child of an `AST_DO_WHILE`) node is always going to be an `AST_STMT_LIST`. Even when there is only a single statement in a loop's body, there will be an `AST_STMT_LIST` which has a single statement child.

    Here's a question concerning this last point: What about C? Can we not be sure that we will always have a `CompoundStatement` instead of only the more general `Statement`? If it is also always a `CompoundStatement`, we could just as well make the field `BlockStarter.statement` a `CompoundStatement` (and perhaps rename it to `content` for consistency.)

Considering the last two points, it might make sense to, once again, have two classes `PHPWhileStatement` and `PHPDoStatement` that extend the respective base classes instead of using the base class directly. What do you think?
