### PR TITLE
Support for switch, break, continue, return, label and goto statements

### DIFF
--- a/src/ast/logical/statements/Label.java
+++ b/src/ast/logical/statements/Label.java
@@ -1,9 +1,21 @@
 package ast.logical.statements;
 
+import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
 public class Label extends Statement
 {
+	private ASTNode name = null;
+
+	public void setNameChild(ASTNode name) {
+		this.name = name;
+		super.addChild(name);
+	}
+	
+	public ASTNode getNameChild() {
+		return this.name;
+	}
+	
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/ast/php/statements/blockstarters/PHPSwitchCase.java
+++ b/src/ast/php/statements/blockstarters/PHPSwitchCase.java
@@ -1,0 +1,21 @@
+package ast.php.statements.blockstarters;
+
+import ast.ASTNode;
+import ast.logical.statements.BlockStarter;
+
+public class PHPSwitchCase extends BlockStarter
+{
+	private ASTNode value = null;
+	
+	public ASTNode getValue()
+	{
+		return this.value;
+	}
+
+	public void setValue(ASTNode value)
+	{
+		this.value = value;
+		super.addChild(value);
+	}
+
+}

--- a/src/ast/php/statements/blockstarters/PHPSwitchList.java
+++ b/src/ast/php/statements/blockstarters/PHPSwitchList.java
@@ -1,0 +1,32 @@
+package ast.php.statements.blockstarters;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.logical.statements.BlockStarter;
+
+public class PHPSwitchList extends BlockStarter implements Iterable<PHPSwitchCase>
+{
+
+	private LinkedList<PHPSwitchCase> switchCases = new LinkedList<PHPSwitchCase>();
+
+	public int size()
+	{
+		return this.switchCases.size();
+	}
+	
+	public PHPSwitchCase getSwitchCase(int i) {
+		return this.switchCases.get(i);
+	}
+
+	public void addSwitchCase(PHPSwitchCase switchCase)
+	{
+		this.switchCases.add(switchCase);
+		super.addChild(switchCase);
+	}
+
+	@Override
+	public Iterator<PHPSwitchCase> iterator() {
+		return this.switchCases.iterator();
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPSwitchStatement.java
+++ b/src/ast/php/statements/blockstarters/PHPSwitchStatement.java
@@ -1,0 +1,32 @@
+package ast.php.statements.blockstarters;
+
+import ast.ASTNode;
+import ast.statements.blockstarters.SwitchStatement;
+
+public class PHPSwitchStatement extends SwitchStatement
+{
+	private ASTNode expression = null; // TODO change type to Expression
+	protected PHPSwitchList switchList = null;
+
+	public ASTNode getExpression()
+	{
+		return this.expression;
+	}
+
+	public void setExpression(ASTNode expression)
+	{
+		this.expression = expression;
+		super.addChild(expression);
+	}
+	
+	public PHPSwitchList getSwitchList()
+	{
+		return this.switchList;
+	}
+	
+	public void setSwitchList(PHPSwitchList switchList)
+	{
+		this.switchList = switchList;
+		super.addChild(switchList);
+	}
+}

--- a/src/ast/php/statements/jump/PHPBreakStatement.java
+++ b/src/ast/php/statements/jump/PHPBreakStatement.java
@@ -1,0 +1,18 @@
+package ast.php.statements.jump;
+
+import ast.ASTNode;
+import ast.statements.jump.BreakStatement;
+
+public class PHPBreakStatement extends BreakStatement
+{
+	private ASTNode depth = null;
+	
+	public void setDepth(ASTNode depth) {
+		this.depth = depth;
+		super.addChild(depth);
+	}
+	
+	public ASTNode getDepth() {
+		return this.depth;
+	}
+}

--- a/src/ast/php/statements/jump/PHPContinueStatement.java
+++ b/src/ast/php/statements/jump/PHPContinueStatement.java
@@ -1,0 +1,18 @@
+package ast.php.statements.jump;
+
+import ast.ASTNode;
+import ast.statements.jump.ContinueStatement;
+
+public class PHPContinueStatement extends ContinueStatement
+{
+	private ASTNode depth = null;
+	
+	public void setDepth(ASTNode depth) {
+		this.depth = depth;
+		super.addChild(depth);
+	}
+	
+	public ASTNode getDepth() {
+		return this.depth;
+	}
+}

--- a/src/ast/statements/jump/GotoStatement.java
+++ b/src/ast/statements/jump/GotoStatement.java
@@ -1,12 +1,27 @@
 package ast.statements.jump;
 
+import ast.ASTNode;
 import ast.logical.statements.JumpStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class GotoStatement extends JumpStatement
 {
-	public String getTarget()
+	private ASTNode label = null;
+
+	public void setTargetLabel(ASTNode label) {
+		this.label = label;
+		super.addChild(label);
+	}
+	
+	public ASTNode getTargetLabel() {
+		return this.label;
+	}
+	
+	public String getTargetName()
 	{
+		// TODO since C world does not use the setTargetLabel() method but
+		// instead uses addChild(), we have to use getChild(0) here
+		// instead of getTargetLabel()
 		return getChild(0).getEscapedCodeStr();
 	}
 

--- a/src/ast/statements/jump/ReturnStatement.java
+++ b/src/ast/statements/jump/ReturnStatement.java
@@ -1,10 +1,24 @@
 package ast.statements.jump;
 
+import ast.ASTNode;
 import ast.logical.statements.JumpStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class ReturnStatement extends JumpStatement
 {
+	private ASTNode returnExpression = null;
+	
+	public ASTNode getReturnExpression()
+	{
+		return this.returnExpression;
+	}
+
+	public void setReturnExpression(ASTNode expression)
+	{
+		this.returnExpression = expression;
+		super.addChild(expression);
+	}
+	
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/languages/c/cfg/CCFGFactory.java
+++ b/src/languages/c/cfg/CCFGFactory.java
@@ -452,7 +452,7 @@ public class CCFGFactory extends CFGFactory
 			gotoBlock.addEdge(gotoBlock.getEntryNode(), gotoContainer);
 			gotoBlock.addEdge(gotoContainer, gotoBlock.getExitNode());
 			gotoBlock.addGotoStatement(gotoContainer,
-					gotoStatement.getTarget());
+					gotoStatement.getTargetName());
 			return gotoBlock;
 		}
 		catch (Exception e)

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -39,6 +39,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
+import ast.statements.jump.ReturnStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
@@ -493,6 +494,50 @@ public class TestPHPCSVASTBuilder
 		assertEquals( "bar", ((Variable)node3).getNameChild().getEscapedCodeStr());
 	}
 
+	/**
+	 * AST_RETURN nodes are nodes representing a return statement.
+	 * 
+	 * Any AST_RETURN node has exactly one child holding the expression to be
+	 * returned, or a null node if nothing is returned.
+	 * 
+	 * This test checks a return statement's child in the following PHP code:
+	 * 
+	 * function foo() : int {
+	 *   return 42;
+	 * }
+	 */
+	@Test
+	public void testReturnStatementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_RETURN,,4,,0,3,,,\n";
+		nodeStr += "8,integer,,4,42,0,3,,,\n";
+		nodeStr += "9,AST_NAME,NAME_NOT_FQ,3,,3,3,,,\n";
+		nodeStr += "10,string,,3,\"int\",0,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "3,9,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)7);
+		
+		assertThat( node, instanceOf(ReturnStatement.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)8), ((ReturnStatement)node).getReturnExpression());
+		assertEquals( "42", ((ReturnStatement)node).getReturnExpression().getEscapedCodeStr());
+	}
+	
 	/**
 	 * AST_BREAK nodes are nodes representing a break statement.
 	 * 

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -31,6 +31,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
+import ast.php.statements.jump.PHPBreakStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -437,7 +438,8 @@ public class TestPHPCSVASTBuilder
 	/**
 	 * AST_VAR nodes are nodes holding variables names.
 	 * 
-	 * Any AST_VAR node has exactly one child which is of type "string".
+	 * Any AST_VAR node has exactly one child which is of type "string", holding
+	 * the variable's name.
 	 * 
 	 * This test checks the names 'somearray', 'foo' and 'bar' in the following PHP code:
 	 * 
@@ -487,6 +489,46 @@ public class TestPHPCSVASTBuilder
 		assertEquals( "bar", ((Variable)node3).getNameChild().getEscapedCodeStr());
 	}
 
+	/**
+	 * AST_BREAK nodes are nodes representing a break statement.
+	 * 
+	 * Any AST_BREAK node has exactly one child which is of type "integer", holding
+	 * the number of enclosing structures to be broken out of.
+	 * 
+	 * This test checks a few break statements' children in the following PHP code:
+	 * 
+	 * break 1;
+	 * break 2;
+	 */
+	@Test
+	public void testBreakStatementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_BREAK,,3,,0,1,,,\n";
+		nodeStr += "4,integer,,3,1,0,1,,,\n";
+		nodeStr += "5,AST_BREAK,,4,,1,1,,,\n";
+		nodeStr += "6,integer,,4,2,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)5);
+		
+		assertThat( node, instanceOf(PHPBreakStatement.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PHPBreakStatement)node).getDepth());
+		assertEquals( "1", ((PHPBreakStatement)node).getDepth().getEscapedCodeStr());
+
+		assertThat( node2, instanceOf(PHPBreakStatement.class));
+		assertEquals( 1, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)6), ((PHPBreakStatement)node2).getDepth());
+		assertEquals( "2", ((PHPBreakStatement)node2).getDepth().getEscapedCodeStr());
+	}
+	
 
 	/* nodes with exactly 2 children */
 	

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -22,6 +22,7 @@ import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
+import ast.php.statements.jump.PHPBreakStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -198,6 +199,36 @@ public class TestPHPCSVASTBuilderMinimal
 	}
 	
 	
