### PR TITLE
Support for try/catch/finally and throw, as well as for ternary and coalesce expressions

### DIFF
--- a/src/ast/expressions/ArgumentList.java
+++ b/src/ast/expressions/ArgumentList.java
@@ -1,7 +1,33 @@
 package ast.expressions;
 
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
 import ast.statements.ExpressionHolder;
 
-public class ArgumentList extends ExpressionHolder
+public class ArgumentList extends ExpressionHolder implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
 {
+	
+	private LinkedList<ASTNode> arguments = new LinkedList<ASTNode>(); // TODO LinkedList<Expression>
+
+	public int size()
+	{
+		return this.arguments.size();
+	}
+	
+	public ASTNode getArgument(int i) { // TODO return type: Expression
+		return this.arguments.get(i);
+	}
+
+	public void addArgument(ASTNode argument) // TODO take an Expression
+	{
+		this.arguments.add(argument);
+		super.addChild(argument);
+	}
+	
+	@Override
+	public Iterator<ASTNode> iterator() {
+		return this.arguments.iterator();
+	}
 }

--- a/src/ast/expressions/ConditionalExpression.java
+++ b/src/ast/expressions/ConditionalExpression.java
@@ -1,6 +1,43 @@
 package ast.expressions;
 
+import ast.ASTNode;
+
 public class ConditionalExpression extends Expression
 {
+	protected ASTNode condition = null; // TODO change type to Expression once mapping is finished
+	protected ASTNode trueExpression = null; // TODO change type to Expression once mapping is finished
+	protected ASTNode falseExpression = null; // TODO change type to Expression once mapping is finished
 
+	public ASTNode getCondition()
+	{
+		return this.condition;
+	}
+
+	public void setCondition(ASTNode expression)
+	{
+		this.condition = expression;
+		super.addChild(expression);
+	}
+	
+	public ASTNode getTrueExpression()
+	{
+		return this.trueExpression;
+	}
+
+	public void setTrueExpression(ASTNode trueExpression)
+	{
+		this.trueExpression = trueExpression;
+		super.addChild(trueExpression);
+	}
+	
+	public ASTNode getFalseExpression()
+	{
+		return this.falseExpression;
+	}
+
+	public void setFalseExpression(ASTNode falseExpression)
+	{
+		this.falseExpression = falseExpression;
+		super.addChild(falseExpression);
+	}
 }

--- a/src/ast/php/expressions/PHPCoalesceExpression.java
+++ b/src/ast/php/expressions/PHPCoalesceExpression.java
@@ -1,0 +1,32 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPCoalesceExpression extends Expression
+{
+	protected ASTNode leftExpression = null;
+	protected ASTNode rightExpression = null;
+
+	public ASTNode getLeftExpression()
+	{
+		return this.leftExpression;
+	}
+
+	public void setLeftExpression(ASTNode leftExpression)
+	{
+		this.leftExpression = leftExpression;
+		super.addChild(leftExpression);
+	}
+
+	public ASTNode getRightExpression()
+	{
+		return this.rightExpression;
+	}
+
+	public void setRightExpression(ASTNode rightExpression)
+	{
+		this.rightExpression = rightExpression;
+		super.addChild(rightExpression);
+	}
+}

--- a/src/ast/statements/blockstarters/CatchList.java
+++ b/src/ast/statements/blockstarters/CatchList.java
@@ -1,0 +1,32 @@
+package ast.statements.blockstarters;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+
+public class CatchList extends ASTNode implements Iterable<CatchStatement>
+{
+	
+	private LinkedList<CatchStatement> catchStatements = new LinkedList<CatchStatement>();
+
+	public int size()
+	{
+		return this.catchStatements.size();
+	}
+	
+	public CatchStatement getCatchStatement(int i) {
+		return this.catchStatements.get(i);
+	}
+
+	public void addCatchStatement(CatchStatement catchStatement)
+	{
+		this.catchStatements.add(catchStatement);
+		super.addChild(catchStatement);
+	}
+
+	@Override
+	public Iterator<CatchStatement> iterator() {
+		return this.catchStatements.iterator();
+	}
+}

--- a/src/ast/statements/blockstarters/CatchStatement.java
+++ b/src/ast/statements/blockstarters/CatchStatement.java
@@ -1,10 +1,50 @@
 package ast.statements.blockstarters;
 
+import ast.ASTNode;
+import ast.expressions.Identifier;
 import ast.logical.statements.BlockStarter;
