### PR TITLE
Support for encapsulated lists, class property declarations and constant declarations

### DIFF
--- a/src/ast/php/expressions/PHPEncapsListExpression.java
+++ b/src/ast/php/expressions/PHPEncapsListExpression.java
@@ -1,0 +1,33 @@
+package ast.php.expressions;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPEncapsListExpression extends Expression implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
+{
+
+	private LinkedList<ASTNode> elements = new LinkedList<ASTNode>(); // TODO LinkedList<Expression>
+
+	public int size()
+	{
+		return this.elements.size();
+	}
+	
+	public ASTNode getElement(int i) { // TODO return type: Expression
+		return this.elements.get(i);
+	}
+
+	public void addElement(ASTNode element) // TODO take an Expression
+	{
+		this.elements.add(element);
+		super.addChild(element);
+	}
+	
+	@Override
+	public Iterator<ASTNode> iterator() {
+		return this.elements.iterator();
+	}
+}

--- a/src/ast/php/statements/ClassConstantDeclaration.java
+++ b/src/ast/php/statements/ClassConstantDeclaration.java
@@ -1,0 +1,32 @@
+package ast.php.statements;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.logical.statements.Statement;
+
+public class ClassConstantDeclaration extends Statement implements Iterable<ConstantElement>
+{
+
+	private LinkedList<ConstantElement> constants = new LinkedList<ConstantElement>();
+
+	public int size()
+	{
+		return this.constants.size();
+	}
+	
+	public ConstantElement getConstantElement(int i) {
+		return this.constants.get(i);
+	}
+
+	public void addConstantElement(ConstantElement constant)
+	{
+		this.constants.add(constant);
+		super.addChild(constant);
+	}
+
+	@Override
+	public Iterator<ConstantElement> iterator() {
+		return this.constants.iterator();
+	}
+}

--- a/src/ast/php/statements/ConstantDeclaration.java
+++ b/src/ast/php/statements/ConstantDeclaration.java
@@ -1,0 +1,32 @@
+package ast.php.statements;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.logical.statements.Statement;
+
+public class ConstantDeclaration extends Statement implements Iterable<ConstantElement>
+{
+
+	private LinkedList<ConstantElement> constants = new LinkedList<ConstantElement>();
+
+	public int size()
+	{
+		return this.constants.size();
+	}
+	
+	public ConstantElement getConstantElement(int i) {
+		return this.constants.get(i);
+	}
+
+	public void addConstantElement(ConstantElement constant)
+	{
+		this.constants.add(constant);
+		super.addChild(constant);
+	}
+
+	@Override
+	public Iterator<ConstantElement> iterator() {
+		return this.constants.iterator();
+	}
+}

--- a/src/ast/php/statements/ConstantElement.java
+++ b/src/ast/php/statements/ConstantElement.java
@@ -1,0 +1,32 @@
+package ast.php.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+
+public class ConstantElement extends Statement
+{
+	private ASTNode name = null;
+	private ASTNode value = null;
+
+	public ASTNode getNameChild()
+	{
+		return this.name;
+	}
+	
+	public void setNameChild(ASTNode name)
+	{
+		this.name = name;
+		super.addChild(name);
+	}
+	
+	public ASTNode getValue()
+	{
+		return this.value;
+	}
+	
+	public void setValue(ASTNode value)
+	{
+		this.value = value;
+		super.addChild(value);
+	}
+}

--- a/src/ast/php/statements/PropertyDeclaration.java
+++ b/src/ast/php/statements/PropertyDeclaration.java
@@ -1,0 +1,32 @@
+package ast.php.statements;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.logical.statements.Statement;
+
+public class PropertyDeclaration extends Statement implements Iterable<PropertyElement>
+{
+
+	private LinkedList<PropertyElement> properties = new LinkedList<PropertyElement>();
+
+	public int size()
+	{
+		return this.properties.size();
+	}
+	
+	public PropertyElement getPropertyElement(int i) {
+		return this.properties.get(i);
+	}
+
+	public void addPropertyElement(PropertyElement property)
+	{
+		this.properties.add(property);
+		super.addChild(property);
+	}
+
+	@Override
+	public Iterator<PropertyElement> iterator() {
+		return this.properties.iterator();
+	}
+}