+	/* nodes with exactly 1 child */
+	
+	/**
+	 * break;
+	 */
+	@Test
+	public void testMinimalBreakStatementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_BREAK,,3,,0,1,,,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PHPBreakStatement.class));
+		assertEquals( 1, node.getChildCount());
+		// TODO ((PHPBreakStatement)node).getDepth() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPBreakStatement accepts arbitrary ASTNode's for depths,
+		// when we actually only want to accept plain nodes. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPBreakStatement)node).getDepth().getProperty("type"));
+	}
+
+
 	/* nodes with exactly 2 children */
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -29,6 +29,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
+import ast.statements.jump.ReturnStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
@@ -203,6 +204,45 @@ public class TestPHPCSVASTBuilderMinimal
 	
 	
 	/* nodes with exactly 1 child */
+	
+	/**
+	 * function foo() {
+	 *   return;
+	 * }
+	 */
+	@Test
+	public void testMinimalReturnStatementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_RETURN,,4,,0,3,,,\n";
+		nodeStr += "8,NULL,,4,,0,3,,,\n";
+		nodeStr += "9,NULL,,3,,3,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "3,9,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)7);
+		
+		assertThat( node, instanceOf(ReturnStatement.class));
+		assertEquals( 1, node.getChildCount());
+		// TODO ((ReturnStatement)node).getReturnExpression() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because ReturnStatement accepts arbitrary ASTNode's for return expressions,
+		// when we actually only want to accept expressions. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((ReturnStatement)node).getReturnExpression().getProperty("type"));
+	}
 	
 	/**
 	 * while (1)

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -25,6 +25,7 @@ import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
 import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.jump.PHPBreakStatement;
+import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -204,21 +205,26 @@ public class TestPHPCSVASTBuilderMinimal
 	/* nodes with exactly 1 child */
 	
 	/**
-	 * break;
+	 * while (1)
+	 *   break;
 	 */
 	@Test
 	public void testMinimalBreakStatementCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