+import ast.logical.statements.CompoundStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class CatchStatement extends BlockStarter
 {
+	private Identifier exceptionIdentifier = null;
+	private ASTNode variableName = null;
+	private CompoundStatement content = null;
+
+	public Identifier getExceptionIdentifier()
+	{
+		return this.exceptionIdentifier;
+	}
+	
+	public void setExceptionIdentifier(Identifier exceptionIdentifier)
+	{
+		this.exceptionIdentifier = exceptionIdentifier;
+		super.addChild(exceptionIdentifier);
+	}
+	
+	public ASTNode getVariableName()
+	{
+		return this.variableName;
+	}
+	
+	public void setVariableName(ASTNode variableName)
+	{
+		this.variableName = variableName;
+		super.addChild(variableName);
+	}
+	
+	public CompoundStatement getContent()
+	{
+		return this.content;
+	}
+	
+	public void setContent(CompoundStatement content)
+	{
+		this.content = content;
+		super.addChild(content);
+	}
+	
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/ast/statements/blockstarters/TryStatement.java
+++ b/src/ast/statements/blockstarters/TryStatement.java
@@ -1,9 +1,5 @@
 package ast.statements.blockstarters;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import ast.ASTNode;
 import ast.logical.statements.BlockStarter;
 import ast.logical.statements.CompoundStatement;
 import ast.walking.ASTNodeVisitor;
@@ -11,7 +7,7 @@ import ast.walking.ASTNodeVisitor;
 public class TryStatement extends BlockStarter
 {
 	private CompoundStatement content = null;
-	private CatchList catchList = null;
+	private CatchList catchList = new CatchList();
 	private CompoundStatement finallyContent = null;
 	
 	public CompoundStatement getContent()
@@ -52,63 +48,4 @@ public class TryStatement extends BlockStarter
 	{
 		visitor.visit(this);
 	}
-	
-	/*
-	 * TODO the fields catchNodes as well as the associated methods below should
-	 * be removed. It would be best for the outer world to only use getCatchList()
-	 * above, and use whatever methods the class CatchList offers, instead of having
-	 * the following methods handle catch nodes directly.
-	 */
-	private List<CatchStatement> catchNodes = new LinkedList<CatchStatement>();
-
-	public void addCatchNode(CatchStatement catchNode)
-	{
-		getCatchNodes().add(catchNode);
-	}
-
-	public List<CatchStatement> getCatchNodes()
-	{
-		return this.catchNodes;
-	}
-
-	public CatchStatement getCatchNode(int index)
-	{
-		return getCatchNodes().get(index);
-	}
-
-	/*
-	 * TODO exactly as with IfStatement which also overrides the
-	 * methods getChildCount() and getChild(int), the following two
-	 * overrides should be moved to an extending class CTryStatement or
-	 * similar since their behavior is inconsistent with the usual behavior
-	 * of these methods in ASTNode and confuses PHP world. What's worse, in
-	 * this case I cannot even create a PHPTryStatement that extends TryStatement
-	 * as there is no good reason for this except to restore the original behavior
-	 * of these methods, but that would be the wrong way to go about it (rather,
-	 * CTryStatement should override them on its own if it needs to.)
-	 * See comments in PHPIfStatement.
-	 */
-	
-	@Override
-	public int getChildCount()
-	{
-		return super.getChildCount() + getCatchNodes().size();
-	}
-
-	@Override
-	public ASTNode getChild(int i)
-	{
-		if (i == 0)
-			return getStatement();
-		else
-			try
-			{
-				return getCatchNode(i - 1);
-			} catch (IndexOutOfBoundsException e)
-			{
-				throw new RuntimeException(
-						"Invalid child number for try statement");
-			}
-	}
-
 }

--- a/src/ast/statements/blockstarters/TryStatement.java
+++ b/src/ast/statements/blockstarters/TryStatement.java
@@ -5,11 +5,60 @@ import java.util.List;
 
 import ast.ASTNode;
 import ast.logical.statements.BlockStarter;
+import ast.logical.statements.CompoundStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class TryStatement extends BlockStarter
 {
-
+	private CompoundStatement content = null;
+	private CatchList catchList = null;
+	private CompoundStatement finallyContent = null;
+	
+	public CompoundStatement getContent()
+	{
+		return this.content;
+	}
+	
+	public void setContent(CompoundStatement content)
+	{
+		this.content = content;
+		super.addChild(content);
+	}
+	
+	public CatchList getCatchList()
+	{
+		return this.catchList;
+	}
+	
+	public void setCatchList(CatchList catchList)
+	{
+		this.catchList = catchList;
+		super.addChild(catchList);
+	}
+	
+	public CompoundStatement getFinallyContent()
+	{
+		return this.finallyContent;
+	}
+	
+	public void setFinallyContent(CompoundStatement finallyContent)
+	{
+		this.finallyContent = finallyContent;
+		super.addChild(finallyContent);
+	}
+	
+	@Override
+	public void accept(ASTNodeVisitor visitor)
+	{
+		visitor.visit(this);
+	}
+	
+	/*
+	 * TODO the fields catchNodes as well as the associated methods below should
+	 * be removed. It would be best for the outer world to only use getCatchList()
+	 * above, and use whatever methods the class CatchList offers, instead of having
+	 * the following methods handle catch nodes directly.
+	 */
 	private List<CatchStatement> catchNodes = new LinkedList<CatchStatement>();
 
 	public void addCatchNode(CatchStatement catchNode)
@@ -27,16 +76,26 @@ public class TryStatement extends BlockStarter
 		return getCatchNodes().get(index);
 	}
 
-	public void accept(ASTNodeVisitor visitor)
-	{
-		visitor.visit(this);
-	}
-
+	/*
+	 * TODO exactly as with IfStatement which also overrides the
+	 * methods getChildCount() and getChild(int), the following two
+	 * overrides should be moved to an extending class CTryStatement or
+	 * similar since their behavior is inconsistent with the usual behavior
+	 * of these methods in ASTNode and confuses PHP world. What's worse, in
+	 * this case I cannot even create a PHPTryStatement that extends TryStatement
+	 * as there is no good reason for this except to restore the original behavior
+	 * of these methods, but that would be the wrong way to go about it (rather,
+	 * CTryStatement should override them on its own if it needs to.)
+	 * See comments in PHPIfStatement.
+	 */
+	
+	@Override
 	public int getChildCount()
 	{
 		return super.getChildCount() + getCatchNodes().size();
 	}
 
+	@Override
 	public ASTNode getChild(int i)
 	{
 		if (i == 0)

--- a/src/ast/statements/jump/ThrowStatement.java
+++ b/src/ast/statements/jump/ThrowStatement.java
@@ -1,10 +1,24 @@
 package ast.statements.jump;
 
+import ast.ASTNode;
 import ast.logical.statements.JumpStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class ThrowStatement extends JumpStatement
 {
+	private ASTNode throwExpression = null;
+	
+	public ASTNode getThrowExpression()
+	{
+		return this.throwExpression;
+	}
+
+	public void setThrowExpression(ASTNode expression)
+	{
+		this.throwExpression = expression;
+		super.addChild(expression);
+	}
+	
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/languages/c/cfg/CCFGFactory.java
+++ b/src/languages/c/cfg/CCFGFactory.java
@@ -314,14 +314,14 @@ public class CCFGFactory extends CFGFactory
 				}
 			}
 
-			if (tryStatement.getCatchNodes() == null)
+			if (tryStatement.getCatchList().size() == 0)
 			{
 				System.err.println("warning: cannot find catch for try");
 				return tryCFG;
 			}
 
 			// Mount exception handlers
-			for (CatchStatement catchStatement : tryStatement.getCatchNodes())
+			for (CatchStatement catchStatement : tryStatement.getCatchList())
 			{
 				CCFG catchBlock = convert(catchStatement.getStatement());
 				tryCFG.mountCFG(tryCFG.getExceptionNode(), tryCFG.getExitNode(),

--- a/src/languages/c/parsing/Functions/builder/NestingReconstructor.java
+++ b/src/languages/c/parsing/Functions/builder/NestingReconstructor.java
@@ -132,8 +132,8 @@ public class NestingReconstructor
 					TryStatement tryStatement = (TryStatement) stack.getTry();
 					if (tryStatement != null)
 					{
-						tryStatement
-								.addCatchNode((CatchStatement) curBlockStarter);
+						tryStatement.getCatchList()
+								.addCatchStatement((CatchStatement) curBlockStarter);
 					} else
 						throw new RuntimeException(
 								"Warning: cannot find try for catch");

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.ASTNode;
+import ast.expressions.ArgumentList;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
@@ -1687,6 +1688,145 @@ public class TestPHPCSVASTBuilder
 	/* nodes with an arbitrary number of children */
 
 	/**
+	 * AST_ARG_LIST nodes are used to denote a list of arguments in a function call.
+	 * 
+	 * Any AST_ARG_LIST node has between 0 and an arbitrarily large number of children.
+	 * Each child corresponds to one argument in the list.
+	 * 
+	 * This test checks an argument list's children in the following PHP code:
+	 * 
+	 * foo($bar, "yabadabadoo");
+	 */
+	@Test
+	public void testArgumentListCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CALL,,3,,0,1,,,\n";
+		nodeStr += "4,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "6,AST_ARG_LIST,,3,,1,1,,,\n";
+		nodeStr += "7,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "8,string,,3,\"bar\",0,1,,,\n";
+		nodeStr += "9,string,,3,\"yabadabadoo\",1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)6);
+		
+		assertThat( node, instanceOf(ArgumentList.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( 2, ((ArgumentList)node).size());
+		assertEquals( ast.getNodeById((long)7), ((ArgumentList)node).getArgument(0));
+		assertEquals( ast.getNodeById((long)9), ((ArgumentList)node).getArgument(1));
+		for( ASTNode argument : (ArgumentList)node)
+			assertTrue( ast.containsValue(argument));
+	}
+	
+	/**
+	 * AST_EXPR_LIST nodes are used for holding a list of expressions, e.g.,
+	 * a list of initializations in a for-loop.
+	 * 
+	 * Any AST_EXPR_LIST node has between 1 and an arbitrarily large number
+	 * of children. Each child corresponds to one expression in the list.
+	 * TODO I am not sure at the moment whether there are situations where
+	 * an AST_EXPR_LIST with 0 children can be generated; I do not think so,
+	 * but look into it more closely.
+	 * 
+	 * This test checks an expression list's children in the following PHP code:
+	 * 
+	 * for ($i = 0, $j = 1; $i < 3; $i++, $j++) {}
+	 */
+	@Test
+	public void testExpressionList() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FOR,,3,,0,1,,,\n";
+		nodeStr += "4,AST_EXPR_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_ASSIGN,,3,,0,1,,,\n";
+		nodeStr += "6,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "7,string,,3,\"i\",0,1,,,\n";
+		nodeStr += "8,integer,,3,0,1,1,,,\n";
+		nodeStr += "9,AST_ASSIGN,,3,,1,1,,,\n";
+		nodeStr += "10,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "11,string,,3,\"j\",0,1,,,\n";
+		nodeStr += "12,integer,,3,1,1,1,,,\n";
+		nodeStr += "13,AST_EXPR_LIST,,3,,1,1,,,\n";
+		nodeStr += "14,AST_BINARY_OP,BINARY_IS_SMALLER,3,,0,1,,,\n";
+		nodeStr += "15,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "16,string,,3,\"i\",0,1,,,\n";
+		nodeStr += "17,integer,,3,3,1,1,,,\n";
+		nodeStr += "18,AST_EXPR_LIST,,3,,2,1,,,\n";
+		nodeStr += "19,AST_POST_INC,,3,,0,1,,,\n";
+		nodeStr += "20,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "21,string,,3,\"i\",0,1,,,\n";
+		nodeStr += "22,AST_POST_INC,,3,,1,1,,,\n";
+		nodeStr += "23,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "24,string,,3,\"j\",0,1,,,\n";
+		nodeStr += "25,AST_STMT_LIST,,3,,3,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "5,8,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "9,12,PARENT_OF\n";
+		edgeStr += "4,9,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "15,16,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "14,17,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "3,13,PARENT_OF\n";
+		edgeStr += "20,21,PARENT_OF\n";
+		edgeStr += "19,20,PARENT_OF\n";
+		edgeStr += "18,19,PARENT_OF\n";
+		edgeStr += "23,24,PARENT_OF\n";
+		edgeStr += "22,23,PARENT_OF\n";
+		edgeStr += "18,22,PARENT_OF\n";
+		edgeStr += "3,18,PARENT_OF\n";
+		edgeStr += "3,25,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)4);
+		ASTNode node2 = ast.getNodeById((long)13);
+		ASTNode node3 = ast.getNodeById((long)18);
+
+		assertThat( node, instanceOf(ExpressionList.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( 2, ((ExpressionList)node).size());
+		assertEquals( ast.getNodeById((long)5), ((ExpressionList)node).getExpression(0));
+		assertEquals( ast.getNodeById((long)9), ((ExpressionList)node).getExpression(1));
+		for( ASTNode expression : (ExpressionList)node) // TODO iterate over Expression's
+			assertTrue( ast.containsValue(expression));
+		
+		assertThat( node2, instanceOf(ExpressionList.class));
+		assertEquals( 1, node2.getChildCount());
+		assertEquals( 1, ((ExpressionList)node2).size());
+		assertEquals( ast.getNodeById((long)14), ((ExpressionList)node2).getExpression(0));
+		for( ASTNode expression : (ExpressionList)node2) // TODO iterate over Expression's
+			assertTrue( ast.containsValue(expression));
+		
+		assertThat( node3, instanceOf(ExpressionList.class));
+		assertEquals( 2, node3.getChildCount());
+		assertEquals( 2, ((ExpressionList)node3).size());
+		assertEquals( ast.getNodeById((long)19), ((ExpressionList)node3).getExpression(0));
+		assertEquals( ast.getNodeById((long)22), ((ExpressionList)node3).getExpression(1));
+		for( ASTNode expression : (ExpressionList)node3) // TODO iterate over Expression's
+			assertTrue( ast.containsValue(expression));
+	}
+	
+	/**
 	 * AST_STMT_LIST nodes are used to declare lists (or "blocks") of statements.
 	 * 
 	 * Any AST_STMT_LIST node has between 0 and an arbitrarily large number of children.
@@ -1969,7 +2109,7 @@ public class TestPHPCSVASTBuilder
 	}
 
 	/**
-	 * AST_PARAM_LIST nodes are used to dentoe a list of function parameters.
+	 * AST_PARAM_LIST nodes are used to denote a list of function parameters.
 	 * 
 	 * Any AST_PARAM_LIST node has between 0 and an arbitrarily large number of children.
 	 * Each child corresponds to one parameter in the list.
@@ -2120,101 +2260,5 @@ public class TestPHPCSVASTBuilder
 		assertEquals( ast.getNodeById((long)9), ((IdentifierList)node).getIdentifier(1));
 		for( Identifier identifier : (IdentifierList)node)
 			assertTrue( ast.containsValue(identifier));
-	}
-	
-	/**
-	 * AST_EXPR_LIST nodes are used for holding a list of expressions, e.g.,
-	 * a list of initializations in a for-loop.
-	 * 
-	 * Any AST_EXPR_LIST node has between 1 and an arbitrarily large number
-	 * of children. Each child corresponds to one expression in the list.
-	 * TODO I am not sure at the moment whether there are situations where
-	 * an AST_EXPR_LIST with 0 children can be generated; I do not think so,
-	 * but look into it more closely.
-	 * 
-	 * This test checks an expression list's children in the following PHP code:
-	 * 
-	 * for ($i = 0, $j = 1; $i < 3; $i++, $j++) {}
-	 */
-	@Test
-	public void testExpressionList() throws IOException, InvalidCSVFile
-	{
-		String nodeStr = nodeHeader;
-		nodeStr += "3,AST_FOR,,3,,0,1,,,\n";
-		nodeStr += "4,AST_EXPR_LIST,,3,,0,1,,,\n";
-		nodeStr += "5,AST_ASSIGN,,3,,0,1,,,\n";
-		nodeStr += "6,AST_VAR,,3,,0,1,,,\n";
-		nodeStr += "7,string,,3,\"i\",0,1,,,\n";
-		nodeStr += "8,integer,,3,0,1,1,,,\n";
-		nodeStr += "9,AST_ASSIGN,,3,,1,1,,,\n";
-		nodeStr += "10,AST_VAR,,3,,0,1,,,\n";
-		nodeStr += "11,string,,3,\"j\",0,1,,,\n";
-		nodeStr += "12,integer,,3,1,1,1,,,\n";
-		nodeStr += "13,AST_EXPR_LIST,,3,,1,1,,,\n";
-		nodeStr += "14,AST_BINARY_OP,BINARY_IS_SMALLER,3,,0,1,,,\n";
-		nodeStr += "15,AST_VAR,,3,,0,1,,,\n";
-		nodeStr += "16,string,,3,\"i\",0,1,,,\n";
-		nodeStr += "17,integer,,3,3,1,1,,,\n";
-		nodeStr += "18,AST_EXPR_LIST,,3,,2,1,,,\n";
-		nodeStr += "19,AST_POST_INC,,3,,0,1,,,\n";
-		nodeStr += "20,AST_VAR,,3,,0,1,,,\n";
-		nodeStr += "21,string,,3,\"i\",0,1,,,\n";
-		nodeStr += "22,AST_POST_INC,,3,,1,1,,,\n";
-		nodeStr += "23,AST_VAR,,3,,0,1,,,\n";
-		nodeStr += "24,string,,3,\"j\",0,1,,,\n";
-		nodeStr += "25,AST_STMT_LIST,,3,,3,1,,,\n";
-
-		String edgeStr = edgeHeader;
-		edgeStr += "6,7,PARENT_OF\n";
-		edgeStr += "5,6,PARENT_OF\n";
-		edgeStr += "5,8,PARENT_OF\n";
-		edgeStr += "4,5,PARENT_OF\n";
-		edgeStr += "10,11,PARENT_OF\n";
-		edgeStr += "9,10,PARENT_OF\n";
-		edgeStr += "9,12,PARENT_OF\n";
-		edgeStr += "4,9,PARENT_OF\n";
-		edgeStr += "3,4,PARENT_OF\n";
-		edgeStr += "15,16,PARENT_OF\n";
-		edgeStr += "14,15,PARENT_OF\n";
-		edgeStr += "14,17,PARENT_OF\n";
-		edgeStr += "13,14,PARENT_OF\n";
-		edgeStr += "3,13,PARENT_OF\n";
-		edgeStr += "20,21,PARENT_OF\n";
-		edgeStr += "19,20,PARENT_OF\n";
-		edgeStr += "18,19,PARENT_OF\n";
-		edgeStr += "23,24,PARENT_OF\n";
-		edgeStr += "22,23,PARENT_OF\n";
-		edgeStr += "18,22,PARENT_OF\n";
-		edgeStr += "3,18,PARENT_OF\n";
-		edgeStr += "3,25,PARENT_OF\n";
-
-		handle(nodeStr, edgeStr);
-
-		ASTNode node = ast.getNodeById((long)4);
-		ASTNode node2 = ast.getNodeById((long)13);
-		ASTNode node3 = ast.getNodeById((long)18);
-
-		assertThat( node, instanceOf(ExpressionList.class));
-		assertEquals( 2, node.getChildCount());
-		assertEquals( 2, ((ExpressionList)node).size());
-		assertEquals( ast.getNodeById((long)5), ((ExpressionList)node).getExpression(0));
-		assertEquals( ast.getNodeById((long)9), ((ExpressionList)node).getExpression(1));
-		for( ASTNode expression : (ExpressionList)node) // TODO iterate over Expression's
-			assertTrue( ast.containsValue(expression));
-		
-		assertThat( node2, instanceOf(ExpressionList.class));
-		assertEquals( 1, node2.getChildCount());
-		assertEquals( 1, ((ExpressionList)node2).size());
-		assertEquals( ast.getNodeById((long)14), ((ExpressionList)node2).getExpression(0));
-		for( ASTNode expression : (ExpressionList)node2) // TODO iterate over Expression's
-			assertTrue( ast.containsValue(expression));
-		
-		assertThat( node3, instanceOf(ExpressionList.class));
-		assertEquals( 2, node3.getChildCount());
-		assertEquals( 2, ((ExpressionList)node3).size());
-		assertEquals( ast.getNodeById((long)19), ((ExpressionList)node3).getExpression(0));
-		assertEquals( ast.getNodeById((long)22), ((ExpressionList)node3).getExpression(1));
-		for( ASTNode expression : (ExpressionList)node3) // TODO iterate over Expression's
-			assertTrue( ast.containsValue(expression));
 	}
 }

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -37,6 +37,8 @@ import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPSwitchStatement;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.blockstarters.CatchList;
+import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -1241,6 +1243,79 @@ public class TestPHPCSVASTBuilder
 	/* nodes with exactly 3 children */
 	
 	/**
+	 * AST_CATCH nodes are used for catch statements.
+	 * 
+	 * Any AST_CATCH node has exactly three children:
+	 * 1) AST_NAME, representing the exception's name
+	 * 2) string, indicating the variable name holding the exception 
+	 * 3) AST_STMT_LIST, representing the catch statement's content
+	 * 
+	 * This test checks a few catch statements' children in the following PHP code:
+	 * 
+	 * try {}
+	 * catch(FooException $f) {}
+	 * catch(BarException $b) {}
+	 * finally {}
+	 */
+	@Test
+	public void testCatchCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_TRY,,3,,0,1,,,\n";
+		nodeStr += "4,AST_STMT_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CATCH_LIST,,3,,1,1,,,\n";
+		nodeStr += "6,AST_CATCH,,4,,0,1,,,\n";
+		nodeStr += "7,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "8,string,,4,\"FooException\",0,1,,,\n";
+		nodeStr += "9,string,,4,\"f\",1,1,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,1,,,\n";
+		nodeStr += "11,AST_CATCH,,5,,1,1,,,\n";
+		nodeStr += "12,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "13,string,,5,\"BarException\",0,1,,,\n";
+		nodeStr += "14,string,,5,\"b\",1,1,,,\n";
+		nodeStr += "15,AST_STMT_LIST,,5,,2,1,,,\n";
+		nodeStr += "16,AST_STMT_LIST,,6,,2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "6,10,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "11,14,PARENT_OF\n";
+		edgeStr += "11,15,PARENT_OF\n";
+		edgeStr += "5,11,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,16,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)6);
+		ASTNode node2 = ast.getNodeById((long)11);
+		
+		assertThat( node, instanceOf(CatchStatement.class));
+		assertEquals( 3, node.getChildCount());
+		assertEquals( ast.getNodeById((long)7), ((CatchStatement)node).getExceptionIdentifier());
+		assertEquals( ast.getNodeById((long)8), ((CatchStatement)node).getExceptionIdentifier().getNameChild());
+		assertEquals( "FooException", ((CatchStatement)node).getExceptionIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)9), ((CatchStatement)node).getVariableName());
+		assertEquals( "f", ((CatchStatement)node).getVariableName().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)10), ((CatchStatement)node).getContent());
+		
+		assertThat( node2, instanceOf(CatchStatement.class));
+		assertEquals( 3, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)12), ((CatchStatement)node2).getExceptionIdentifier());
+		assertEquals( ast.getNodeById((long)13), ((CatchStatement)node2).getExceptionIdentifier().getNameChild());
+		assertEquals( "BarException", ((CatchStatement)node2).getExceptionIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)14), ((CatchStatement)node2).getVariableName());
+		assertEquals( "b", ((CatchStatement)node2).getVariableName().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)15), ((CatchStatement)node2).getContent());
+	}
+
+	/**
 	 * AST_PARAM nodes are used for function parameters.
 	 * 
 	 * Any AST_PARAM node has exactly three children:
@@ -1691,7 +1766,68 @@ public class TestPHPCSVASTBuilder
 	}
 	
 	/**
-	 * AST_PARAM_LIST nodes are used for function parameters.
+	 * AST_CATCH_LIST nodes are used to denote a list of catch statements.
+	 * 
+	 * Any AST_CATCH_LIST node has between 0 and an arbitrarily large number of children.
+	 * Each child corresponds to one catch statement in the list.
+	 * 
+	 * This test checks a catch list's children in the following PHP code:
+	 * 
+	 * try {}
+	 * catch(FooException $f) {}
+	 * catch(BarException $b) {}
+	 * finally {}
+	 */
+	@Test
+	public void testCatchListCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_TRY,,3,,0,1,,,\n";
+		nodeStr += "4,AST_STMT_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CATCH_LIST,,3,,1,1,,,\n";
+		nodeStr += "6,AST_CATCH,,4,,0,1,,,\n";
+		nodeStr += "7,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "8,string,,4,\"FooException\",0,1,,,\n";
+		nodeStr += "9,string,,4,\"f\",1,1,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,1,,,\n";
+		nodeStr += "11,AST_CATCH,,5,,1,1,,,\n";
+		nodeStr += "12,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "13,string,,5,\"BarException\",0,1,,,\n";
+		nodeStr += "14,string,,5,\"b\",1,1,,,\n";
+		nodeStr += "15,AST_STMT_LIST,,5,,2,1,,,\n";
+		nodeStr += "16,AST_STMT_LIST,,6,,2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "6,10,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "11,14,PARENT_OF\n";
+		edgeStr += "11,15,PARENT_OF\n";
+		edgeStr += "5,11,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,16,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)5);
+		
+		assertThat( node, instanceOf(CatchList.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( 2, ((CatchList)node).size());
+		
+		assertEquals( ast.getNodeById((long)6), ((CatchList)node).getCatchStatement(0));
+		assertEquals( ast.getNodeById((long)11), ((CatchList)node).getCatchStatement(1));
+		for( CatchStatement catchstatement : (CatchList)node)
+			assertTrue( ast.containsValue(catchstatement));
+	}
+
+	/**
+	 * AST_PARAM_LIST nodes are used to dentoe a list of function parameters.
 	 * 
 	 * Any AST_PARAM_LIST node has between 0 and an arbitrarily large number of children.
 	 * Each child corresponds to one parameter in the list.

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -24,6 +24,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
@@ -765,6 +766,42 @@ public class TestPHPCSVASTBuilder
 	
 
 	/* nodes with exactly 2 children */
+	
+	/**
+	 * AST_COALESCE nodes are used to represent coalesce expressions, i.e., expressions
+	 * using the ?? operator.
+	 * 
+	 * Any AST_COALESCE node has exactly two children:
+	 * 1) various possible types (including plain nodes), representing
+	 *    the expression on the left side
+	 * 2) various possible types (including plain nodes), representing
+	 *    the expression on the right side
+	 * 
+	 * This test checks a coalesce expression's children in the following PHP code:
+	 * 
+	 * "foo" ?? "bar";
+	 */
+	@Test
+	public void testCoalesceCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_COALESCE,,3,,0,1,,,\n";
+		nodeStr += "4,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "5,string,,3,\"bar\",1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PHPCoalesceExpression.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PHPCoalesceExpression)node).getLeftExpression());
+		assertEquals( ast.getNodeById((long)5), ((PHPCoalesceExpression)node).getRightExpression());
+	}
 	
 	/**
 	 * AST_WHILE nodes are used to declare while loops.

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.ASTNode;
+import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
@@ -1242,6 +1243,48 @@ public class TestPHPCSVASTBuilder
 
 	
 	/* nodes with exactly 3 children */