--- a/src/ast/php/statements/PropertyElement.java
+++ b/src/ast/php/statements/PropertyElement.java
@@ -1,0 +1,32 @@
+package ast.php.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+
+public class PropertyElement extends Statement
+{
+	private ASTNode name = null;
+	private ASTNode defaultvalue = null;
+
+	public ASTNode getNameChild()
+	{
+		return this.name;
+	}
+	
+	public void setNameChild(ASTNode name)
+	{
+		this.name = name;
+		super.addChild(name);
+	}
+	
+	public ASTNode getDefault()
+	{
+		return this.defaultvalue;
+	}
+	
+	public void setDefault(ASTNode defaultvalue)
+	{
+		this.defaultvalue = defaultvalue;
+		super.addChild(defaultvalue);
+	}
+}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -27,6 +27,8 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.php.statements.PropertyDeclaration;
+import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
@@ -147,6 +149,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_SWITCH_CASE:
 				errno = handleSwitchCase((PHPSwitchCase)startNode, endNode, childnum);
 				break;
+			case PHPCSVNodeTypes.TYPE_PROP_ELEM:
+				errno = handlePropertyElement((PropertyElement)startNode, endNode, childnum);
+				break;
 
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
@@ -210,6 +215,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLOSURE_USES:
 				errno = handleClosureUses((ClosureUses)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_PROP_DECL:
+				errno = handlePropertyDeclaration((PropertyDeclaration)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_NAME_LIST:
 				errno = handleIdentifierList((IdentifierList)startNode, endNode, childnum);
@@ -715,6 +723,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		return errno;
 	}
+	
+	private int handlePropertyElement( PropertyElement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child: plain node
+				startNode.setNameChild(endNode);
+				break;
+			case 1: // default child: either plain or NULL node
+				startNode.setDefault(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -1023,6 +1051,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleClosureUses( ClosureUses startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addClosureVar((ClosureVar)endNode);
+
+		return 0;
+	}
+	
+	private int handlePropertyDeclaration( PropertyDeclaration startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addPropertyElement((PropertyElement)endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -27,6 +27,9 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.php.statements.ClassConstantDeclaration;
+import ast.php.statements.ConstantDeclaration;
+import ast.php.statements.ConstantElement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
@@ -152,6 +155,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_PROP_ELEM:
 				errno = handlePropertyElement((PropertyElement)startNode, endNode, childnum);
 				break;
+			case PHPCSVNodeTypes.TYPE_CONST_ELEM:
+				errno = handleConstantElement((ConstantElement)startNode, endNode, childnum);
+				break;
 
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
@@ -218,6 +224,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PROP_DECL:
 				errno = handlePropertyDeclaration((PropertyDeclaration)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CONST_DECL:
+				errno = handleConstantDeclaration((ConstantDeclaration)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLASS_CONST_DECL:
+				errno = handleClassConstantDeclaration((ClassConstantDeclaration)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_NAME_LIST:
 				errno = handleIdentifierList((IdentifierList)startNode, endNode, childnum);
@@ -733,7 +745,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // name child: plain node
 				startNode.setNameChild(endNode);
 				break;
-			case 1: // default child: either plain or NULL node
+			case 1: // default child: either Expression or NULL node
 				startNode.setDefault(endNode);
 				break;
 				
@@ -742,6 +754,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		}
 		
 		return errno;		
+	}
+	
+	private int handleConstantElement( ConstantElement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child: plain node
+				startNode.setNameChild(endNode);
+				break;
+			case 1: // default child: Expression node
+				startNode.setValue(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
 	}
 
 
@@ -1058,6 +1090,20 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handlePropertyDeclaration( PropertyDeclaration startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addPropertyElement((PropertyElement)endNode);
+
+		return 0;
+	}
+	
+	private int handleConstantDeclaration( ConstantDeclaration startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addConstantElement((ConstantElement)endNode);
+
+		return 0;
+	}
+	
+	private int handleClassConstantDeclaration( ClassConstantDeclaration startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addConstantElement((ConstantElement)endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -18,6 +18,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
@@ -185,6 +186,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY:
 				errno = handleArray((PHPArrayExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_ENCAPS_LIST:
+				errno = handleEncapsList((PHPEncapsListExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
 				errno = handleExpressionList((ExpressionList)startNode, endNode, childnum);
@@ -963,6 +967,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleArray( PHPArrayExpression startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addArrayElement((PHPArrayElement)endNode);
+
+		return 0;
+	}
+	
+	private int handleEncapsList( PHPEncapsListExpression startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addElement(endNode); // TODO cast to Expression
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -31,6 +31,9 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.php.statements.ClassConstantDeclaration;
+import ast.php.statements.ConstantDeclaration;
+import ast.php.statements.ConstantElement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
@@ -140,6 +143,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_PROP_ELEM:
 				retval = handlePropertyElement(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_CONST_ELEM:
+				retval = handleConstantElement(row, ast);
+				break;
 
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
@@ -206,6 +212,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PROP_DECL:
 				retval = handlePropertyDeclaration(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CONST_DECL:
+				retval = handleConstantDeclaration(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLASS_CONST_DECL:
+				retval = handleClassConstantDeclaration(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_NAME_LIST:
 				retval = handleIdentifierList(row, ast);
@@ -795,6 +807,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		return id;
 	}
+	
+	private long handleConstantElement(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ConstantElement newNode = new ConstantElement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -1226,6 +1260,50 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handlePropertyDeclaration(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PropertyDeclaration newNode = new PropertyDeclaration();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleConstantDeclaration(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ConstantDeclaration newNode = new ConstantDeclaration();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleClassConstantDeclaration(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ClassConstantDeclaration newNode = new ClassConstantDeclaration();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -31,6 +31,8 @@ import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
+import ast.php.statements.PropertyDeclaration;
+import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
@@ -135,6 +137,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_SWITCH_CASE:
 				retval = handleSwitchCase(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_PROP_ELEM:
+				retval = handlePropertyElement(row, ast);
+				break;
 
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
@@ -198,6 +203,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLOSURE_USES:
 				retval = handleClosureUses(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_PROP_DECL:
+				retval = handlePropertyDeclaration(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_NAME_LIST:
 				retval = handleIdentifierList(row, ast);
@@ -765,6 +773,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		return id;
 	}
+	
+	private long handlePropertyElement(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PropertyElement newNode = new PropertyElement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -1174,6 +1204,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleClosureUses(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ClosureUses newNode = new ClosureUses();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handlePropertyDeclaration(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PropertyDeclaration newNode = new PropertyDeclaration();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -22,6 +22,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
@@ -173,6 +174,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY:
 				retval = handleArray(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_ENCAPS_LIST:
+				retval = handleEncapsList(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_EXPR_LIST:
 				retval = handleExpressionList(row, ast);
@@ -994,6 +998,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleArray(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPArrayExpression newNode = new PHPArrayExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleEncapsList(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPEncapsListExpression newNode = new PHPEncapsListExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -82,6 +82,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_ARG_LIST = "AST_ARG_LIST";
 	public static final String TYPE_LIST = "AST_LIST";
 	public static final String TYPE_ARRAY = "AST_ARRAY";
+	public static final String TYPE_ENCAPS_LIST = "AST_ENCAPS_LIST";
 	public static final String TYPE_EXPR_LIST = "AST_EXPR_LIST";
 	public static final String TYPE_STMT_LIST = "AST_STMT_LIST";
 	public static final String TYPE_IF = "AST_IF";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -65,6 +65,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH = "AST_SWITCH";
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 	public static final String TYPE_PROP_ELEM = "AST_PROP_ELEM";
+	public static final String TYPE_CONST_ELEM = "AST_CONST_ELEM";
 
 	// nodes with exactly 3 children
 	public static final String TYPE_METHOD_CALL = "AST_METHOD_CALL";
@@ -92,6 +93,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
 	public static final String TYPE_CLOSURE_USES = "AST_CLOSURE_USES";
 	public static final String TYPE_PROP_DECL = "AST_PROP_DECL";
+	public static final String TYPE_CONST_DECL = "AST_CONST_DECL";
+	public static final String TYPE_CLASS_CONST_DECL = "AST_CLASS_CONST_DECL";
 	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";
 
 	/* node flags */

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -64,6 +64,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_IF_ELEM = "AST_IF_ELEM";
 	public static final String TYPE_SWITCH = "AST_SWITCH";
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
+	public static final String TYPE_PROP_ELEM = "AST_PROP_ELEM";
 
 	// nodes with exactly 3 children
 	public static final String TYPE_METHOD_CALL = "AST_METHOD_CALL";
@@ -90,6 +91,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CATCH_LIST = "AST_CATCH_LIST";
 	public static final String TYPE_PARAM_LIST = "AST_PARAM_LIST";
 	public static final String TYPE_CLOSURE_USES = "AST_CLOSURE_USES";
+	public static final String TYPE_PROP_DECL = "AST_PROP_DECL";
 	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";
 
 	/* node flags */


### PR DESCRIPTION
**Support for encapsulated lists**

* `AST_ENCAPS_LIST` -> `ast.php.expressions.PHPEncapsListExpression`

**Support for property declarations**

* `AST_PROP_DECL` -> `ast.php.statements.PropertyDeclaration`
* `AST_PROP_ELEM` -> `ast.php.statements.PropertyElement`

I added `PropertyDeclaration` and `PropertyElement` to `ast.php.statements` for now, though they might also be useful for other object-oriented languages.

Otherwise, not too much to say about these, more to come tomorrow. :)
