### PR TITLE
Minimalistic tests, support for expression lists and for loops

### DIFF
--- a/src/ast/expressions/ExpressionList.java
+++ b/src/ast/expressions/ExpressionList.java
@@ -1,0 +1,34 @@
+package ast.expressions;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+
+public class ExpressionList extends ASTNode implements Iterable<ASTNode>
+{
+	private LinkedList<ASTNode> expressions = new LinkedList<ASTNode>();
+	// TODO eventually, of course, this has to be a LinkedList<Expression>
+	// However, until we have completed the PHP AST -> Joern mapping, we must
+	// use ASTNode or we will get ClassCastException's
+
+	public int size()
+	{
+		return this.expressions.size();
+	}
+	
+	public ASTNode getExpression(int i) {
+		return this.expressions.get(i);
+	}
+
+	public void addExpression(ASTNode expression)
+	{
+		this.expressions.add(expression);
+		super.addChild(expression);
+	}
+
+	@Override
+	public Iterator<ASTNode> iterator() {
+		return this.expressions.iterator();
+	}
+}

--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -5,7 +5,7 @@ import ast.walking.ASTNodeVisitor;
 
 public class Identifier extends Expression
 {
-	private ASTNode name = new ASTNode();
+	private ASTNode name = null;
 	
 	public Identifier()
 	{

--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -2,7 +2,6 @@ package ast.functionDef;
 
 import ast.ASTNode;
 import ast.ASTNodeProperties;
-import ast.DummyIdentifierNode;
 import ast.expressions.Identifier;
 import ast.logical.statements.CompoundStatement;
 import ast.walking.ASTNodeVisitor;
@@ -10,10 +9,10 @@ import ast.walking.ASTNodeVisitor;
 public class FunctionDef extends ASTNode
 {
 
-	private Identifier identifier = new DummyIdentifierNode();
-	private ParameterList parameterList = new ParameterList();
-	private CompoundStatement content = new CompoundStatement();
-	private Identifier returnType = null;
+	protected Identifier identifier = null;
+	protected ParameterList parameterList = null;
+	protected CompoundStatement content = null;
+	protected Identifier returnType = null;
 
 	public void addChild(ASTNode node)
 	{

--- a/src/ast/logical/statements/BlockStarter.java
+++ b/src/ast/logical/statements/BlockStarter.java
@@ -4,7 +4,7 @@ import ast.ASTNode;
 
 public class BlockStarter extends Statement
 {
-	protected ASTNode condition = null;
+	protected ASTNode condition = null; // TODO change type back to Expression (or Condition)
 	protected Statement statement = null;
 
 	public ASTNode getCondition()
@@ -18,7 +18,6 @@ public class BlockStarter extends Statement
 		super.addChild(expression);
 	}
 	
-	// for C, getStatement() and setStatement()
 	public Statement getStatement()
 	{
 		return this.statement;
@@ -28,18 +27,6 @@ public class BlockStarter extends Statement
 	{
 		this.statement = statement;
 		super.addChild(statement);
-	}
-	
-	// for PHP, getContent() and setContent()
-	public CompoundStatement getContent()
-	{
-		return (CompoundStatement)this.statement;
-	}
-	
-	public void setContent(CompoundStatement content)
-	{
-		this.statement = content;
-		super.addChild(content);
 	}
 
 	@Override

--- a/src/ast/php/functionDef/ClosureVar.java
+++ b/src/ast/php/functionDef/ClosureVar.java
@@ -4,7 +4,7 @@ import ast.ASTNode;
 
 public class ClosureVar extends ASTNode
 {
-	private ASTNode name = new ASTNode();
+	private ASTNode name = null;
 	
 	public void setNameChild(ASTNode name) {
 		this.name = name;

--- a/src/ast/php/functionDef/Method.java
+++ b/src/ast/php/functionDef/Method.java
@@ -1,7 +1,15 @@
 package ast.php.functionDef;
 
+import ast.ASTNode;
 import ast.functionDef.FunctionDef;
+import ast.logical.statements.CompoundStatement;
 
 public class Method extends FunctionDef
 {
+	public void setContent(ASTNode content)
+	{
+		if( content instanceof CompoundStatement)
+			this.content = (CompoundStatement)content;
+		super.addChild(content);
+	}
 }

--- a/src/ast/statements/blockstarters/ForStatement.java
+++ b/src/ast/statements/blockstarters/ForStatement.java
@@ -10,27 +10,29 @@ import ast.walking.ASTNodeVisitor;
 
 public class ForStatement extends BlockStarter
 {
-	private ASTNode forInitStatement = null;
-	private ASTNode expression = null;
+	private ASTNode forInitExpression = null; // TODO make this an ExpressionList sometime (might need to create a PHPForStatement)
+	private ASTNode forLoopExpression = null; // TODO make this an ExpressionList sometime (might need to create a PHPForStatement)
 
-	public ASTNode getForInitStatement()
+	public ASTNode getForInitExpression()
 	{
-		return forInitStatement;
+		return forInitExpression;
 	}
 
-	private void setForInitStatement(ASTNode forInitStatement)
+	public void setForInitExpression(ASTNode expression)
 	{
-		this.forInitStatement = forInitStatement;
+		this.forInitExpression = expression;
+		super.addChild(expression);
 	}
 
-	public ASTNode getExpression()
+	public ASTNode getForLoopExpression()
 	{
-		return expression;
+		return forLoopExpression;
 	}
 
-	private void setExpression(ASTNode expression)
+	public void setForLoopExpression(ASTNode expression)
 	{
-		this.expression = expression;
+		this.forLoopExpression = expression;
+		super.addChild(expression);
 	}
 
 	@Override
@@ -39,14 +41,16 @@ public class ForStatement extends BlockStarter
 		if (node instanceof Condition)
 			setCondition((Condition) node);
 		else if (node instanceof ForInit)
-			setForInitStatement(node);
+			setForInitExpression(node);
 		else if (node instanceof Expression)
-			setExpression(node);
+			setForLoopExpression(node);
 		else if (node instanceof Statement)
 			setStatement((Statement) node);
-		super.addChild(node);
+		else
+			super.addChild(node);
 	}
 
+	@Override
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/languages/c/cfg/CCFGFactory.java
+++ b/src/languages/c/cfg/CCFGFactory.java
@@ -179,9 +179,9 @@ public class CCFGFactory extends CFGFactory
 		{
 			CCFG forBlock = new CCFG();
 
-			ASTNode initialization = forStatement.getForInitStatement();
+			ASTNode initialization = forStatement.getForInitExpression();
 			ASTNode condition = forStatement.getCondition();
-			ASTNode expression = forStatement.getExpression();
+			ASTNode expression = forStatement.getForLoopExpression();
 
 			CFG forBody = convert(forStatement.getStatement());
 			CFGNode conditionContainer;

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -330,7 +330,7 @@ public class TestPHPCSVASTBuilder
 	 * Any AST_METHOD node has exactly four children:
 	 * 1) AST_PARAM_LIST
 	 * 2) NULL, for structural compatibility with AST_CLOSURE
-	 * 3) AST_STMT_LIST
+	 * 3) AST_STMT_LIST or NULL (possible for abstract methods)
 	 * 4) AST_NAME or NULL, indicating the return type
 	 * 
 	 * This test checks a method's name and children in the following PHP code:
@@ -434,7 +434,8 @@ public class TestPHPCSVASTBuilder
 	 * 1) various possible types, representing the expression in the loop's guard,
 	 *    also known as "condition" or "predicate"
 	 *    (e.g., could be AST_VAR, AST_CONST, AST_CALL, AST_BINARY_OP, etc...)
-	 * 2) AST_STMT_LIST, representing the statements executed in the loop's body
+	 * 2) statement types or NULL, representing the code in the loop's body
+	 *    (e.g., could be AST_STMT_LIST, AST_CALL, etc...)
 	 * 
 	 * This test checks a few while loops' children in the following PHP code:
 	 * 
