### PR TITLE
Support for variables, foreach loops, and if statements

### DIFF
--- a/src/ast/expressions/Variable.java
+++ b/src/ast/expressions/Variable.java
@@ -1,0 +1,17 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class Variable extends Expression
+{
+	private ASTNode name = null;
+	
+	public void setNameChild(ASTNode name) {
+		this.name = name;
+		super.addChild(name);
+	}
+	
+	public ASTNode getNameChild() {
+		return this.name;
+	}
+}

--- a/src/ast/php/statements/blockstarters/ForEachStatement.java
+++ b/src/ast/php/statements/blockstarters/ForEachStatement.java
@@ -1,0 +1,57 @@
+package ast.php.statements.blockstarters;
+
+import ast.ASTNode;
+import ast.expressions.Variable;
+import ast.logical.statements.BlockStarter;
+
+public class ForEachStatement extends BlockStarter
+{
+	private ASTNode iteratedObject = null; // TODO make this an Expression sometime
+	private Variable key = null;
+	private Variable value = null;
+
+	@Override
+	public ASTNode getCondition()
+	{
+		return null;
+	}
+
+	@Override
+	public void setCondition(ASTNode expression)
+	{
+	}
+	
+	public ASTNode getIteratedObject()
+	{
+		return this.iteratedObject;
+	}
+
+	public void setIteratedObject(ASTNode expression)
+	{
+		this.iteratedObject = expression;
+		super.addChild(expression);
+	}
+
+	public ASTNode getValueVar()
+	{
+		return this.value;
+	}
+
+	public void setValueVar(Variable value)
+	{
+		this.value = value;
+		super.addChild(value);
+	}
+	
+	public ASTNode getKeyVar()
+	{
+		return this.key;
+	}
+
+	public void setKeyVar(ASTNode key)
+	{
+		if (key instanceof Variable)
+			this.key = (Variable)key;
+		super.addChild(key);
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPIfElement.java
+++ b/src/ast/php/statements/blockstarters/PHPIfElement.java
@@ -1,0 +1,7 @@
+package ast.php.statements.blockstarters;
+
+import ast.logical.statements.BlockStarter;
+
+public class PHPIfElement extends BlockStarter
+{
+}

--- a/src/ast/php/statements/blockstarters/PHPIfStatement.java
+++ b/src/ast/php/statements/blockstarters/PHPIfStatement.java
@@ -1,0 +1,80 @@
+package ast.php.statements.blockstarters;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+import ast.statements.blockstarters.ElseStatement;
+import ast.statements.blockstarters.IfStatement;
+
+public class PHPIfStatement extends IfStatement implements Iterable<PHPIfElement>
+{
+
+	private LinkedList<PHPIfElement> ifElements = new LinkedList<PHPIfElement>();
+
+	public int size()
+	{
+		return this.ifElements.size();
+	}
+	
+	public PHPIfElement getIfElement(int i) {
+		return this.ifElements.get(i);
+	}
+
+	public void addIfElement(PHPIfElement ifElement)
+	{
+		this.ifElements.add(ifElement);
+		super.addChild(ifElement);
+	}
+
+	@Override
+	public Iterator<PHPIfElement> iterator() {
+		return this.ifElements.iterator();
+	}
+	
+	// Need to override getChildCount() and getChild(int) because they are also overridden
+	// by IfStatement, and we want to restore the original behavior from ASTNode.
+	// TODO this is really ugly: we should create a class CIfStatement that implements if-statements
+	// for C, and have the base class IfStatement abstract from both CIfStatement and PHPIfStatement.
+	// Then, CIfStatement can override getChildCount() and getChild(int) on its own and
+	// without imposing its behavior to if-statements for other languages that would
+	// like to inherit from IfStatement.
+	@Override
+	public int getChildCount()
+	{
+		if (children == null)
+			return 0;
+		return children.size();
+	}
+	
+	@Override
+	public ASTNode getChild(int i)
+	{
+		if (children == null)
+			return null;
+
+		ASTNode retval;
+		try
+		{
+			retval = children.get(i);
+		} catch (IndexOutOfBoundsException ex)
+		{
+			return null;
+		}
+		return retval;
+	}
+
+	// Same as for getChildCount() and getChild(int), we have to override
+	// getElseNode() and setElseNode(ElseStatement) as we do not want them for PHP
+	@Override
+	public ElseStatement getElseNode()
+	{
+		throw new RuntimeException("Error: else nodes are not used by PHP if-statements!");
+	}
+
+	@Override
+	public void setElseNode(ElseStatement elseNode)
+	{
+		throw new RuntimeException("Error: else nodes are not used by PHP if-statements!");
+	}
+}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -20,6 +20,7 @@ import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
+import ast.php.statements.blockstarters.ForEachStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -365,7 +366,40 @@ public class TestPHPCSVASTBuilderMinimal
 		assertNull( ((ForStatement)node).getStatement());
 	}
 	
-	
+	/**
+	 * foreach ($somearray as $foo);
+	 */
+	@Test
+	public void testForEachCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FOREACH,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"somearray\",0,1,,,\n";
+		nodeStr += "6,AST_VAR,,3,,1,1,,,\n";
+		nodeStr += "7,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "8,NULL,,3,,2,1,,,\n";
+		nodeStr += "9,NULL,,3,,3,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "3,8,PARENT_OF\n";
+		edgeStr += "3,9,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+
+		assertThat( node, instanceOf(ForEachStatement.class));
+		assertEquals( 4, node.getChildCount());
+		assertNull( ((ForEachStatement)node).getKeyVar());
+		assertNull( ((ForEachStatement)node).getStatement());
+	}
+
+
 	/* nodes with an arbitrary number of children */
 
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -21,6 +21,7 @@ import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.statements.blockstarters.ForEachStatement;
+import ast.php.statements.blockstarters.PHPIfElement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -288,6 +289,54 @@ public class TestPHPCSVASTBuilderMinimal
 		assertEquals( 2, node2.getChildCount());
 		assertThat( ((DoStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
 	}
+	
+	/**
+	 * if(true) ;
+	 * else ;
+	 */
+	@Test
+	public void testMinimalIfElementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_IF,,3,,0,1,,,\n";
+		nodeStr += "4,AST_IF_ELEM,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CONST,,3,,0,1,,,\n";
+		nodeStr += "6,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "7,string,,3,\"true\",0,1,,,\n";
+		nodeStr += "8,NULL,,3,,1,1,,,\n";
+		nodeStr += "9,AST_IF_ELEM,,4,,1,1,,,\n";
+		nodeStr += "10,NULL,,4,,0,1,,,\n";
+		nodeStr += "11,NULL,,4,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "4,8,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "9,11,PARENT_OF\n";
+		edgeStr += "3,9,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)4);
+		ASTNode node2 = ast.getNodeById((long)9);
+		
+		assertThat( node, instanceOf(PHPIfElement.class));
+		assertEquals( 2, node.getChildCount());
+		assertNull( ((PHPIfElement)node).getStatement());
+
+		assertThat( node2, instanceOf(PHPIfElement.class));
+		assertEquals( 2, node2.getChildCount());
+		// TODO ((PHPIfElement)node2).getCondition() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPIfElement accepts arbitrary ASTNode's for conditions,
+		// when we actually only want to accept Expression's. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPIfElement)node2).getCondition().getProperty("type"));
+		assertNull( ((PHPIfElement)node2).getStatement());
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -370,7 +419,7 @@ public class TestPHPCSVASTBuilderMinimal
 	 * foreach ($somearray as $foo);
 	 */
 	@Test
-	public void testForEachCreation() throws IOException, InvalidCSVFile
+	public void testMinimalForEachCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "3,AST_FOREACH,,3,,0,1,,,\n";

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -9,6 +9,7 @@ import ast.CodeLocation;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
@@ -19,6 +20,7 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.php.statements.blockstarters.ForEachStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.IfStatement;
@@ -60,6 +62,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				retval = handleClass(row, ast);
 				break;
 
+			// nodes with exactly 1 child
+			case PHPCSVNodeTypes.TYPE_VAR:
+				retval = handleVariable(row, ast);
+				break;
+
 			// nodes with exactly 2 children
 			case PHPCSVNodeTypes.TYPE_WHILE:
 				retval = handleWhile(row, ast);
@@ -76,6 +83,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// nodes with exactly 4 children
 			case PHPCSVNodeTypes.TYPE_FOR:
 				retval = handleFor(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_FOREACH:
+				retval = handleForEach(row, ast);
 				break;
 
 			// nodes with an arbitrary number of children
@@ -326,6 +336,31 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	}
 	
 	
+	/* nodes with exactly 1 child */
+	
+	private long handleVariable(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		Variable newNode = new Variable();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	
 	/* nodes with exactly 2 children */
 	
 	private long handleWhile(KeyedCSVRow row, ASTUnderConstruction ast)
@@ -403,6 +438,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleFor(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ForStatement newNode = new ForStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleForEach(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ForEachStatement newNode = new ForEachStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -21,9 +21,10 @@ import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.blockstarters.ForEachStatement;
+import ast.php.statements.blockstarters.PHPIfElement;
+import ast.php.statements.blockstarters.PHPIfStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
-import ast.statements.blockstarters.IfStatement;
 import ast.statements.blockstarters.WhileStatement;
 
 public class PHPCSVNodeInterpreter implements CSVRowInterpreter
@@ -73,6 +74,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_DO_WHILE:
 				retval = handleDo(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_IF_ELEM:
+				retval = handleIfElement(row, ast);
 				break;
 
 			// nodes with exactly 3 children
@@ -406,6 +410,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		return id;
 	}
+	
+	private long handleIfElement(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPIfElement newNode = new PHPIfElement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -528,7 +554,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private long handleIf(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		IfStatement newNode = new IfStatement();
+		PHPIfStatement newNode = new PHPIfStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -44,6 +44,9 @@ public class PHPCSVNodeTypes
 
 	public static final String TYPE_CLASS = "AST_CLASS";
 
+	// nodes with exactly 1 child
+	public static final String TYPE_VAR = "AST_VAR";
+
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
@@ -53,6 +56,7 @@ public class PHPCSVNodeTypes
 
 	// nodes with exactly 4 children
 	public static final String TYPE_FOR = "AST_FOR";
+	public static final String TYPE_FOREACH = "AST_FOREACH";
 
 	// nodes with an arbitrary number of children
 	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -50,6 +50,7 @@ public class PHPCSVNodeTypes
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
+	public static final String TYPE_IF_ELEM = "AST_IF_ELEM";
 
 	// nodes with exactly 3 children
 	public static final String TYPE_PARAM = "AST_PARAM";


### PR DESCRIPTION
I fully mapped `foreach` loops and `if` statements into Joern. Both of these are obviously relevant for CFG generation. Unfortunately, I assume that neither of these two can be handled by the current CFG-generating code in Joern. So, here's some work coming your way. :wink: 

Concerning `foreach` loops: They do not exist in C, and so Joern's CFG factory currently has no support for them at all.

Concerning `if` statements: Even though `if` statements do exist in C, they are slightly more complex in PHP, mostly due to the existence of the `elseif` construct. In C, there is no `elseif` (one would use `else if` instead), and so whenever there is a construct consisting of multiple if/else statements in C, one would accordingly obtain nested AST nodes, i.e., an if-statement with another if-statement under the else-node, yet another if-statement under the else-node of that second if-statement, etc.

When using the `elseif` construct in PHP, this is different. Rather than a nested hierarchy of if/else statements, we obtain a flat hierarchy of if-elements. Each if-element has two children: the expression that corresponds to the element's guard (the "predicate" or "condition"), and the statement to be executed if that expression evaluates to true. This is perhaps best explained by example. The following PHP code:

```php
if($foo) {}
elseif($bar) {}
elseif($buz) {}
else {}
```
will generate the following AST:

```
AST_STMT_LIST
    0: AST_IF
        0: AST_IF_ELEM
            0: AST_VAR
                0: "foo"
            1: AST_STMT_LIST
        1: AST_IF_ELEM
            0: AST_VAR
                0: "bar"
            1: AST_STMT_LIST
        2: AST_IF_ELEM
            0: AST_VAR
                0: "buz"
            1: AST_STMT_LIST
        3: AST_IF_ELEM
            0: null
            1: AST_STMT_LIST
```

To evaluate such an if-statement, all the PHP interpreter has to do is to go through the list of if-elements in order and evaluate the if-elements' expressions (i.e., the first child) until the first such expression evaluates to true. Then, the corresponding statement (i.e., the second child of that if-element) is executed. A final `else` is straightforwardly represented by an if-element whose guard is a null node (which makes sense as there is no guard, and distinguishes a final `else` from a semantically equivalent, but syntactically different final `elseif(true)`). Thus, if-elements are a common abstraction of `if`, `elseif` and `else` blocks. In fact, from an AST point of view, if-elements are pretty similar to while- and do-while nodes, having two children: a condition and a statement.

This in particular implies that there is no distinguished `else` node as is the case for if-statements in C, and that an if-statement in PHP is *iterable*. I therefore had to write two new classes, `PHPIfStatement` and `PHPIfElement`, with `PHPIfStatement` inheriting from `IfStatement`. However, as was the case a few times in the past, it should be noted that it would be nicer to have an abstract `IfStatement` base class, and a `CIfStatement` and a `PHPIfStatement` that extend it. In particular, the current `IfStatement` class, originally written for C, declares `getElse()` and `setElse()` methods which do not make sense in PHP, and which I thus had to override in order to have them throw a runtime exception; similarly I had to re-override the `getChild(int)` and `getChildCount()` methods which `IfStatement` overrides itself, in order to restore the original behavior implemented in `ASTNode`.