+	
+	/**
+	 * AST_CONDITIONAL nodes are used to represent conditional expressions using the ?: operator,
+	 * also known as the ternary conditional operator.
+	 * 
+	 * Any AST_CONDITIONAL node has exactly three children:
+	 * 1) an expression representing the conditional
+	 * 2) an expression representing the true branch, or NULL
+	 * 3) an expression representing the false branch
+	 * 
+	 * This test checks a conditional expression's children in the following PHP code:
+	 * 
+	 * true ? "foo" : "bar";
+	 */
+	@Test
+	public void testConditionalCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CONDITIONAL,,3,,0,1,,,\n";
+		nodeStr += "4,AST_CONST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "6,string,,3,\"true\",0,1,,,\n";
+		nodeStr += "7,string,,3,\"foo\",1,1,,,\n";
+		nodeStr += "8,string,,3,\"bar\",2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,7,PARENT_OF\n";
+		edgeStr += "3,8,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(ConditionalExpression.class));
+		assertEquals( 3, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((ConditionalExpression)node).getCondition());
+		assertEquals( ast.getNodeById((long)7), ((ConditionalExpression)node).getTrueExpression());
+		assertEquals( ast.getNodeById((long)8), ((ConditionalExpression)node).getFalseExpression());
+	}
 	
 	/**
 	 * AST_TRY nodes are used for try statements.

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -41,6 +41,7 @@ import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
+import ast.statements.blockstarters.TryStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
@@ -1241,6 +1242,67 @@ public class TestPHPCSVASTBuilder
 
 	
 	/* nodes with exactly 3 children */