@@ -498,29 +499,30 @@ public class TestPHPCSVASTBuilder
 		assertThat( node, instanceOf(WhileStatement.class));
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)4), ((WhileStatement)node).getCondition());
-		assertEquals( ast.getNodeById((long)6), ((WhileStatement)node).getContent());
+		assertEquals( ast.getNodeById((long)6), ((WhileStatement)node).getStatement());
 
 		assertThat( node2, instanceOf(WhileStatement.class));
 		assertEquals( 2, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)8), ((WhileStatement)node2).getCondition());
-		assertEquals( ast.getNodeById((long)11), ((WhileStatement)node2).getContent());
+		assertEquals( ast.getNodeById((long)11), ((WhileStatement)node2).getStatement());
 		
 		assertThat( node3, instanceOf(WhileStatement.class));
 		assertEquals( 2, node3.getChildCount());
 		assertEquals( ast.getNodeById((long)13), ((WhileStatement)node3).getCondition());
-		assertEquals( ast.getNodeById((long)17), ((WhileStatement)node3).getContent());
+		assertEquals( ast.getNodeById((long)17), ((WhileStatement)node3).getStatement());
 		
 		assertThat( node4, instanceOf(WhileStatement.class));
 		assertEquals( 2, node4.getChildCount());
 		assertEquals( ast.getNodeById((long)19), ((WhileStatement)node4).getCondition());
