### PR TITLE
Support for call, static call and method call expressions

### DIFF
--- a/src/ast/expressions/CallExpression.java
+++ b/src/ast/expressions/CallExpression.java
@@ -32,7 +32,20 @@ public class CallExpression extends PostfixExpression
 	@Override
 	public void addChild(ASTNode node)
 	{
-		if (node instanceof Identifier)
+		if (this.getClass().equals(CallExpression.class) &&
+				node instanceof Identifier)
+			// TODO refactor C world:
+			// 1. create a CCallExpression extending CallExpression
+			// 2. move addChild method to CCallExpression
+			// 3. remove ugly this.getClass().equals(CallExpression.class) condition above
+			// -> The only reason why we have to use that condition above is that we only want to call
+			// setTarget((Identifier)node) here to set the target method name of CallExpressions in C world,
+			// but not in PHP world (PHP world calls setTarget(ASTNode) directly).
+			// That is, the addChild(ASTNode) override is unnecessary in PHP world, and in particular
+			// its presence even *hurts* for PHP's StaticCallExpression, since there, without the ugly
+			// condition above to make sure we are not in a subclass, it would have the
+			// effect of calling the setTarget() method with the *class* name of the called method;
+			// see StaticCallExpression.setTargetClass(Identifier)
 			setTarget((Identifier)node);
 		else if (node instanceof ArgumentList)
 			setArgumentList((ArgumentList)node);

--- a/src/ast/expressions/CallExpression.java
+++ b/src/ast/expressions/CallExpression.java
@@ -4,18 +4,18 @@ import ast.ASTNode;
 
 public class CallExpression extends PostfixExpression
 {
-	private ASTNode target = null; // TODO change type to Expression once the mapping is finished
+	private ASTNode targetFunc = null; // TODO change type to Expression once the mapping is finished
 	private ArgumentList argumentList = null;
 	
-	public ASTNode getTarget() // TODO change type to Expression
+	public ASTNode getTargetFunc() // TODO change type to Expression
 	{
-		return this.target;
+		return this.targetFunc;
 	}
 	
-	public void setTarget(ASTNode target) // TODO change type to Expression
+	public void setTargetFunc(ASTNode targetFunc) // TODO change type to Expression
 	{
-		this.target = target;
-		super.addChild(target);
+		this.targetFunc = targetFunc;
+		super.addChild(targetFunc);
 	}
 	
 	public ArgumentList getArgumentList()
@@ -39,14 +39,14 @@ public class CallExpression extends PostfixExpression
 			// 2. move addChild method to CCallExpression
 			// 3. remove ugly this.getClass().equals(CallExpression.class) condition above
 			// -> The only reason why we have to use that condition above is that we only want to call
-			// setTarget((Identifier)node) here to set the target method name of CallExpressions in C world,
-			// but not in PHP world (PHP world calls setTarget(ASTNode) directly).
+			// setTargetFunc((Identifier)node) here to set the target function name of CallExpressions in C world,
+			// but not in PHP world (PHP world calls setTargetFunc(ASTNode) directly).
 			// That is, the addChild(ASTNode) override is unnecessary in PHP world, and in particular
 			// its presence even *hurts* for PHP's StaticCallExpression, since there, without the ugly
 			// condition above to make sure we are not in a subclass, it would have the
-			// effect of calling the setTarget() method with the *class* name of the called method;
+			// effect of calling the setTargetFunc() method with the *class* name of the called method;
 			// see StaticCallExpression.setTargetClass(Identifier)
-			setTarget((Identifier)node);
+			setTargetFunc((Identifier)node);
 		else if (node instanceof ArgumentList)
 			setArgumentList((ArgumentList)node);
 		else

--- a/src/ast/expressions/CallExpression.java
+++ b/src/ast/expressions/CallExpression.java
@@ -1,13 +1,42 @@
 package ast.expressions;
 
+import ast.ASTNode;
+
 public class CallExpression extends PostfixExpression
 {
-
-	public Expression getTarget()
+	private ASTNode target = null; // TODO change type to Expression once the mapping is finished
+	private ArgumentList argumentList = null;
+	
+	public ASTNode getTarget() // TODO change type to Expression
 	{
-		if (children == null)
-			return null;
-		return (Expression) children.get(0);
+		return this.target;
 	}
-
+	
+	public void setTarget(ASTNode target) // TODO change type to Expression
+	{
+		this.target = target;
+		super.addChild(target);
+	}
+	
+	public ArgumentList getArgumentList()
+	{
+		return this.argumentList;
+	}
+	
+	public void setArgumentList(ArgumentList argumentList)
+	{
+		this.argumentList = argumentList;
+		super.addChild(argumentList);
+	}
+	
+	@Override
+	public void addChild(ASTNode node)
+	{
+		if (node instanceof Identifier)
+			setTarget((Identifier)node);
+		else if (node instanceof ArgumentList)
+			setArgumentList((ArgumentList)node);
+		else
+			super.addChild(node);
+	}
 }

--- a/src/ast/expressions/ExpressionList.java
+++ b/src/ast/expressions/ExpressionList.java
@@ -5,7 +5,7 @@ import java.util.LinkedList;
 
 import ast.ASTNode;
 
-public class ExpressionList extends ASTNode implements Iterable<ASTNode>
+public class ExpressionList extends ASTNode implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
 {
 	private LinkedList<ASTNode> expressions = new LinkedList<ASTNode>();
 	// TODO eventually, of course, this has to be a LinkedList<Expression>

--- a/src/ast/php/expressions/MethodCallExpression.java
+++ b/src/ast/php/expressions/MethodCallExpression.java
@@ -2,7 +2,6 @@ package ast.php.expressions;
 
 import ast.ASTNode;
 import ast.expressions.CallExpression;
-import ast.expressions.Identifier;
 
 public class MethodCallExpression extends CallExpression
 {

--- a/src/ast/php/expressions/MethodCallExpression.java
+++ b/src/ast/php/expressions/MethodCallExpression.java
@@ -1,0 +1,21 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.CallExpression;
+import ast.expressions.Identifier;
+
+public class MethodCallExpression extends CallExpression
+{
+	private ASTNode targetObject = null; // TODO make this an Expression once mapping is finished
+	
+	public ASTNode getTargetObject() // TODO return Expression
+	{
+		return this.targetObject;
+	}
+	
+	public void setTargetObject(ASTNode targetObject) // TODO take Expression
+	{
+		this.targetObject = targetObject;
+		super.addChild(targetObject);
+	}
+}

--- a/src/ast/php/expressions/PHPArrayElement.java
+++ b/src/ast/php/expressions/PHPArrayElement.java
@@ -1,0 +1,32 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPArrayElement extends Expression
+{
+	private ASTNode value = null; // TODO change type to Expression once mapping is finished
+	private ASTNode key = null; // TODO change type to Expression once mapping is finished
+
+	public ASTNode getValue()
+	{
+		return this.value;
+	}
+
+	public void setValue(ASTNode value)
+	{
+		this.value = value;
+		super.addChild(value);
+	}
+	
+	public ASTNode getKey()
+	{
+		return this.key;
+	}
+	
+	public void setKey(ASTNode key)
+	{
+		this.key = key;
+		super.addChild(key);
+	}
+}

--- a/src/ast/php/expressions/PHPArrayExpression.java
+++ b/src/ast/php/expressions/PHPArrayExpression.java
@@ -1,0 +1,32 @@
+package ast.php.expressions;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.expressions.Expression;
+
+public class PHPArrayExpression extends Expression implements Iterable<PHPArrayElement>
+{
+
+	private LinkedList<PHPArrayElement> arrayElements = new LinkedList<PHPArrayElement>();
+
+	public int size()
+	{
+		return this.arrayElements.size();
+	}
+	
+	public PHPArrayElement getArrayElement(int i) {
+		return this.arrayElements.get(i);
+	}
+
+	public void addArrayElement(PHPArrayElement arrayElement)
+	{
+		this.arrayElements.add(arrayElement);
+		super.addChild(arrayElement);
+	}
+
+	@Override
+	public Iterator<PHPArrayElement> iterator() {
+		return this.arrayElements.iterator();
+	}
+}

--- a/src/ast/php/expressions/PHPListExpression.java
+++ b/src/ast/php/expressions/PHPListExpression.java
@@ -1,0 +1,33 @@
+package ast.php.expressions;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPListExpression extends Expression implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
+{
+
+	private LinkedList<ASTNode> elements = new LinkedList<ASTNode>(); // TODO LinkedList<Expression>
+
+	public int size()
+	{
+		return this.elements.size();
+	}
+	
+	public ASTNode getElement(int i) { // TODO return type: Expression
+		return this.elements.get(i);
+	}
+
+	public void addElement(ASTNode element) // TODO take an Expression
+	{
+		this.elements.add(element);
+		super.addChild(element);
+	}
+	
+	@Override
+	public Iterator<ASTNode> iterator() {
+		return this.elements.iterator();
+	}
+}

--- a/src/ast/php/expressions/StaticCallExpression.java
+++ b/src/ast/php/expressions/StaticCallExpression.java
@@ -1,0 +1,20 @@
+package ast.php.expressions;
+
+import ast.expressions.CallExpression;
+import ast.expressions.Identifier;
+
+public class StaticCallExpression extends CallExpression
+{
+	private Identifier targetClass = null;
+	
+	public Identifier getTargetClass()
+	{
+		return this.targetClass;
+	}
+	
+	public void setTargetClass(Identifier targetClass)
+	{
+		this.targetClass = targetClass;
+		super.addChild(targetClass);
+	}
+}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -20,6 +20,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.PHPArrayExpression;
+import ast.php.expressions.PHPListExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
@@ -702,6 +703,42 @@ public class TestPHPCSVASTBuilderMinimal
 		assertThat( node, instanceOf(ArgumentList.class));
 		assertEquals( 0, node.getChildCount());
 		assertEquals( 0, ((ArgumentList)node).size());
+	}
+	
+	/**
+	 * Fun note: The following code was perfectly valid prior to PHP 7.
+	 * Starting with PHP 7, it will throw a runtime exception.
+	 * However, it will *parse* fine in all cases.
+	 * 
+	 * list() = array();
+	 */
+	@Test
+	public void testMinimalListCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_ASSIGN,,3,,0,1,,,\n";
+		nodeStr += "4,AST_LIST,,3,,0,1,,,\n";
+		nodeStr += "5,NULL,,3,,0,1,,,\n";
+		nodeStr += "6,AST_ARRAY,,3,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)4);
+
+		assertThat( node, instanceOf(PHPListExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( 1, ((PHPListExpression)node).size());
+		// TODO ((PHPListExpression)node).getElement(0) should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPListExpression accepts arbitrary ASTNode's as elements,
+		// when we actually only want to accept expressions. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPListExpression)node).getElement(0).getProperty("type"));
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -19,6 +19,7 @@ import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.PHPArrayExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
@@ -701,6 +702,26 @@ public class TestPHPCSVASTBuilderMinimal
 		assertThat( node, instanceOf(ArgumentList.class));
 		assertEquals( 0, node.getChildCount());
 		assertEquals( 0, ((ArgumentList)node).size());
+	}
+	
+	/**
+	 * array();
+	 */
+	@Test
+	public void testMinimalArrayCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_ARRAY,,3,,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+
+		assertThat( node, instanceOf(PHPArrayExpression.class));
+		assertEquals( 0, node.getChildCount());
+		assertEquals( 0, ((PHPArrayExpression)node).size());
 	}
 	
 	/**

--- a/src/tests/parseTreeToAST/CodeNestingTest.java
+++ b/src/tests/parseTreeToAST/CodeNestingTest.java
@@ -181,7 +181,7 @@ public class CodeNestingTest
 		ExpressionStatement stmt = (ExpressionStatement) contentItem
 				.getStatements().get(0);
 		CallExpression expr = (CallExpression) stmt.getChild(0);
-		assertTrue(expr.getTarget().getEscapedCodeStr().equals("foo"));
+		assertTrue(expr.getTargetFunc().getEscapedCodeStr().equals("foo"));
 		ArgumentList argList = (ArgumentList) expr.getChild(1);
 		Argument arg = (Argument) argList.getChild(0);
 	}
@@ -195,7 +195,7 @@ public class CodeNestingTest
 		ExpressionStatement stmt = (ExpressionStatement) contentItem
 				.getStatements().get(0);
 		CallExpression expr = (CallExpression) stmt.getChild(0);
-		assertTrue(expr.getTarget().getEscapedCodeStr().equals("foo"));
+		assertTrue(expr.getTargetFunc().getEscapedCodeStr().equals("foo"));
 	}
 
 }

--- a/src/tests/parseTreeToAST/ExpressionParsingTest.java
+++ b/src/tests/parseTreeToAST/ExpressionParsingTest.java
@@ -233,7 +233,7 @@ public class ExpressionParsingTest
 				.get(0);
 		CallExpression expr = (CallExpression) ((Condition)starter.getCondition())
 				.getExpression();
-		assertTrue(expr.getTarget().getEscapedCodeStr().equals("foo"));
+		assertTrue(expr.getTargetFunc().getEscapedCodeStr().equals("foo"));
 	}
 
 }

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -18,6 +18,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -178,6 +179,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// nodes with an arbitrary number of children
 			case PHPCSVNodeTypes.TYPE_ARG_LIST:
 				errno = handleArgumentList((ArgumentList)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_LIST:
+				errno = handleList((PHPListExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY:
 				errno = handleArray((PHPArrayExpression)startNode, endNode, childnum);
@@ -945,6 +949,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleArgumentList( ArgumentList startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addArgument(endNode); // TODO cast to Expression
+
+		return 0;
+	}
+	
+	private int handleList( PHPListExpression startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addElement(endNode); // TODO cast to Expression
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -2,6 +2,7 @@ package tools.phpast2cfg;
 
 import ast.ASTNode;
 import ast.expressions.ArgumentList;
+import ast.expressions.CallExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
@@ -115,6 +116,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			case PHPCSVNodeTypes.TYPE_CALL:
+				errno = handleCall((CallExpression)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
 				break;
@@ -493,6 +497,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 2 children */
 
+	private int handleCall( CallExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change CallExpression.target to be an Expression instead
+				// of a generic ASTNode, and getTarget() and setTarget() accordingly
+				startNode.setTarget(endNode);
+				break;
+			case 1: // args child: ArgumentList node
+				startNode.setArgumentList((ArgumentList)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
 	private int handleCoalesce( PHPCoalesceExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -15,6 +15,7 @@ import ast.logical.statements.Label;
 import ast.logical.statements.Statement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
@@ -140,6 +141,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_STATIC_CALL:
+				errno = handleStaticCall((StaticCallExpression)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_CONDITIONAL:
 				errno = handleConditional((ConditionalExpression)startNode, endNode, childnum);
 				break;
@@ -669,6 +673,31 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 
 	/* nodes with exactly 3 children */
+	
+	private int handleStaticCall( StaticCallExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // class child: Identifier node
+				startNode.setTargetClass((Identifier)endNode);
+				break;
+			case 1: // method child: "string" node
+				// TODO in time, we should be able to cast endNode to a plain
+				// node type that extends Expression.
+				startNode.setTarget(endNode);
+				break;
+			case 2: // args child: ArgumentList node
+				startNode.setArgumentList((ArgumentList)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
 	
 	private int handleConditional( ConditionalExpression startNode, ASTNode endNode, int childnum)
 	{

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -14,6 +14,7 @@ import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.logical.statements.Statement;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
@@ -141,6 +142,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
+				errno = handleMethodCall((MethodCallExpression)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_STATIC_CALL:
 				errno = handleStaticCall((StaticCallExpression)startNode, endNode, childnum);
 				break;
@@ -510,8 +514,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // expr child: Expression node
 				// TODO in time, we should be able to cast endNode to Expression;
 				// then, change CallExpression.target to be an Expression instead
-				// of a generic ASTNode, and getTarget() and setTarget() accordingly
-				startNode.setTarget(endNode);
+				// of a generic ASTNode, and getTargetFunc() and setTargetFunc() accordingly
+				startNode.setTargetFunc(endNode);
 				break;
 			case 1: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
@@ -674,6 +678,35 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 3 children */
 	
+	private int handleMethodCall( MethodCallExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change MethodCallExpression.targetObject to be an Expression instead
+				// of a generic ASTNode, and getTargetObject() and setTargetObject() accordingly
+				startNode.setTargetObject(endNode);
+				break;
+			case 1: // method child: "string" node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change CallExpression.target to be an Expression instead
+				// of a generic ASTNode, and getTargetFunc() and setTargetFunc() accordingly
+				startNode.setTargetFunc(endNode);
+				break;
+			case 2: // args child: ArgumentList node
+				startNode.setArgumentList((ArgumentList)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
 	private int handleStaticCall( StaticCallExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
@@ -686,7 +719,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 1: // method child: "string" node
 				// TODO in time, we should be able to cast endNode to a plain
 				// node type that extends Expression.
-				startNode.setTarget(endNode);
+				startNode.setTargetFunc(endNode);
 				break;
 			case 2: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -19,6 +19,7 @@ import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
@@ -128,6 +129,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_STATIC_CALL:
+				retval = handleStaticCall(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_CONDITIONAL:
 				retval = handleConditional(row, ast);
 				break;
@@ -723,6 +727,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 3 children */
 
+	private long handleStaticCall(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		StaticCallExpression newNode = new StaticCallExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleConditional(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ConditionalExpression newNode = new ConditionalExpression();

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -22,6 +22,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -166,6 +167,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// nodes with an arbitrary number of children
 			case PHPCSVNodeTypes.TYPE_ARG_LIST:
 				retval = handleArgumentList(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_LIST:
+				retval = handleList(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY:
 				retval = handleArray(row, ast);
@@ -946,6 +950,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleArgumentList(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ArgumentList newNode = new ArgumentList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPListExpression newNode = new PHPListExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -18,6 +18,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
@@ -129,6 +130,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
+				retval = handleMethodCall(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_STATIC_CALL:
 				retval = handleStaticCall(row, ast);
 				break;
@@ -727,6 +731,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 3 children */
 
+	private long handleMethodCall(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		MethodCallExpression newNode = new MethodCallExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleStaticCall(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		StaticCallExpression newNode = new StaticCallExpression();

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -7,6 +7,7 @@ import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
 import ast.expressions.ArgumentList;
+import ast.expressions.CallExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
@@ -103,6 +104,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			case PHPCSVNodeTypes.TYPE_CALL:
+				retval = handleCall(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				retval = handleCoalesce(row, ast);
 				break;
@@ -561,6 +565,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	
 	
 	/* nodes with exactly 2 children */
+	
+	private long handleCall(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		CallExpression newNode = new CallExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 	
 	private long handleCoalesce(KeyedCSVRow row, ASTUnderConstruction ast)
 	{

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -19,6 +19,8 @@ import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.MethodCallExpression;
+import ast.php.expressions.PHPArrayElement;
+import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
@@ -109,6 +111,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_CALL:
 				retval = handleCall(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
+				retval = handleArrayElement(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				retval = handleCoalesce(row, ast);
 				break;
@@ -161,6 +166,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// nodes with an arbitrary number of children
 			case PHPCSVNodeTypes.TYPE_ARG_LIST:
 				retval = handleArgumentList(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_ARRAY:
+				retval = handleArray(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
 				retval = handleExpressionList(row, ast);
@@ -596,6 +604,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		return id;
 	}
 	
+	private long handleArrayElement(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPArrayElement newNode = new PHPArrayElement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleCoalesce(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPCoalesceExpression newNode = new PHPCoalesceExpression();
@@ -916,6 +946,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleArgumentList(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ArgumentList newNode = new ArgumentList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleArray(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPArrayExpression newNode = new PHPArrayExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -65,6 +65,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 
 	// nodes with exactly 3 children
+	public static final String TYPE_STATIC_CALL = "AST_STATIC_CALL";
 	public static final String TYPE_CONDITIONAL = "AST_CONDITIONAL";
 
 	public static final String TYPE_TRY = "AST_TRY";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 
 	// nodes with exactly 2 children
+	public static final String TYPE_CALL = "AST_CALL";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	
 	public static final String TYPE_WHILE = "AST_WHILE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -80,6 +80,7 @@ public class PHPCSVNodeTypes
 
 	// nodes with an arbitrary number of children
 	public static final String TYPE_ARG_LIST = "AST_ARG_LIST";
+	public static final String TYPE_LIST = "AST_LIST";
 	public static final String TYPE_ARRAY = "AST_ARRAY";
 	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -65,6 +65,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 
 	// nodes with exactly 3 children
+	public static final String TYPE_METHOD_CALL = "AST_METHOD_CALL";
 	public static final String TYPE_STATIC_CALL = "AST_STATIC_CALL";
 	public static final String TYPE_CONDITIONAL = "AST_CONDITIONAL";
 

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -56,6 +56,7 @@ public class PHPCSVNodeTypes
 
 	// nodes with exactly 2 children
 	public static final String TYPE_CALL = "AST_CALL";
+	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	
 	public static final String TYPE_WHILE = "AST_WHILE";
@@ -79,6 +80,7 @@ public class PHPCSVNodeTypes
 
 	// nodes with an arbitrary number of children
 	public static final String TYPE_ARG_LIST = "AST_ARG_LIST";
+	public static final String TYPE_ARRAY = "AST_ARRAY";
 	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";


### PR DESCRIPTION
**Support for call expressions**

* `AST_CALL` -> `ast.expressions.CallExpression`

This looks pretty straightforward, but there are some intricacies.
In C world, a call expression has two children: an `Identifier` representing the called function name; and an `ArgumentList` representing the argument list. Fine.
In PHP world, there are two children too, and the second one is also an argument list, but the first one is not *necessarily* an `Identifier`. Indeed, PHP allows you to do
```php
function foo() { echo "Hello World!"; }
$bar = "foo";
$bar();
```
Neat, is it not? :smile: So we can only say that the first child is an expression, which is fine; it's only a bit more general than in C world.

Now, `CallExpression` already had a method `getTarget()` (which I renamed to `getTargetFunc()` for reasons that will become apparent later), but what it returned was `children.get(0)`, which is ugly as it assumes children are added in a certain order, and prevents the PHP edge interpreter from reliably using a `setTargetFunc(Expression)` method that adds a child which `getTargetFunc()` will return. So I added a `targetFunc` field, added a setter method and refactored the getter method to return that field. I also did the same for the argument list, for which there were no fields, getters or setters at all.

However, rewriting `getTargetFunc()` in that way was a problem for C world, since C world never called the setter method. Thus I also added an override of `addChild(ASTNode)` to `CallExpression` which calls the setter method if the child is an `Identifier` (and similarly for the argument list). This is the way C world usually handles this. Whenever such a thing is missing, I always add an appropriate comment to issue #80, but this time around I had to do it myself so that all tests would still pass.

**Support for static call expressions**

* ` AST_STATIC_CALL` -> `ast.php.expressions.StaticCallExpression`

Since PHP knows classes and objects, there are two more types of call expressions. The first one is a *static call expression* to call a static method `foo` of an uninstantiated class `Buz`:
```php
Buz::foo($bar);
```

I created `StaticCallExpression` and had it extend `CallExpression`, so that the `targetFunc` and `argumentList` fields with their getters and setters are inherited. Additionally, `StaticCallExpression` declares an `Identifier targetClass` with appropriate getters and setters. (By the way, this is the reason why `getTarget()` was renamed to `getTargetFunc()`, to distinguish it clearly from `getTargetClass()`.)

But now it gets ugly again. :confused: The setter method `setTargetClass(Identifier)` in `StaticCallExpression` calls `super.addChild(ASTNode)` to add the child representing the target class to the node's children. But this of course calls `CallExpression#addChild(ASTNode)` first; this method in turn calls `ASTNode#addChild(ASTNode)` which is what we actually want, but the problem is that—as I explained above—the method `CallExpression#addChild(ASTNode)` additionally calls the setter for the *function* name, since it sees that the child node being added is an `Identifier` and thinks *"Oh, this must be the function name!"*. But it's not. It's the class name. So the `addChild(ASTNode)` override which I had just previously created myself to accomodate C world now stood in my own way. :wink: In order to prevent this from happening, I had to add the condition `if(this.getClass().equals(CallExpression.class) ... )` to `CallExpression#addChild(ASTNode)` so that it would only call the setter for the function name if the current object is an instance of `CallExpression` itself, but not an instance of a subclass of `CallExpression`. Talk about ugly! The clean way would be to have a `CCallExpression` extend `CallExpression` and have it override `addChild(ASTNode)` on its own. As a few times in the past, the inherent problem is that this behavior is specific to C world, and if C world needs specific behavior, it should use extend the base classes instead of modifying the base class's behavior. (I know, I did it myself, but I had to. :blush:) I will add an appropriate comment to #80.

Note that a few days ago there was a somewhat similar problem with `GotoStatement#getTargetName()` returning `getChild(0).getEscapedCodeStr()`, see PR #81. But that was less of an issue since PHP world does not need `getTargetName()` anyway (only `getTargetLabel()`), and anyway `GotoStatement` does not have any extending classes.

**Support for method call expressions**

* `AST_METHOD_CALL` -> `ast.php.expressions.MethodCallExpression`

Finally, the third type of call expression is a *method call expression*. This is when you call a method of an instance of a class. Accordingly, I added a `MethodCallExpression` extending `CallExpression` with a `targetObject` field with getters and setters, resembling the `targetClass` field of `StaticCallExpression`.

Note that for a method call expression, *both* the `targetFunc` and the `targetObject` fields can be all kinds of expressions. The typical usage would probably be something like
```php
class Buz { function foo() { echo "Hello World!"; } }
$bar = new Buz();
$bar->foo();
```
Here `targetObject` is a variable node and `targetFunc` is a plain string node.

But you can do much weirder stuff, say
```php
class Buz { function foo() { echo "Hello World!"; } }
function bar() { return new Buz(); }
$foo = "foo";
bar()->$foo();
```
Here `targetObject` is another call expression node and `targetFunc` is a variable node.

Other than that, this class did not pose any new problems, though. :blush:

To be continued...