+	
+	/**
+	 * AST_TRY nodes are used for try statements.
+	 * 
+	 * Any AST_TRY node has exactly three children:
+	 * 1) AST_STMT_LIST, representing the code to be "tried"
+	 * 2) AST_CATCH_LIST, representing the list of catch statements, i.e.,
+	 *    the list of caught exceptions.
+	 * 3) AST_STMT_LIST or NULL, representing a finally statement, if it exists.
+	 * 
+	 * This test checks a few catch statements' children in the following PHP code:
+	 * 
+	 * try {}
+	 * catch(FooException $f) {}
+	 * catch(BarException $b) {}
+	 * finally {}
+	 */
+	@Test
+	public void testTryCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_TRY,,3,,0,1,,,\n";
+		nodeStr += "4,AST_STMT_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CATCH_LIST,,3,,1,1,,,\n";
+		nodeStr += "6,AST_CATCH,,4,,0,1,,,\n";
+		nodeStr += "7,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "8,string,,4,\"FooException\",0,1,,,\n";
+		nodeStr += "9,string,,4,\"f\",1,1,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,1,,,\n";
+		nodeStr += "11,AST_CATCH,,5,,1,1,,,\n";
+		nodeStr += "12,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "13,string,,5,\"BarException\",0,1,,,\n";
+		nodeStr += "14,string,,5,\"b\",1,1,,,\n";
+		nodeStr += "15,AST_STMT_LIST,,5,,2,1,,,\n";
+		nodeStr += "16,AST_STMT_LIST,,6,,2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "6,10,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "11,14,PARENT_OF\n";
+		edgeStr += "11,15,PARENT_OF\n";
+		edgeStr += "5,11,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,16,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(TryStatement.class));
+		assertEquals( 3, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((TryStatement)node).getContent());
+		assertEquals( ast.getNodeById((long)5), ((TryStatement)node).getCatchList());
+		assertEquals( ast.getNodeById((long)16), ((TryStatement)node).getFinallyContent());
+	}
 	
 	/**
 	 * AST_CATCH nodes are used for catch statements.

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -29,6 +29,7 @@ import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
+import ast.statements.blockstarters.TryStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.ReturnStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
@@ -491,6 +492,43 @@ public class TestPHPCSVASTBuilderMinimal
 
 
 	/* nodes with exactly 3 children */