-		assertEquals( ast.getNodeById((long)23), ((WhileStatement)node4).getContent());
+		assertEquals( ast.getNodeById((long)23), ((WhileStatement)node4).getStatement());
 	}
 
 	/**
 	 * AST_DO_WHILE nodes are used to declare do-while loops.
 	 * 
 	 * Any AST_DO_WHILE node has exactly two children:
-	 * 1) AST_STMT_LIST, representing the statements executed in the loop's body
+	 * 1) statement types or NULL, representing the code in the loop's body
+	 *    (e.g., could be AST_STMT_LIST, AST_CALL, etc...)
 	 * 2) various possible types, representing the expression in the loop's guard,
 	 *    also known as "condition" or "predicate"
 	 *    (e.g., could be AST_VAR, AST_CONST, AST_CALL, AST_BINARY_OP, etc...)
@@ -586,22 +588,22 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node, instanceOf(DoStatement.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( ast.getNodeById((long)4), ((DoStatement)node).getContent());
+		assertEquals( ast.getNodeById((long)4), ((DoStatement)node).getStatement());
 		assertEquals( ast.getNodeById((long)5), ((DoStatement)node).getCondition());
 
 		assertThat( node2, instanceOf(DoStatement.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)8), ((DoStatement)node2).getContent());
+		assertEquals( ast.getNodeById((long)8), ((DoStatement)node2).getStatement());
 		assertEquals( ast.getNodeById((long)9), ((DoStatement)node2).getCondition());
 		
 		assertThat( node3, instanceOf(DoStatement.class));
 		assertEquals( 2, node3.getChildCount());
-		assertEquals( ast.getNodeById((long)13), ((DoStatement)node3).getContent());
+		assertEquals( ast.getNodeById((long)13), ((DoStatement)node3).getStatement());
 		assertEquals( ast.getNodeById((long)14), ((DoStatement)node3).getCondition());
 		
 		assertThat( node4, instanceOf(DoStatement.class));
 		assertEquals( 2, node4.getChildCount());
-		assertEquals( ast.getNodeById((long)19), ((DoStatement)node4).getContent());
+		assertEquals( ast.getNodeById((long)19), ((DoStatement)node4).getStatement());
 		assertEquals( ast.getNodeById((long)20), ((DoStatement)node4).getCondition());
 	}
 
@@ -791,8 +793,10 @@ public class TestPHPCSVASTBuilder
 	 * AST_CLOSURE_USES nodes are used for holding a list of variables that
 	 * occur within the 'use' language construct of closure declarations.
 	 * 
-	 * Any AST_CLOSURE_USES node has between 0 and an arbitrarily large number
+	 * Any AST_CLOSURE_USES node has between 1 and an arbitrarily large number
 	 * of children. Each child corresponds to one closure variable in the list.
+	 * (It cannot have 0 children as the 'use' construct can only be used in
+	 * conjunction with at least 1 variable name.)
 	 * 
 	 * This test checks a closure 'uses' list's children in the following PHP code:
 	 * 
@@ -838,8 +842,11 @@ public class TestPHPCSVASTBuilder
 	 * AST_NAME_LIST nodes are used for holding a list of identifiers, e.g.,
 	 * a list of names referring to interfaces that a class extends.
 	 * 
-	 * Any AST_NAME_LIST node has between 0 and an arbitrarily large number
+	 * Any AST_NAME_LIST node has between 1 and an arbitrarily large number
 	 * of children. Each child corresponds to one identifier in the list.
+	 * TODO I am not sure at the moment whether there are situations where
+	 * an AST_NAME_LIST with 0 children can be generated; I do not think so,
+	 * but look into it more closely.
 	 * 
 	 * This test checks an identifier list's children in the following PHP code:
 	 * 

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -27,6 +27,7 @@ import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.statements.blockstarters.DoStatement;
+import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
@@ -676,6 +677,90 @@ public class TestPHPCSVASTBuilder
 		assertEquals( "buz", ((PHPParameter)node2).getNameChild().getEscapedCodeStr());
 		assertEquals( ast.getNodeById((long)14), ((PHPParameter)node2).getDefault());
 		assertEquals( "yabadabadoo", ((PHPParameter)node2).getDefault().getEscapedCodeStr());
+	}
+
+	
+	/* nodes with exactly 4 children */
+
+	/**
+	 * AST_FOR nodes are used to declare for-loops.
+	 * 
+	 * Any AST_FOR node has exactly four children:
+	 * 1) AST_EXPR_LIST or NULL, representing the list of expressions
+	 *    used to initialize the loop
+	 * 2) AST_EXPR_LIST or NULL, representing the list of expressions
+	 *    in the loop's guard, used to check whether to continue iterating
+	 * 3) AST_EXPR_LIST or NULL, representing the list of expressions
+	 *    used to increment or otherwise modify variables in each step
+	 * 4) statement types or NULL, representing the code in the loop's body
+	 *    (e.g., could be AST_STMT_LIST, AST_CALL, etc...)
+	 * 
+	 * This test checks a for loop's children in the following PHP code:
+	 * 
+	 * for ($i = 0, $j = 1; $i < 3; $i++, $j++) {}
+	 */
+	@Test
+	public void testForCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FOR,,3,,0,1,,,\n";
+		nodeStr += "4,AST_EXPR_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_ASSIGN,,3,,0,1,,,\n";
+		nodeStr += "6,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "7,string,,3,\"i\",0,1,,,\n";
+		nodeStr += "8,integer,,3,0,1,1,,,\n";
+		nodeStr += "9,AST_ASSIGN,,3,,1,1,,,\n";
+		nodeStr += "10,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "11,string,,3,\"j\",0,1,,,\n";
+		nodeStr += "12,integer,,3,1,1,1,,,\n";
+		nodeStr += "13,AST_EXPR_LIST,,3,,1,1,,,\n";
+		nodeStr += "14,AST_BINARY_OP,BINARY_IS_SMALLER,3,,0,1,,,\n";
+		nodeStr += "15,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "16,string,,3,\"i\",0,1,,,\n";
+		nodeStr += "17,integer,,3,3,1,1,,,\n";
+		nodeStr += "18,AST_EXPR_LIST,,3,,2,1,,,\n";
+		nodeStr += "19,AST_POST_INC,,3,,0,1,,,\n";
+		nodeStr += "20,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "21,string,,3,\"i\",0,1,,,\n";
+		nodeStr += "22,AST_POST_INC,,3,,1,1,,,\n";
+		nodeStr += "23,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "24,string,,3,\"j\",0,1,,,\n";
+		nodeStr += "25,AST_STMT_LIST,,3,,3,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "5,8,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "9,12,PARENT_OF\n";
+		edgeStr += "4,9,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "15,16,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "14,17,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "3,13,PARENT_OF\n";
+		edgeStr += "20,21,PARENT_OF\n";
+		edgeStr += "19,20,PARENT_OF\n";
+		edgeStr += "18,19,PARENT_OF\n";
+		edgeStr += "23,24,PARENT_OF\n";
+		edgeStr += "22,23,PARENT_OF\n";
+		edgeStr += "18,22,PARENT_OF\n";
+		edgeStr += "3,18,PARENT_OF\n";
+		edgeStr += "3,25,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+
+		assertThat( node, instanceOf(ForStatement.class));
+		assertEquals( 4, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((ForStatement)node).getForInitExpression());
+		assertEquals( ast.getNodeById((long)13), ((ForStatement)node).getCondition());
+		assertEquals( ast.getNodeById((long)18), ((ForStatement)node).getForLoopExpression());
+		assertEquals( ast.getNodeById((long)25), ((ForStatement)node).getStatement());
 	}
 	
 	

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -1,0 +1,370 @@
+package tests.inputModules;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ast.ASTNode;
+import ast.functionDef.FunctionDef;
+import ast.functionDef.ParameterList;
+import ast.logical.statements.CompoundStatement;
+import ast.php.declarations.PHPClassDef;
+import ast.php.functionDef.Closure;
+import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPParameter;
+import ast.statements.blockstarters.DoStatement;
+import ast.statements.blockstarters.WhileStatement;
+import inputModules.csv.KeyedCSV.KeyedCSVReader;
+import inputModules.csv.KeyedCSV.KeyedCSVRow;
+import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
+import inputModules.csv.csv2ast.ASTUnderConstruction;
+import tools.phpast2cfg.PHPCSVEdgeInterpreter;
+import tools.phpast2cfg.PHPCSVNodeInterpreter;
+
+/**
+ * This class implements some tests similar to those in TestPHPCSVASTBuilder,
+ * but re-implements those tests in a "minimal" way in that these tests try
+ * to parse PHP code that generates as few child nodes as possible: e.g.,
+ * classes that do not extend another class or implement any interfaces,
+ * functions that do not take parameters or return anything, methods that
+ * are abstract and unimplemented, etc. (whereas tests in TestPHPCSVASTBuilder
+ * do the exact opposite and aim to generate every possible child for testing.)
+ */
+public class TestPHPCSVASTBuilderMinimal
+{
+	PHPCSVNodeInterpreter nodeInterpreter = new PHPCSVNodeInterpreter();
+	PHPCSVEdgeInterpreter edgeInterpreter = new PHPCSVEdgeInterpreter();
+	
+	ASTUnderConstruction ast;
+	KeyedCSVReader nodeReader;
+	KeyedCSVReader edgeReader;
+	
+	// See {@link http://neo4j.com/docs/stable/import-tool-header-format.html} for detailed
+	// information about the header file format
+	String nodeHeader = "id:ID,type,flags:string[],lineno:int,code,childnum:int,funcid:int,endlineno:int,name,doccomment\n";
+	String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
+
+	@Before
+	public void init()
+	{
+		ast = new ASTUnderConstruction();	
+		nodeReader = new KeyedCSVReader();
+		edgeReader = new KeyedCSVReader();
+	}
+	
+	private void handle(String nodeStr, String edgeStr)
+			throws IOException, InvalidCSVFile
+	{
+		nodeReader.init(new StringReader(nodeStr));
+		edgeReader.init(new StringReader(edgeStr));
+		
+		KeyedCSVRow keyedRow;
+		while ((keyedRow = nodeReader.getNextRow()) != null)
+			nodeInterpreter.handle(keyedRow, ast);
+		while ((keyedRow = edgeReader.getNextRow()) != null)
+			edgeInterpreter.handle(keyedRow, ast);
+	}
+
+
+	/* declaration nodes */	
+
+	/**
+	 * function foo() {}
+	 */
+	@Test
+	public void testMinimalFunctionDefCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,3,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "3,7,PARENT_OF\n";
+		
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(FunctionDef.class));
+		assertEquals( 4, node.getChildCount());
+		assertNull( ((FunctionDef)node).getReturnType());
+	}
+
+	/**
+	 * function() {};
+	 */
+	@Test
+	public void testMinimalClosureCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CLOSURE,,3,,0,1,3,{closure},\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,NULL,,3,,3,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "3,7,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(Closure.class));
+		assertEquals( 4, node.getChildCount());
+		assertNull( ((Closure)node).getClosureUses());
+		assertNull( ((Closure)node).getReturnType());
+	}
+
+	/**
+	 * abstract class bar {
+	 *   function foo();
+	 * }
+	 */
+	@Test
+	public void testMinimalMethodCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "8,AST_METHOD,MODIFIER_PUBLIC,4,,0,6,4,foo,\n";
+		nodeStr += "9,AST_PARAM_LIST,,4,,0,8,,,\n";
+		nodeStr += "10,NULL,,4,,1,8,,,\n";
+		nodeStr += "11,NULL,,4,,2,8,,,\n";
+		nodeStr += "12,NULL,,4,,3,8,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "8,10,PARENT_OF\n";
+		edgeStr += "8,11,PARENT_OF\n";
+		edgeStr += "8,12,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)8);
+		
+		assertThat( node, instanceOf(Method.class));
+		assertEquals( 4, node.getChildCount());
+		assertNull( ((Method)node).getContent());
+		assertNull( ((Method)node).getReturnType());
+	}
+	
+	/**
+	 * class foo {}
+	 */
+	@Test
+	public void testMinimalClassCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		
+		nodeStr += "3,AST_CLASS,,3,,0,1,3,foo,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "5,NULL,,3,,1,1,,,\n";
+		nodeStr += "6,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,1,3,\"foo\",\n";
+		nodeStr += "7,AST_STMT_LIST,,3,,0,6,,,\n";
+		
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PHPClassDef.class));
+		assertEquals( 3, node.getChildCount());
+		assertNull( ((PHPClassDef)node).getExtends());
+		assertNull( ((PHPClassDef)node).getImplements());
+	}
+	
+	
+	/* nodes with exactly 2 children */
+	
+	/**
+	 * while($foo);
+	 * while($foo) bar();
+	 */
+	@Test
+	public void testMinimalWhileCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_WHILE,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "6,NULL,,3,,1,1,,,\n";
+		nodeStr += "7,AST_WHILE,,4,,1,1,,,\n";
+		nodeStr += "8,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "9,string,,4,\"foo\",0,1,,,\n";
+		nodeStr += "10,AST_CALL,,4,,1,1,,,\n";
+		nodeStr += "11,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "12,string,,4,\"bar\",0,1,,,\n";
+		nodeStr += "13,AST_ARG_LIST,,4,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "10,13,PARENT_OF\n";
+		edgeStr += "7,10,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)7);
+
+		assertThat( node, instanceOf(WhileStatement.class));
+		assertEquals( 2, node.getChildCount());
+		assertNull( ((WhileStatement)node).getStatement());
+
+		assertThat( node2, instanceOf(WhileStatement.class));
+		assertEquals( 2, node2.getChildCount());
+		assertThat( ((WhileStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
+	}
+
+	/**
+	 * do ; while($foo);
+	 * do bar(); while($foo);
+	 */
+	@Test
+	public void testMinimalDoCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_DO_WHILE,,3,,0,1,,,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "5,AST_VAR,,3,,1,1,,,\n";
+		nodeStr += "6,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "7,AST_DO_WHILE,,4,,1,1,,,\n";
+		nodeStr += "8,AST_CALL,,4,,0,1,,,\n";
+		nodeStr += "9,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "10,string,,4,\"bar\",0,1,,,\n";
+		nodeStr += "11,AST_ARG_LIST,,4,,1,1,,,\n";
+		nodeStr += "12,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "13,string,,4,\"foo\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "8,11,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "7,12,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)7);
+		
+		assertThat( node, instanceOf(DoStatement.class));
+		assertEquals( 2, node.getChildCount());
+		assertNull( ((DoStatement)node).getStatement());
+
+		assertThat( node2, instanceOf(DoStatement.class));
+		assertEquals( 2, node2.getChildCount());
+		assertThat( ((DoStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
+	}
+
+
+	/* nodes with exactly 3 children */
+	
+	/**
+	 * function foo($bar) {}
+	 */
+	@Test
+	public void testMinimalParameterCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,AST_PARAM,,3,,0,3,,,\n";
+		nodeStr += "6,NULL,,3,,0,3,,,\n";
+		nodeStr += "7,string,,3,\"bar\",1,3,,,\n";
+		nodeStr += "8,NULL,,3,,2,3,,,\n";
+		nodeStr += "9,NULL,,3,,1,3,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "11,NULL,,3,,3,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "5,7,PARENT_OF\n";
+		edgeStr += "5,8,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)5);
+		
+		assertThat( node, instanceOf(PHPParameter.class));
+		assertEquals( 3, node.getChildCount());
+		assertNull( ((PHPParameter)node).getType());
+		// Note that ((PHPParameter)node).getDefault() is always non-null,
+		// even when there is no default type. Technically, this is because
+		// we allow arbitrary node types to designate the default value anyway,
+		// including the null node (more generally, all plain nodes are fine)
+		assertEquals( "NULL", ((PHPParameter)node).getDefault().getProperty("type"));
+	}
+	
+	
+	/* nodes with an arbitrary number of children */
+
+	/**
+	 * <empty file>
+	 */
+	@Test
+	public void testMinimalCompoundStatementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;	
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)2);
+		
+		assertThat( node, instanceOf(CompoundStatement.class));
+		assertEquals( 0, node.getChildCount());
+		assertEquals( 0, ((CompoundStatement)node).getStatements().size());
+	}
+	
+	/**
+	 * function foo() {}
+	 */
+	@Test
+	public void testMinimalParameterListCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+
+		String edgeStr = edgeHeader;
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)4);
+		
+		assertThat( node, instanceOf(ParameterList.class));
+		assertEquals( 0, node.getChildCount());
+	}
+}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -21,6 +21,7 @@ import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.statements.blockstarters.DoStatement;
+import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
@@ -324,6 +325,44 @@ public class TestPHPCSVASTBuilderMinimal
 		// we allow arbitrary node types to designate the default value anyway,
 		// including the null node (more generally, all plain nodes are fine)
 		assertEquals( "NULL", ((PHPParameter)node).getDefault().getProperty("type"));