-		nodeStr += "3,AST_BREAK,,3,,0,1,,,\n";
-		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "3,AST_WHILE,,3,,0,1,,,\n";
+		nodeStr += "4,integer,,3,1,0,1,,,\n";
+		nodeStr += "5,AST_BREAK,,4,,1,1,,,\n";
+		nodeStr += "6,NULL,,4,,0,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
 
-		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node = ast.getNodeById((long)5);
 		
 		assertThat( node, instanceOf(PHPBreakStatement.class));
 		assertEquals( 1, node.getChildCount());
@@ -228,6 +234,38 @@ public class TestPHPCSVASTBuilderMinimal
 		// when we actually only want to accept plain nodes. Once the mapping is
 		// finished, we can fix that.
 		assertEquals( "NULL", ((PHPBreakStatement)node).getDepth().getProperty("type"));
+	}
+	
+	/**
+	 * while (1)
+	 *   continue;
+	 */
+	@Test
+	public void testMinimalContinueStatementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_WHILE,,3,,0,1,,,\n";
+		nodeStr += "4,integer,,3,1,0,1,,,\n";
+		nodeStr += "5,AST_CONTINUE,,4,,1,1,,,\n";
+		nodeStr += "6,NULL,,4,,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)5);
+		
+		assertThat( node, instanceOf(PHPContinueStatement.class));
+		assertEquals( 1, node.getChildCount());
+		// TODO ((PHPContinueStatement)node).getDepth() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPContinueStatement accepts arbitrary ASTNode's for depths,
+		// when we actually only want to accept plain nodes. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPContinueStatement)node).getDepth().getProperty("type"));
 	}
 
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -19,6 +19,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
+import ast.php.statements.jump.PHPBreakStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -78,6 +79,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// nodes with exactly 1 child
 			case PHPCSVNodeTypes.TYPE_VAR:
 				errno = handleVariable((Variable)startNode, endNode, childnum);