+	
+	/**
+	 * try {}
+	 * catch(Exception $e) {}
+	 */
+	@Test
+	public void testMinimalTryCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_TRY,,3,,0,1,,,\n";
+		nodeStr += "4,AST_STMT_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CATCH_LIST,,3,,1,1,,,\n";
+		nodeStr += "6,AST_CATCH,,4,,0,1,,,\n";
+		nodeStr += "7,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "8,string,,4,\"Exception\",0,1,,,\n";
+		nodeStr += "9,string,,4,\"e\",1,1,,,\n";
+		nodeStr += "10,AST_STMT_LIST,,4,,2,1,,,\n";
+		nodeStr += "11,NULL,,3,,2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "6,9,PARENT_OF\n";
+		edgeStr += "6,10,PARENT_OF\n";
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,11,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(TryStatement.class));
+		assertEquals( 3, node.getChildCount());
+		assertNull( ((TryStatement)node).getFinallyContent());
+	}
 	
 	/**
 	 * function foo($bar) {}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.ASTNode;
+import ast.expressions.ArgumentList;
 import ast.expressions.ConditionalExpression;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -676,6 +677,32 @@ public class TestPHPCSVASTBuilderMinimal
 
 	/* nodes with an arbitrary number of children */
 
+	/**
+	 * foo();
+	 */
+	@Test
+	public void testMinimalArgumentListCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CALL,,3,,0,1,,,\n";
+		nodeStr += "4,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "6,AST_ARG_LIST,,3,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)6);
+		
+		assertThat( node, instanceOf(ArgumentList.class));
+		assertEquals( 0, node.getChildCount());
+		assertEquals( 0, ((ArgumentList)node).size());
+	}
+	
 	/**
 	 * <empty file>
 	 */

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.ASTNode;
+import ast.expressions.ConditionalExpression;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
@@ -493,6 +494,41 @@ public class TestPHPCSVASTBuilderMinimal
 
 	/* nodes with exactly 3 children */
 	