+	}
+
+	
+	/* nodes with exactly 4 children */
+
+	/**
+	 * for (;;);
+	 */
+	@Test
+	public void testMinimalForCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FOR,,3,,0,1,,,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "5,NULL,,3,,1,1,,,\n";
+		nodeStr += "6,NULL,,3,,2,1,,,\n";
+		nodeStr += "7,NULL,,3,,3,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "3,7,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+
+		assertThat( node, instanceOf(ForStatement.class));
+		assertEquals( 4, node.getChildCount());
+		// TODO The three calls to obtain the for-loop's expression list's should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because ForStatement accepts arbitrary ASTNode's for them. Might need to
+		// create a new class PHPForLoop for that, but finish mapping first.
+		assertEquals( "NULL", ((ForStatement)node).getForInitExpression().getProperty("type"));
+		assertEquals( "NULL", ((ForStatement)node).getCondition().getProperty("type"));
+		assertEquals( "NULL", ((ForStatement)node).getForLoopExpression().getProperty("type"));
+		assertNull( ((ForStatement)node).getStatement());
 	}
 	
 	

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1,6 +1,7 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
+import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
 import ast.functionDef.FunctionDef;
@@ -84,6 +85,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 				
 			// nodes with an arbitrary number of children
+			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
+				errno = handleExpressionList((ExpressionList)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_STMT_LIST:
 				errno = handleCompound((CompoundStatement)startNode, endNode, childnum);
 				break;
@@ -363,9 +367,16 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	/* nodes with an arbitrary number of children */
 	
+	private int handleExpressionList( ExpressionList startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addExpression(endNode); // TODO cast to Expression
+
+		return 0;
+	}
+	
 	private int handleCompound( CompoundStatement startNode, ASTNode endNode, int childnum)
 	{
-		startNode.addChild(endNode);
+		startNode.addChild(endNode); // TODO introduce addStatement in CompoundStatement (and cast to Statement)
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -6,6 +6,7 @@ import ast.expressions.IdentifierList;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
+import ast.logical.statements.Statement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -237,8 +238,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 1: // NULL child
 				startNode.addChild(endNode);
 				break;
-			case 2: // stmts child
-				startNode.setContent((CompoundStatement)endNode);
+			case 2: // stmts child: either CompoundStatement or NULL
+				startNode.setContent(endNode);
 				break;
 			case 3: // returnType child: either Identifier or NULL node
 				startNode.setReturnType(endNode);
@@ -289,8 +290,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// then, change BlockStarter.condition to be an Expression instead
 				// of a generic ASTNode, and getCondition() and setCondition() accordingly
 				break;
-			case 1: // stmts child
-				startNode.setContent((CompoundStatement)endNode);
+			case 1: // stmts child: statement node (e.g., AST_STMT_LIST) or NULL node
+				if( endNode instanceof Statement)
+					startNode.setStatement((Statement)endNode);
+				else
+					startNode.addChild(endNode);
+				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
+				// unless it is a NULL node: test that!
 				break;
 
 			default:
@@ -307,7 +313,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // stmts child
-				startNode.setContent((CompoundStatement)endNode);
+				if( endNode instanceof Statement)
+					startNode.setStatement((Statement)endNode);
+				else
+					startNode.addChild(endNode);
+				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
+				// unless it is a NULL node: test that!
 				break;
 			case 1: // cond child
 				startNode.setCondition(endNode);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,6 +6,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
+import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
 import ast.functionDef.FunctionDef;
@@ -78,6 +79,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with an arbitrary number of children
+			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
+				retval = handleExpressionList(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_STMT_LIST:
 				retval = handleCompound(row, ast);
 				break;
@@ -420,6 +424,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	
 	
 	/* nodes with an arbitrary number of children */
+
+	private long handleExpressionList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ExpressionList newNode = new ExpressionList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 	private long handleCompound(KeyedCSVRow row, ASTUnderConstruction ast)
 	{

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_FOR = "AST_FOR";
 
 	// nodes with an arbitrary number of children
+	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";


### PR DESCRIPTION
* Added a new class `TestPHPCSVASTBuilderMinimal` to add some minimalistic tests which check for null children, etc.

    In view of some recent developments, I felt it was a good idea to introduce a new test class that generates some AST nodes that have as few children as possible (as opposed to the "normal" test class `TestPHPCSVASTBuilder` which aims to generate all possible children of any AST node), so we don't get `NullPointerException`'s flying around our ears once we throw Joern on real-world PHP code.

    For instance, while and do-while statements may have a "statement" child that is only a single
statement and thus is not an `AST_STMT_LIST`. This can even be a no-op statement, composed
only of a semicolon, which generates a null node.

    Another interesting insight was that methods can have no `AST_STMT_LIST` body at all (e.g., method
signatures defined in an abstract class); this does not hold for functions or closures (these
always have an `AST_STMT_LIST` body.)

* Added support for `AST_EXPR_LIST` -> `ast.expressions.ExpressionList`

    Similarly as for the `IdentifierList`, I felt that the concept is general enough to be in the general `ast.expressions` package. :) We need these for for-loops...

* Added support for `AST_FOR` -> `ast.statements.blockstarters.ForStatement`

    I also was so blunt as to rename `ForStatement`'s extra fields, namely,
    * `forInitStatement` -> `forInitExpression`
    * `expression` -> `forLoopExpression`

    as well as the corrresponding getter- and setter-methods.

    The reason for the first being that a for-loop's initialization expression is not a statement, but an expression. For the second, I simply did not find the name "expression" very expressive. ;)

    This obviously implied changing the names at the call sites, but there is only one call site for each of these, in `CCFGFactory`.

Oh, and we also celebrate our 200th unit test in Joern. :smile: Have a nice week-end!