+				break;
+				
+			case PHPCSVNodeTypes.TYPE_BREAK:
+				errno = handleBreak((PHPBreakStatement)startNode, endNode, childnum);
 				break;
 
 			// nodes with exactly 2 children
@@ -322,7 +327,24 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		return errno;		
 	}
 	
-	
+	private int handleBreak( PHPBreakStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // depth child
+				startNode.setDepth(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+
+
 	/* nodes with exactly 2 children */
 
 	private int handleWhile( WhileStatement startNode, ASTNode endNode, int childnum)

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -27,6 +27,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
+import ast.statements.jump.ReturnStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.ASTUnderConstruction;
@@ -85,6 +86,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				errno = handleVariable((Variable)startNode, endNode, childnum);
 				break;
 				
+			case PHPCSVNodeTypes.TYPE_RETURN:
+				errno = handleReturn((ReturnStatement)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_BREAK:
 				errno = handleBreak((PHPBreakStatement)startNode, endNode, childnum);
 				break;
@@ -341,6 +345,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		}
 		
 		return errno;		
+	}
+	
+	private int handleReturn( ReturnStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setReturnExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
 	}
 	
 	private int handleBreak( PHPBreakStatement startNode, ASTNode endNode, int childnum)

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -23,6 +23,7 @@ import ast.php.statements.blockstarters.PHPSwitchCase;
 import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPSwitchStatement;
 import ast.php.statements.jump.PHPBreakStatement;
+import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -86,6 +87,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				
 			case PHPCSVNodeTypes.TYPE_BREAK:
 				errno = handleBreak((PHPBreakStatement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CONTINUE:
+				errno = handleContinue((PHPContinueStatement)startNode, endNode, childnum);
 				break;
 
 			// nodes with exactly 2 children
@@ -340,6 +344,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	}
 	
 	private int handleBreak( PHPBreakStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // depth child
+				startNode.setDepth(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleContinue( PHPContinueStatement startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -8,6 +8,7 @@ import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
+import ast.logical.statements.Label;
 import ast.logical.statements.Statement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
@@ -27,6 +28,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
+import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
@@ -88,6 +90,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				errno = handleReturn((ReturnStatement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_LABEL:
+				errno = handleLabel((Label)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_GOTO:
+				errno = handleGoto((GotoStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_BREAK:
 				errno = handleBreak((PHPBreakStatement)startNode, endNode, childnum);
@@ -355,6 +363,40 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // expr child
 				startNode.setReturnExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleLabel( Label startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child
+				startNode.setNameChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleGoto( GotoStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // label child
+				startNode.setTargetLabel(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -31,6 +31,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
+import ast.statements.jump.ReturnStatement;
 
 public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 {
@@ -73,6 +74,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				retval = handleVariable(row, ast);
 				break;
 			
+			case PHPCSVNodeTypes.TYPE_RETURN:
+				retval = handleReturn(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_BREAK:
 				retval = handleBreak(row, ast);
 				break;
@@ -366,6 +370,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleVariable(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Variable newNode = new Variable();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleReturn(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ReturnStatement newNode = new ReturnStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -23,6 +23,9 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
+import ast.php.statements.blockstarters.PHPSwitchCase;
+import ast.php.statements.blockstarters.PHPSwitchList;
+import ast.php.statements.blockstarters.PHPSwitchStatement;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
@@ -83,6 +86,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_IF_ELEM:
 				retval = handleIfElement(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_SWITCH:
+				retval = handleSwitch(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_SWITCH_CASE:
+				retval = handleSwitchCase(row, ast);
+				break;
 
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_PARAM:
@@ -106,6 +115,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_IF:
 				retval = handleIf(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_SWITCH_LIST:
+				retval = handleSwitchList(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
 				retval = handleParameterList(row, ast);
@@ -459,6 +471,50 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		return id;
 	}
+	
+	private long handleSwitch(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPSwitchStatement newNode = new PHPSwitchStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleSwitchCase(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPSwitchCase newNode = new PHPSwitchCase();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -582,6 +638,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleIf(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPIfStatement newNode = new PHPIfStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleSwitchList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPSwitchList newNode = new PHPSwitchList();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -27,6 +27,7 @@ import ast.php.statements.blockstarters.PHPSwitchCase;
 import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPSwitchStatement;
 import ast.php.statements.jump.PHPBreakStatement;
+import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -74,6 +75,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			
 			case PHPCSVNodeTypes.TYPE_BREAK:
 				retval = handleBreak(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CONTINUE:
+				retval = handleContinue(row, ast);
 				break;
 
 			// nodes with exactly 2 children
@@ -384,6 +388,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleBreak(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPBreakStatement newNode = new PHPBreakStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleContinue(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPContinueStatement newNode = new PHPContinueStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -13,6 +13,7 @@ import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
+import ast.logical.statements.Label;
 import ast.php.declarations.PHPClassDef;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -31,6 +32,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
+import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
 
 public class PHPCSVNodeInterpreter implements CSVRowInterpreter
@@ -76,6 +78,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				retval = handleReturn(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_LABEL:
+				retval = handleLabel(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_GOTO:
+				retval = handleGoto(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_BREAK:
 				retval = handleBreak(row, ast);
@@ -392,6 +400,50 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleReturn(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ReturnStatement newNode = new ReturnStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleLabel(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		Label newNode = new Label();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleGoto(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		GotoStatement newNode = new GotoStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -23,6 +23,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
+import ast.php.statements.jump.PHPBreakStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -66,6 +67,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// nodes with exactly 1 child
 			case PHPCSVNodeTypes.TYPE_VAR:
 				retval = handleVariable(row, ast);
+				break;
+			
+			case PHPCSVNodeTypes.TYPE_BREAK:
+				retval = handleBreak(row, ast);
 				break;
 
 			// nodes with exactly 2 children
@@ -345,6 +350,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleVariable(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Variable newNode = new Variable();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleBreak(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPBreakStatement newNode = new PHPBreakStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -48,6 +48,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_VAR = "AST_VAR";
 	
 	public static final String TYPE_BREAK = "AST_BREAK";
+	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -48,6 +48,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_VAR = "AST_VAR";
 	
 	public static final String TYPE_RETURN = "AST_RETURN";
+	public static final String TYPE_LABEL = "AST_LABEL";
+	public static final String TYPE_GOTO = "AST_GOTO";
 	public static final String TYPE_BREAK = "AST_BREAK";
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -53,6 +53,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
 	public static final String TYPE_IF_ELEM = "AST_IF_ELEM";
+	public static final String TYPE_SWITCH = "AST_SWITCH";
+	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 
 	// nodes with exactly 3 children
 	public static final String TYPE_PARAM = "AST_PARAM";
@@ -65,6 +67,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";
+	public static final String TYPE_SWITCH_LIST = "AST_SWITCH_LIST";
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
 	public static final String TYPE_CLOSURE_USES = "AST_CLOSURE_USES";
 	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -46,6 +46,8 @@ public class PHPCSVNodeTypes
 
 	// nodes with exactly 1 child
 	public static final String TYPE_VAR = "AST_VAR";
+	
+	public static final String TYPE_BREAK = "AST_BREAK";
 
 	// nodes with exactly 2 children
 	public static final String TYPE_WHILE = "AST_WHILE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -47,6 +47,7 @@ public class PHPCSVNodeTypes
 	// nodes with exactly 1 child
 	public static final String TYPE_VAR = "AST_VAR";
 	
+	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_BREAK = "AST_BREAK";
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 


### PR DESCRIPTION
It wouldn't be me if I didn't write an essay on this, so here we go. :smile: 

**Support for switch statements**

There are three new classes: `PHPSwitchStatement` (=`AST_SWITCH`), `PHPSwitchList` (=`AST_SWITCH_LIST`) and `PHPSwitchCase` (=`AST_SWITCH_CASE`). Here `PHPSwitchStatement` extends the base class `SwitchStatement`.

Switch statements in PHP ASTs are represented like so:
* A `PHPSwitchStatement` has an expression and a switch list;
* a `PHPSwitchList` has an arbitrary number of switch cases;
* a  `PHPSwitchCase` has a value (matched against the evaluated expression) and a statement list.

Here, a `PHPSwitchCase` is pretty similar to a `PHPIfElement` in that it has a condition and a statement, except that the condition may only be a value (not an expression), and the statement is *always* a compound statement: I checked. :wink: A `PHPSwitchList` is pretty similar to a `PHPIfStatement` in that it has an abritrary number of `PHPSwitchCase`s, resp. `PHPIfElement`s. Also see PR #79.

Additionaly, there is the `PHPSwitchStatement` which has a `PHPSwitchList` child and additionally has an expression child that is evaluated by the parser and matched against the individual `PHPSwitchCase`'s value children.

**Support for break and continue statements**

There are two new classes: `PHPBreakStatement` (=`AST_BREAK`) and `PHPContinueStatement` (=`AST_CONTINUE`) which extend `BreakStatement` and `ContinueStatement`, respectively.

The reason that I had to create extending classes instead of using the base classes is that PHP's `break` and `continue` statements may have an optional numeric argument, denoting the number of enclosing structures to be broken out of, resp. the number of enclosing loops to be skipped to the end of.

As per the approach detailed in issue #80, I thus created extending classes that declare an additional `depth` field referencing the `depth` child, with corresponding getters and setters. C world does not know of such a thing, so it should not be in the base class.

**Support for return statements**

In this case `AST_RETURN` is mapped to the base class `ReturnStatement`, no new classes.

However, I did enrich the `ReturnStatement` with a `returnExpression` field referencing the child that contains the expression being returned (if there is one), and corresponding getters and setters. In this case I chose to enrich the base class instead of creating an extending PHP-aware class, since return expressions also occur in C and other languages, so it makes sense to have this in the base class.

But I wonder: How is a return statement's expression handled in C world? Using some generic `addChild(ASTNode`) and `getChild(0)` calls, perhaps? In this case, it might be nicer to refactor `ReturnStatement` to override the method `addChild(ASTNode)` (as other node classes do, too)  and have it also set the `returnExpression`. This would be consistent with C world's behavior in other node classes, and would allow it to also use the `getReturnExpression()` method instead of using `getChild(0)` or so. It's only a suggestion and I admit it's rather cosmetic, but I'll add a comment to issue #80 in case you want to consider this. :smile:

**Support for label and goto statements**

Here also, `AST_LABEL` and `AST_GOTO` could be directly mapped onto the `Label` and `GotoStatement` base classes.

Exactly as with the return statements, I enriched the base class `Label` with a `name` field referencing the child that represents the label's name, with according getters and setters. And I enriched `GotoStatement` with a `label` field referencing the child that represent's the goto statement's target, with according getters and setters (`getLabelTarget()` and `setLabelTarget(ASTNode)`). Again, such fields were not present in the base class, but I think they make sense. So as with return statements, I would suggest refactoring these classes to override the `addChild(ASTNode)` method and have them set the corresponding field for C world, such that the getters can also be used by C world instead of a generic `getChild(0)`. Once again, I will add comments in issue #80 for your consideration.

One last note, the `GotoStatement` did have a method called `getTarget()` which returned the string `getChild(0).getEscapedCodeStr()`. I renamed it to `getTargetName()` for consistency and fixed `CCFGFactory` to account for that. If you want to make the changes suggested above, I would then also suggest to have this method return `getTargetLabel().getEscapedCodeStr()` instead. It would be more beautiful. :)