+	/**
+	 * true ?: "bar";
+	 */
+	@Test
+	public void testMinimalConditionalCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CONDITIONAL,,3,,0,1,,,\n";
+		nodeStr += "4,AST_CONST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
+		nodeStr += "6,string,,3,\"true\",0,1,,,\n";
+		nodeStr += "7,NULL,,3,,1,1,,,\n";
+		nodeStr += "8,string,,3,\"bar\",2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,7,PARENT_OF\n";
+		edgeStr += "3,8,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(ConditionalExpression.class));
+		assertEquals( 3, node.getChildCount());
+		// TODO ((ConditionalExpression)node).getTrueExpression() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because ConditionalExpression accepts arbitrary ASTNode's for true expressions,
+		// when we actually only want to accept expressions. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((ConditionalExpression)node).getTrueExpression().getProperty("type"));
+	}
+
 	/**
 	 * try {}
 	 * catch(Exception $e) {}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -26,6 +26,7 @@ import ast.php.statements.blockstarters.PHPSwitchCase;
 import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -645,6 +646,33 @@ public class TestPHPCSVASTBuilderMinimal
 		assertThat( node, instanceOf(PHPSwitchList.class));
 		assertEquals( 0, node.getChildCount());
 		assertEquals( 0, ((PHPSwitchList)node).size());
+	}
+	
+	/**
+	 * try {}
+	 * finally {}
+	 */
+	@Test
+	public void testMinimalCatchListCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_TRY,,3,,0,1,,,\n";
+		nodeStr += "4,AST_STMT_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CATCH_LIST,,3,,1,1,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,4,,2,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)5);
+		
+		assertThat( node, instanceOf(CatchList.class));
+		assertEquals( 0, node.getChildCount());
+		assertEquals( 0, ((CatchList)node).size());
 	}
 	
 	/**

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -25,6 +25,8 @@ import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPSwitchStatement;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.blockstarters.CatchList;
+import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -126,6 +128,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_CATCH:
+				errno = handleCatch((CatchStatement)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_PARAM:
 				errno = handleParameter((PHPParameter)startNode, endNode, childnum);
 				break;
@@ -150,6 +155,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SWITCH_LIST:
 				errno = handleSwitchList((PHPSwitchList)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CATCH_LIST:
+				errno = handleCatchList((CatchList)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
 				errno = handleParameterList((ParameterList)startNode, endNode, childnum);
@@ -597,6 +605,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 3 children */
 	
+	private int handleCatch( CatchStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // exception child: Identifier node
+				startNode.setExceptionIdentifier((Identifier)endNode);
+				break;
+			case 1: // varName child: plain node
+				startNode.setVariableName(endNode);
+				break;
+			case 2: // stmts child: CompoundStatement node
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
 	private int handleParameter( PHPParameter startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
@@ -716,6 +747,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleSwitchList( PHPSwitchList startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addSwitchCase((PHPSwitchCase)endNode);
+
+		return 0;
+	}
+	
+	private int handleCatchList( CatchList startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addCatchStatement((CatchStatement)endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1,6 +1,7 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
+import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
@@ -129,6 +130,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_CONDITIONAL:
+				errno = handleConditional((ConditionalExpression)startNode, endNode, childnum);
+				break;
+				
 			case PHPCSVNodeTypes.TYPE_TRY:
 				errno = handleTry((TryStatement)startNode, endNode, childnum);
 				break;
@@ -608,6 +613,39 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 
 	/* nodes with exactly 3 children */
+	
+	private int handleConditional( ConditionalExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // cond child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change ConditionalExpression.condition to be an Expression instead
+				// of a generic ASTNode, and getCondition() and setCondition() accordingly
+				startNode.setCondition(endNode);
+				break;
+			case 1: // trueExpr child: Expression node or NULL
+				// TODO in time, we should be able to cast endNode to Expression, unless it is NULL;
+				// then, use an appropriate case distinction here,
+				// and change ConditionalExpression.trueExpression to be an Expression instead
+				// of a generic ASTNode, and getTrueExpression() and getTrueExpression() accordingly
+				startNode.setTrueExpression(endNode);
+				break;
+			case 2: // falseExpr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change ConditionalExpression.falseExpression to be an Expression instead
+				// of a generic ASTNode, and getFalseExpression() and getFalseExpression() accordingly
+				startNode.setFalseExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
 	
 	private int handleTry( TryStatement startNode, ASTNode endNode, int childnum)
 	{

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -30,6 +30,7 @@ import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
+import ast.statements.jump.ThrowStatement;
 import inputModules.csv.KeyedCSV.KeyedCSVRow;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.ASTUnderConstruction;
@@ -93,6 +94,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_LABEL:
 				errno = handleLabel((Label)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_THROW:
+				errno = handleThrow((ThrowStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_GOTO:
 				errno = handleGoto((GotoStatement)startNode, endNode, childnum);
@@ -380,6 +384,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // name child
 				startNode.setNameChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleThrow( ThrowStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setThrowExpression(endNode);
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change ThrowStatement.throwExpression to be an Expression instead
+				// of a generic ASTNode, and getThrowExpression() and setThrowExpression() accordingly
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -12,6 +12,7 @@ import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.logical.statements.Statement;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
@@ -113,6 +114,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			case PHPCSVNodeTypes.TYPE_COALESCE:
+				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
+				break;
+
 			case PHPCSVNodeTypes.TYPE_WHILE:
 				errno = handleWhile((WhileStatement)startNode, endNode, childnum);
 				break;
@@ -484,6 +489,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 2 children */
 
+	private int handleCoalesce( PHPCoalesceExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // left child: Expression or plain node
+				startNode.setLeftExpression(endNode);
+				break;
+			case 1: // right child: Expression or plain node
+				startNode.setRightExpression(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
 	private int handleWhile( WhileStatement startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1,6 +1,7 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
+import ast.expressions.ArgumentList;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
@@ -158,6 +159,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 				
 			// nodes with an arbitrary number of children
+			case PHPCSVNodeTypes.TYPE_ARG_LIST:
+				errno = handleArgumentList((ArgumentList)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
 				errno = handleExpressionList((ExpressionList)startNode, endNode, childnum);
 				break;
@@ -815,6 +819,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	
 	
 	/* nodes with an arbitrary number of children */
+	
+	private int handleArgumentList( ArgumentList startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addArgument(endNode); // TODO cast to Expression
+
+		return 0;
+	}
 	
 	private int handleExpressionList( ExpressionList startNode, ASTNode endNode, int childnum)
 	{

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -29,6 +29,7 @@ import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
+import ast.statements.blockstarters.TryStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
@@ -128,6 +129,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_TRY:
+				errno = handleTry((TryStatement)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_CATCH:
 				errno = handleCatch((CatchStatement)startNode, endNode, childnum);
 				break;
@@ -604,6 +608,32 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 
 	/* nodes with exactly 3 children */
+	
+	private int handleTry( TryStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // tryStmts child: CompoundStatement node
+				startNode.setContent((CompoundStatement)endNode);
+				break;
+			case 1: // catches child: CatchList node
+				startNode.setCatchList((CatchList)endNode);
+				break;
+			case 2: // finallyStmts child: CompoundStatement or NULL node
+				if( endNode instanceof CompoundStatement)
+					startNode.setFinallyContent((CompoundStatement)endNode);
+				else
+					startNode.addChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
 	
 	private int handleCatch( CatchStatement startNode, ASTNode endNode, int childnum)
 	{

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,6 +6,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
+import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
@@ -117,6 +118,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_CONDITIONAL:
+				retval = handleConditional(row, ast);
+				break;
+				
 			case PHPCSVNodeTypes.TYPE_TRY:
 				retval = handleTry(row, ast);
 				break;
@@ -661,6 +666,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 3 children */
 
+	private long handleConditional(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ConditionalExpression newNode = new ConditionalExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleTry(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		TryStatement newNode = new TryStatement();

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -16,6 +16,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
@@ -101,6 +102,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			case PHPCSVNodeTypes.TYPE_COALESCE:
+				retval = handleCoalesce(row, ast);
+				break;
+
 			case PHPCSVNodeTypes.TYPE_WHILE:
 				retval = handleWhile(row, ast);
 				break;
@@ -552,6 +557,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	
 	
 	/* nodes with exactly 2 children */
+	
+	private long handleCoalesce(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPCoalesceExpression newNode = new PHPCoalesceExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 	
 	private long handleWhile(KeyedCSVRow row, ASTUnderConstruction ast)
 	{

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -33,6 +33,7 @@ import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
+import ast.statements.blockstarters.TryStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
@@ -116,6 +117,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_TRY:
+				retval = handleTry(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_CATCH:
 				retval = handleCatch(row, ast);
 				break;
@@ -656,6 +660,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 
 	/* nodes with exactly 3 children */
+
+	private long handleTry(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		TryStatement newNode = new TryStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 	private long handleCatch(KeyedCSVRow row, ASTUnderConstruction ast)
 	{

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -29,6 +29,8 @@ import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPSwitchStatement;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.blockstarters.CatchList;
+import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
@@ -114,6 +116,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_CATCH:
+				retval = handleCatch(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_PARAM:
 				retval = handleParameter(row, ast);
 				break;
@@ -138,6 +143,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SWITCH_LIST:
 				retval = handleSwitchList(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CATCH_LIST:
+				retval = handleCatchList(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_PARAM_LIST:
 				retval = handleParameterList(row, ast);
@@ -649,6 +657,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 3 children */
 
+	private long handleCatch(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		CatchStatement newNode = new CatchStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleParameter(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPParameter newNode = new PHPParameter();
@@ -790,6 +820,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleSwitchList(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPSwitchList newNode = new PHPSwitchList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleCatchList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		CatchList newNode = new CatchList();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -34,6 +34,7 @@ import ast.statements.blockstarters.ForStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
 import ast.statements.jump.ReturnStatement;
+import ast.statements.jump.ThrowStatement;
 
 public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 {
@@ -81,6 +82,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_LABEL:
 				retval = handleLabel(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_THROW:
+				retval = handleThrow(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_GOTO:
 				retval = handleGoto(row, ast);
@@ -422,6 +426,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleLabel(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Label newNode = new Label();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleThrow(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ThrowStatement newNode = new ThrowStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,6 +6,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
+import ast.expressions.ArgumentList;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
@@ -146,6 +147,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with an arbitrary number of children
+			case PHPCSVNodeTypes.TYPE_ARG_LIST:
+				retval = handleArgumentList(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
 				retval = handleExpressionList(row, ast);
 				break;
@@ -831,6 +835,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	
 	/* nodes with an arbitrary number of children */
 
+	private long handleArgumentList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ArgumentList newNode = new ArgumentList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleExpressionList(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ExpressionList newNode = new ExpressionList();

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -49,6 +49,7 @@ public class PHPCSVNodeTypes
 	
 	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_LABEL = "AST_LABEL";
+	public static final String TYPE_THROW = "AST_THROW";
 	public static final String TYPE_GOTO = "AST_GOTO";
 	public static final String TYPE_BREAK = "AST_BREAK";
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -75,6 +75,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_FOREACH = "AST_FOREACH";
 
 	// nodes with an arbitrary number of children
+	public static final String TYPE_ARG_LIST = "AST_ARG_LIST";
 	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -62,6 +62,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 
 	// nodes with exactly 3 children
+	public static final String TYPE_TRY = "AST_TRY";
 	public static final String TYPE_CATCH = "AST_CATCH";
 	public static final String TYPE_PARAM = "AST_PARAM";
 

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -62,6 +62,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 
 	// nodes with exactly 3 children
+	public static final String TYPE_CATCH = "AST_CATCH";
 	public static final String TYPE_PARAM = "AST_PARAM";
 
 	// nodes with exactly 4 children
@@ -73,6 +74,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";
 	public static final String TYPE_SWITCH_LIST = "AST_SWITCH_LIST";
+	public static final String TYPE_CATCH_LIST = "AST_CATCH_LIST";
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
 	public static final String TYPE_CLOSURE_USES = "AST_CLOSURE_USES";
 	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -62,6 +62,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 
 	// nodes with exactly 3 children
+	public static final String TYPE_CONDITIONAL = "AST_CONDITIONAL";
+
 	public static final String TYPE_TRY = "AST_TRY";
 	public static final String TYPE_CATCH = "AST_CATCH";
 	public static final String TYPE_PARAM = "AST_PARAM";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 
 	// nodes with exactly 2 children
+	public static final String TYPE_COALESCE = "AST_COALESCE";
+	
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
 	public static final String TYPE_IF_ELEM = "AST_IF_ELEM";


### PR DESCRIPTION
Let's start from the simplest addition to the most complex addition.

**Support for throw statements**

Straightforward:
* `AST_THROW` -> `ast.statements.jump.ThrowStatement`

I added a `throwExpression` field to `ThrowStatement` with corresponding accessor methods. As in similar cases (e.g., `ReturnStatement`, `Label`), I would suggest refactoring C world to override `addChild(ASTNode)` and have it call `setThrowExpression(ASTNode)` as it similarly does for most nodes, to enable using `getThrowExpression()` instead of `getChild(0)` or so. I will add a corresponding comment to issue #80.

**Support for ternary and coalesce expressions**

* `AST_CONDITIONAL` -> `ast.expressions.ConditionalExpression`
* `AST_COALESCE` -> `ast.php.expressions.PHPCoalesceExpression`

Well, the conditional ternary operator also exists in C. The only thing to say about it is that, exactly as above, I extended `ConditionalExpression` with some global fields and accessors and I suggest refactoring C world blah. I will add a comment to #80.

One question concerning `ConditionalExpression`: I assume that, as is the case with, e.g., if-statements, a `ConditionalExpression` in itself does not constitute a CFG node (even when it is used as a statement). Rather, it declares three CFG nodes: a condition and a left and a right branch. Is that correct? So for example when we have a Groovy function called `isStatementOrPredicate()` in python-joern, we would consider the condition of a `ConditionalExpression` a "predicate", and the left and right branches "statements"? Even though they aren't really predicates or statements, but simply CFG nodes? I'm not complaining about the function name or anything, I only seek to understand the relationship between ternary operators and CFGs.

As far as the coalesce expression is concerned, it is similar to a conditional expression, but very PHP-specific, which is why I declared it as a new node type in the `ast.php.expressions` package. It has been introduced with PHP 7. See https://wiki.php.net/rfc/isset_ternary. I assume it will play a role very similar to that of conditional expressions during CFG generation.

**Support for try/catch/finally statements**

* `AST_CATCH` -> `ast.statements.blockstarters.CatchStatement`
* `AST_CATCH_LIST` -> `ast.statements.blockstarters.CatchList`
* `AST_TRY` -> `ast.statements.blockstarters.TryStatement`

This was kind of ugly and there are several things to say here.

1. A question first: I was surprised to see an existing `TryStatement` and an existing `CatchStatement`. As far as I know C does not have these constructs? Why was it there already? This confused the hell out of me. :wink: 

2. I added a `finallyContent` field with corresponding accessor methods to `TryStatement`. This was not there already, but I felt that it still made sense to put this in the base class instead of having a `PHPTryStatement` extending `TryStatement` with the only purpose of adding this field, since the concept of a *finally* block is general enough to be useful for other languages than PHP (e.g., Java, Python, ...).

3. It wouldn't have otherwise been a problem that these constructs are already there per se, but the way `TryStatement` was written was somewhat incompatible with PHP ASTs. Namely, for PHP ASTs, you can divide all nodes into two disjoint sets:
   * AST nodes that have a fixed number of children. These children must not necessarily all be of the same type. Most nodes fall into this category.
   * AST nodes with an arbitrary number of children. These children *all have the same type*. Examples include `AST_IF` nodes with their `AST_IF_ELEM` children (see PR #79), or `AST_PARAM_LIST` nodes with their `AST_PARAM` children (see PR #75). Or, in this instance, `AST_CATCH_LIST` nodes with their `AST_CATCH` children.

    Now, try statement nodes in PHP ASTs have exactly three children: a statement list representing the content of the *try* block; a catch list that contains catch statement children (representing the various *catch* blocks); and a statement list representing the content of the *finally* block. The problem was that the way `TryStatement` was written, it did not use a single child representing a list of catch nodes, but maintained catch nodes as immediate children. Thereby `TryStatement` could have an arbitrary number of children, though of different types (the first child was a `CompoundStatement` and all others were `CatchStatement`'s). This was not in line with the way PHP ASTs are built, and left me without a "good" possibility to map `AST_CATCH_LIST` nodes into Joern ASTs. This architecture also induced the presence of some ugly hacks in `TryStatement`: The method  `getChildCount()` had been overridden to return `super.getChildCount() + getCatchNodes().size()`, and `getChild(int i)` had been overridden to return `getCatchNode(i - 1)` unless `i` was equal to `0`. :confused: This was similar to the ugly case with `IfStatement` overriding these methods, see PR #79. But it was even worse here because I did not even have a good reason to have a `PHPTryStatement` extend `TryStatement` wherein I could have re-overridden these methods in order to restore the original behavior as I did with `PHPIfStatement` (which I had to create anyway because of the existence of `elseif` constructs.)
    I thus had to refactor the `TryStatement` class to use this intermediate abstraction layer, a `CatchList`. Since you cannot really use both approaches at the same time, I then also had to refactor C world to account for this new architecture, which was fortunately very easy. See commit 6b397718953b88f0e8d34212ff28d709715547f6. Indeed, the good news is that C world does not really need to "know" about this abstraction layer: Whether `TryStatement` maintains its *catch* blocks as a `java.util.LinkedList` or an `ast.statements.blockstarters.CatchList` shouldn't really bother the outer world at all. The only noticeable difference for C world will be that now, `TryStatement` always has two children: the try block and the catch list; whereas before, `TryStatement` could have a variable number of children. All tests were still passing, though; I assume that the number of children of a `TryStatement` was never tested anywhere. You should probably still have a look to make sure this is all fine. :blush: Note that for PHP ASTs, `TryStatement` always has three children, since there is the *finally* block, see point 2. It was also a side problem that the previous architecture did not really allow for a clean integration of such *finally* blocks.
    Thank you for making it through this lengthy paragraph.

4. One last note. While doing the refactoring in C world, I noticed this strange condition in `CCFGFactory`:
    `if (tryStatement.getCatchNodes() == null)`
    However, this did not make any sense, because `TryStatement` globally declared
    `private List<CatchStatement> catchNodes = new LinkedList<CatchStatement>();`
    So `getCatchNodes()` would never return `null`, and thus the code under that if-statement in `CCFGFactory` was unreachable. I now replaced the condition with
    `if (tryStatement.getCatchList().size() == 0)`
    which I assume is what was meant. But maybe I missed something?

I hope you enjoyed today's essay. :wink: This PR should, I think, wrap up all node types where CFG generation is non-trivial because they involve CFG edges other than ε-edges. :blush: 