### PR TITLE
Support for traits, namespaces, (group) use statements, static variable declarations, declare statements, array indexing expressions, (static) property access expressions and class constant access expressions

### DIFF
--- a/src/ast/expressions/ArrayIndexing.java
+++ b/src/ast/expressions/ArrayIndexing.java
@@ -1,5 +1,31 @@
 package ast.expressions;
 
+import ast.ASTNode;
+
 public class ArrayIndexing extends Expression
 {
+	private ASTNode array = null; // TODO make this an Expression
+	private ASTNode index = null; // TODO make this an Expression
+
+	public ASTNode getArrayExpression() // TODO return an Expression
+	{
+		return this.array;
+	}
+
+	public void setArrayExpression(ASTNode array) // TODO take an Expression
+	{
+		this.array = array;
+		super.addChild(array);
+	}
+	
+	public ASTNode getIndexExpression() // TODO return an Expression
+	{
+		return this.index;
+	}
+
+	public void setIndexExpression(ASTNode index) // TODO take an Expression
+	{
+		this.index = index;
+		super.addChild(index);
+	}
 }

--- a/src/ast/expressions/ClassConstantExpression.java
+++ b/src/ast/expressions/ClassConstantExpression.java
@@ -1,0 +1,31 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class ClassConstantExpression extends Expression
+{
+	private ASTNode classExpression = null; // TODO make this an Expression
+	private ASTNode constantName = null;
+
+	public ASTNode getClassExpression() // TODO return an Expression
+	{
+		return this.classExpression;
+	}
+
+	public void setClassExpression(ASTNode classExpression) // TODO take an Expression
+	{
+		this.classExpression = classExpression;
+		super.addChild(classExpression);
+	}
+	
+	public ASTNode getConstantName()
+	{
+		return this.constantName;
+	}
+
+	public void setConstantName(ASTNode constantName)
+	{
+		this.constantName = constantName;
+		super.addChild(constantName);
+	}
+}

--- a/src/ast/expressions/PropertyExpression.java
+++ b/src/ast/expressions/PropertyExpression.java
@@ -1,0 +1,31 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class PropertyExpression extends Expression
+{
+	private ASTNode objectExpression = null; // TODO make this an Expression
+	private ASTNode propertyName = null;
+
+	public ASTNode getObjectExpression() // TODO return an Expression
+	{
+		return this.objectExpression;
+	}
+
+	public void setObjectExpression(ASTNode objectExpression) // TODO take an Expression
+	{
+		this.objectExpression = objectExpression;
+		super.addChild(objectExpression);
+	}
+	
+	public ASTNode getPropertyName()
+	{
+		return this.propertyName;
+	}
+
+	public void setPropertyName(ASTNode propertyName)
+	{
+		this.propertyName = propertyName;
+		super.addChild(propertyName);
+	}
+}

--- a/src/ast/expressions/StaticPropertyExpression.java
+++ b/src/ast/expressions/StaticPropertyExpression.java
@@ -1,0 +1,31 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class StaticPropertyExpression extends Expression
+{
+	private ASTNode classExpression = null; // TODO make this an Expression
+	private ASTNode propertyName = null;
+
+	public ASTNode getClassExpression() // TODO return an Expression
+	{
+		return this.classExpression;
+	}
+
+	public void setClassExpression(ASTNode classExpression) // TODO take an Expression
+	{
+		this.classExpression = classExpression;
+		super.addChild(classExpression);
+	}
+	
+	public ASTNode getPropertyName()
+	{
+		return this.propertyName;
+	}
+
+	public void setPropertyName(ASTNode propertyName)
+	{
+		this.propertyName = propertyName;
+		super.addChild(propertyName);
+	}
+}

--- a/src/ast/php/statements/PHPGroupUseStatement.java
+++ b/src/ast/php/statements/PHPGroupUseStatement.java
@@ -1,0 +1,33 @@
+package ast.php.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+import ast.statements.UseStatement;
+
+public class PHPGroupUseStatement extends Statement
+{
+	private ASTNode prefix = null;
+	private UseStatement uses = null;
+	
+	public ASTNode getPrefix()
+	{
+		return this.prefix;
+	}
+
+	public void setPrefix(ASTNode prefix)
+	{
+		this.prefix = prefix;
+		super.addChild(prefix);
+	}
+	
+	public UseStatement getUses()
+	{
+		return this.uses;
+	}
+
+	public void setUses(UseStatement uses)
+	{
+		this.uses = uses;
+		super.addChild(uses);
+	}
+}

--- a/src/ast/php/statements/StaticVariableDeclaration.java
+++ b/src/ast/php/statements/StaticVariableDeclaration.java
@@ -1,0 +1,32 @@
+package ast.php.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+
+public class StaticVariableDeclaration extends Statement
+{
+	private ASTNode name = null;
+	private ASTNode defaultvalue = null; // TODO make this an Expression
+
+	public ASTNode getNameChild()
+	{
+		return this.name;
+	}
+	
+	public void setNameChild(ASTNode name)
+	{
+		this.name = name;
+		super.addChild(name);
+	}
+	
+	public ASTNode getDefault() // TODO make this an Expression
+	{
+		return this.defaultvalue;
+	}
+	
+	public void setDefault(ASTNode defaultvalue) // TODO make this an Expression
+	{
+		this.defaultvalue = defaultvalue;
+		super.addChild(defaultvalue);
+	}
+}

--- a/src/ast/php/statements/blockstarters/MethodReference.java
+++ b/src/ast/php/statements/blockstarters/MethodReference.java
@@ -1,0 +1,32 @@
+package ast.php.statements.blockstarters;
+
+import ast.ASTNode;
+import ast.expressions.Identifier;
+
+public class MethodReference extends ASTNode
+{
+	private Identifier classIdentifier = null;
+	private ASTNode methodName = null;
+	
+	public Identifier getClassIdentifier()
+	{
+		return this.classIdentifier;
+	}
+
+	public void setClassIdentifier(Identifier classIdentifier)
+	{
+		this.classIdentifier = classIdentifier;
+		super.addChild(classIdentifier);
+	}
+	
+	public ASTNode getMethodName()
+	{
+		return this.methodName;
+	}
+
+	public void setMethodName(ASTNode methodName)
+	{
+		this.methodName = methodName;
+		super.addChild(methodName);
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPDeclareStatement.java
+++ b/src/ast/php/statements/blockstarters/PHPDeclareStatement.java
@@ -1,0 +1,33 @@
+package ast.php.statements.blockstarters;
+
+import ast.logical.statements.BlockStarter;
+import ast.logical.statements.CompoundStatement;
+import ast.php.statements.ConstantDeclaration;
+
+public class PHPDeclareStatement extends BlockStarter
+{
+	private ConstantDeclaration declares = null;
+	private CompoundStatement content = null;
+
+	public ConstantDeclaration getDeclares()
+	{
+		return this.declares;
+	}
+
+	public void setDeclares(ConstantDeclaration declares)
+	{
+		this.declares = declares;
+		super.addChild(declares);
+	}
+	
+	public CompoundStatement getContent()
+	{
+		return this.content;
+	}
+
+	public void setContent(CompoundStatement content)
+	{
+		this.content = content;
+		super.addChild(content);
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPTraitAdaptationElement.java
+++ b/src/ast/php/statements/blockstarters/PHPTraitAdaptationElement.java
@@ -1,0 +1,19 @@
+package ast.php.statements.blockstarters;
+
+import ast.logical.statements.Statement;
+
+public class PHPTraitAdaptationElement extends Statement
+{
+	private MethodReference method = null;
+	
+	public MethodReference getMethod()
+	{
+		return this.method;
+	}
+
+	public void setMethod(MethodReference method)
+	{
+		this.method = method;
+		super.addChild(method);
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPTraitAdaptations.java
+++ b/src/ast/php/statements/blockstarters/PHPTraitAdaptations.java
@@ -1,0 +1,32 @@
+package ast.php.statements.blockstarters;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.logical.statements.BlockStarter;
+
+public class PHPTraitAdaptations extends BlockStarter implements Iterable<PHPTraitAdaptationElement>
+{
+
+	private LinkedList<PHPTraitAdaptationElement> traitAdaptations = new LinkedList<PHPTraitAdaptationElement>();
+
+	public int size()
+	{
+		return this.traitAdaptations.size();
+	}
+	
+	public PHPTraitAdaptationElement getTraitAdaptationElement(int i) {
+		return this.traitAdaptations.get(i);
+	}
+
+	public void addTraitAdaptationElement(PHPTraitAdaptationElement traitAdaptation)
+	{
+		this.traitAdaptations.add(traitAdaptation);
+		super.addChild(traitAdaptation);
+	}
+
+	@Override
+	public Iterator<PHPTraitAdaptationElement> iterator() {
+		return this.traitAdaptations.iterator();
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPTraitAlias.java
+++ b/src/ast/php/statements/blockstarters/PHPTraitAlias.java
@@ -1,0 +1,19 @@
+package ast.php.statements.blockstarters;
+
+import ast.ASTNode;
+
+public class PHPTraitAlias extends PHPTraitAdaptationElement
+{
+	private ASTNode alias = null;
+	
+	public ASTNode getAlias()
+	{
+		return this.alias;
+	}
+
+	public void setAlias(ASTNode alias)
+	{
+		this.alias = alias;
+		super.addChild(alias);
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPTraitPrecedence.java
+++ b/src/ast/php/statements/blockstarters/PHPTraitPrecedence.java
@@ -1,0 +1,19 @@
+package ast.php.statements.blockstarters;
+
+import ast.expressions.IdentifierList;
+
+public class PHPTraitPrecedence extends PHPTraitAdaptationElement
+{
+	private IdentifierList insteadof = null;
+	
+	public IdentifierList getInsteadOf()
+	{
+		return this.insteadof;
+	}
+
+	public void setInsteadOf(IdentifierList insteadof)
+	{
+		this.insteadof = insteadof;
+		super.addChild(insteadof);
+	}
+}

--- a/src/ast/php/statements/blockstarters/PHPUseTrait.java
+++ b/src/ast/php/statements/blockstarters/PHPUseTrait.java
@@ -1,0 +1,32 @@
+package ast.php.statements.blockstarters;
+
+import ast.expressions.IdentifierList;
+import ast.logical.statements.BlockStarter;
+
+public class PHPUseTrait extends BlockStarter
+{
+	private IdentifierList traits = null;
+	private PHPTraitAdaptations traitAdaptations = null;
+
+	public IdentifierList getTraits()
+	{
+		return this.traits;
+	}
+
+	public void setTraits(IdentifierList traits)
+	{
+		this.traits = traits;
+		super.addChild(traits);
+	}
+	
+	public PHPTraitAdaptations getTraitAdaptations()
+	{
+		return this.traitAdaptations;
+	}
+
+	public void setTraitAdaptations(PHPTraitAdaptations traitAdaptations)
+	{
+		this.traitAdaptations = traitAdaptations;
+		super.addChild(traitAdaptations);
+	}
+}

--- a/src/ast/statements/UseElement.java
+++ b/src/ast/statements/UseElement.java
@@ -1,0 +1,32 @@
+package ast.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+
+public class UseElement extends Statement
+{
+	private ASTNode namespace = null;
+	private ASTNode alias = null;
+	
+	public ASTNode getNamespace()
+	{
+		return this.namespace;
+	}
+
+	public void setNamespace(ASTNode namespace)
+	{
+		this.namespace = namespace;
+		super.addChild(namespace);
+	}
+	
+	public ASTNode getAlias()
+	{
+		return this.alias;
+	}
+
+	public void setAlias(ASTNode alias)
+	{
+		this.alias = alias;
+		super.addChild(alias);
+	}
+}

--- a/src/ast/statements/UseStatement.java
+++ b/src/ast/statements/UseStatement.java
@@ -1,0 +1,32 @@
+package ast.statements;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import ast.logical.statements.Statement;
+
+public class UseStatement extends Statement implements Iterable<UseElement>
+{
+
+	private LinkedList<UseElement> useElements = new LinkedList<UseElement>();
+
+	public int size()
+	{
+		return this.useElements.size();
+	}
+	
+	public UseElement getUseElement(int i) {
+		return this.useElements.get(i);
+	}
+
+	public void addUseElement(UseElement useElement)
+	{
+		this.useElements.add(useElement);
+		super.addChild(useElement);
+	}
+
+	@Override
+	public Iterator<UseElement> iterator() {
+		return this.useElements.iterator();
+	}
+}

--- a/src/ast/statements/blockstarters/NamespaceStatement.java
+++ b/src/ast/statements/blockstarters/NamespaceStatement.java
@@ -1,0 +1,33 @@
+package ast.statements.blockstarters;
+
+import ast.ASTNode;
+import ast.logical.statements.BlockStarter;
+import ast.logical.statements.CompoundStatement;
+
+public class NamespaceStatement extends BlockStarter
+{
+	private ASTNode name = null;
+	private CompoundStatement content = null;
+
+	public ASTNode getName()
+	{
+		return this.name;
+	}
+	
+	public void setName(ASTNode name)
+	{
+		this.name = name;
+		super.addChild(name);
+	}
+	
+	public CompoundStatement getContent()
+	{
+		return this.content;
+	}
+	
+	public void setContent(CompoundStatement content)
+	{
+		this.content = content;
+		super.addChild(content);
+	}
+}

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -48,6 +48,7 @@ import ast.php.statements.PropertyElement;
 import ast.php.statements.StaticVariableDeclaration;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.MethodReference;
+import ast.php.statements.blockstarters.PHPDeclareStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
@@ -1546,6 +1547,66 @@ public class TestPHPCSVASTBuilder
 		// finished, we can fix that.
 		assertEquals( "NULL", ((PHPSwitchCase)node4).getValue().getProperty("type"));
 		assertEquals( ast.getNodeById((long)22), ((PHPSwitchCase)node4).getStatement());
+	}
+	
+	/**
+	 * AST_DECLARE nodes are used to denote declare statements.
+	 * See http://php.net/manual/en/control-structures.declare.php
+	 * 
+	 * Any AST_DECLARE node has exactly two children:
+	 * 1) AST_CONST_DECL, holding the set directive(s)
+	 * 2) AST_STMT_LIST or NULL, holding the code to be executed under the given directives
+	 *    (If no curly brackets are used, then this child is NULL and the directives affect
+	 *    all code following the declare statement.)
+	 *    
+	 * This test checks a few declare statement's children in the following PHP code:
+	 * 
+	 * declare(ticks=1) {}
+	 * declare(encoding='ISO-8859-1');
+	 */
+	@Test
+	public void testDeclareCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_DECLARE,,3,,0,1,,,\n";
+		nodeStr += "4,AST_CONST_DECL,,3,,0,1,,,\n";
+		nodeStr += "5,AST_CONST_ELEM,,3,,0,1,,,\n";
+		nodeStr += "6,string,,3,\"ticks\",0,1,,,\n";
+		nodeStr += "7,integer,,3,1,1,1,,,\n";
+		nodeStr += "8,AST_STMT_LIST,,3,,1,1,,,\n";
+		nodeStr += "9,AST_DECLARE,,4,,1,1,,,\n";
+		nodeStr += "10,AST_CONST_DECL,,4,,0,1,,,\n";
+		nodeStr += "11,AST_CONST_ELEM,,4,,0,1,,,\n";
+		nodeStr += "12,string,,4,\"encoding\",0,1,,,\n";
+		nodeStr += "13,string,,4,\"ISO-8859-1\",1,1,,,\n";
+		nodeStr += "14,NULL,,4,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "5,6,PARENT_OF\n";
+		edgeStr += "5,7,PARENT_OF\n";
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,8,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "11,13,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "9,14,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)9);
+		
+		assertThat( node, instanceOf(PHPDeclareStatement.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PHPDeclareStatement)node).getDeclares());
+		assertEquals( ast.getNodeById((long)8), ((PHPDeclareStatement)node).getContent());
+
+		assertThat( node2, instanceOf(PHPDeclareStatement.class));
+		assertEquals( 2, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)10), ((PHPDeclareStatement)node2).getDeclares());
+		assertNull( ((PHPDeclareStatement)node2).getContent());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -31,6 +31,7 @@ import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPUseTrait;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.UseElement;
 import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
@@ -533,6 +534,37 @@ public class TestPHPCSVASTBuilderMinimal
 		assertThat( node, instanceOf(PHPUseTrait.class));
 		assertEquals( 2, node.getChildCount());
 		assertNull( ((PHPUseTrait)node).getTraitAdaptations());
+	}
+	
+	/**
+	 * use Foo\Bar;
+	 */
+	@Test
+	public void testUseElementCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_USE,T_CLASS,3,,0,1,,,\n";
+		nodeStr += "4,AST_USE_ELEM,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"Foo\\Bar\",0,1,,,\n";
+		nodeStr += "6,NULL,,3,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "4,6,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)4);
+
+		assertThat( node, instanceOf(UseElement.class));
+		assertEquals( 2, node.getChildCount());
+		// TODO ((UseElement)node).getAlias() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because UseElement accepts arbitrary ASTNode's for aliases,
+		// when we actually only want to accept strings. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((UseElement)node).getAlias().getProperty("type"));
 	}
 
 

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -28,6 +28,7 @@ import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
 import ast.php.statements.blockstarters.PHPSwitchList;
+import ast.php.statements.blockstarters.PHPUseTrait;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.CatchList;
@@ -492,6 +493,46 @@ public class TestPHPCSVASTBuilderMinimal
 		// when we actually only want to accept ints/strings/doubles. Once the mapping is
 		// finished, we can fix that.
 		assertEquals( "NULL", ((PHPSwitchCase)node).getValue().getProperty("type"));
+	}
+	
+	/**
+	 * class SomeClass {
+	 *   use Foo;
+	 * }
+	 */
+	@Test
+	public void testMinimalUseTraitCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CLASS,,3,,0,1,5,SomeClass,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+		nodeStr += "5,NULL,,3,,1,1,,,\n";
+		nodeStr += "6,AST_TOPLEVEL,TOPLEVEL_CLASS,3,,2,1,5,\"SomeClass\",\n";
+		nodeStr += "7,AST_STMT_LIST,,3,,0,6,,,\n";
+		nodeStr += "8,AST_USE_TRAIT,,4,,0,6,,,\n";
+		nodeStr += "9,AST_NAME_LIST,,4,,0,6,,,\n";
+		nodeStr += "10,AST_NAME,NAME_NOT_FQ,4,,0,6,,,\n";
+		nodeStr += "11,string,,4,\"Foo\",0,6,,,\n";
+		nodeStr += "12,NULL,,4,,1,6,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "8,12,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)8);
+		
+		assertThat( node, instanceOf(PHPUseTrait.class));
+		assertEquals( 2, node.getChildCount());
+		assertNull( ((PHPUseTrait)node).getTraitAdaptations());
 	}
 
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -33,6 +33,7 @@ import ast.php.statements.ConstantElement;
 import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
+import ast.php.statements.StaticVariableDeclaration;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.MethodReference;
 import ast.php.statements.blockstarters.PHPIfElement;
@@ -147,6 +148,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
 				break;
 
+			case PHPCSVNodeTypes.TYPE_STATIC:
+				errno = handleStaticVariable((StaticVariableDeclaration)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_WHILE:
 				errno = handleWhile((WhileStatement)startNode, endNode, childnum);
 				break;
@@ -646,6 +650,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		return errno;
 	}
 	
+	private int handleStaticVariable( StaticVariableDeclaration startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child: plain node
+				startNode.setNameChild(endNode);
+				break;
+			case 1: // default child: either Expression or NULL node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change StaticVariableDeclaration.defaultvalue to be an Expression instead
+				// of a generic ASTNode, and getDefault() and setDefault() accordingly
+				startNode.setDefault(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
 	private int handleWhile( WhileStatement startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
@@ -783,6 +810,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setNameChild(endNode);
 				break;
 			case 1: // default child: either Expression or NULL node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change PropertyElement.defaultvalue to be an Expression instead
+				// of a generic ASTNode, and getDefault() and setDefault() accordingly
 				startNode.setDefault(endNode);
 				break;
 				

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -46,6 +46,8 @@ import ast.php.statements.blockstarters.PHPTraitPrecedence;
 import ast.php.statements.blockstarters.PHPUseTrait;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.UseElement;
+import ast.statements.UseStatement;
 import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
@@ -173,6 +175,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_METHOD_REFERENCE:
 				errno = handleMethodReference((MethodReference)startNode, endNode, childnum);
 				break;
+			case PHPCSVNodeTypes.TYPE_USE_ELEM:
+				errno = handleUseElement((UseElement)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_TRAIT_ALIAS:
 				errno = handleTraitAlias((PHPTraitAlias)startNode, endNode, childnum);
 				break;
@@ -254,6 +259,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_TRAIT_ADAPTATIONS:
 				errno = handleTraitAdaptations((PHPTraitAdaptations)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_USE:
+				errno = handleUseStatement((UseStatement)startNode, endNode, childnum);
 				break;
 				
 			default:
@@ -863,6 +871,30 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		return errno;
 	}
 	
+	private int handleUseElement( UseElement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child: string node
+				startNode.setNamespace(endNode);
+				break;
+			case 1: // alias child: string or NULL node
+				// TODO in time, we should be able to cast endNode to a plain
+				// node type that extends Expression, unless endNode is a null
+				// node; then, adapt UseElement to use a string node and
+				// make a case distinction here to use setAlias() or addChild()
+				startNode.setAlias(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
 	private int handleTraitAlias( PHPTraitAlias startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
@@ -1229,6 +1261,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	private int handleTraitAdaptations( PHPTraitAdaptations startNode, ASTNode endNode, int childnum)
 	{
 		startNode.addTraitAdaptationElement((PHPTraitAdaptationElement)endNode);
+
+		return 0;
+	}
+	
+	private int handleUseStatement( UseStatement startNode, ASTNode endNode, int childnum)
+	{
+		startNode.addUseElement((UseElement)endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -2,6 +2,7 @@ package tools.phpast2cfg;
 
 import ast.ASTNode;
 import ast.expressions.ArgumentList;
+import ast.expressions.ArrayIndexing;
 import ast.expressions.CallExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
@@ -139,6 +140,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			case PHPCSVNodeTypes.TYPE_DIM:
+				errno = handleArrayIndexing((ArrayIndexing)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_CALL:
 				errno = handleCall((CallExpression)startNode, endNode, childnum);
 				break;
@@ -586,6 +590,33 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 	/* nodes with exactly 2 children */
 
+	private int handleArrayIndexing( ArrayIndexing startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change ArrayIndexing.arrayExpression to be an Expression instead
+				// of a generic ASTNode, and getArrayExpression() and setArrayExpression() accordingly
+				startNode.setArrayExpression(endNode);
+				break;
+			case 1: // dim child: Expression or NULL node
+				// TODO in time, we should be able to cast endNode to Expression,
+				// unless it's a null node; then, use case distinction here,
+				// change ArrayIndexing.indexExpression to be an Expression instead
+				// of a generic ASTNode, and getIndexExpression() and setIndexExpression() accordingly
+				startNode.setIndexExpression(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
 	private int handleCall( CallExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -4,10 +4,13 @@ import ast.ASTNode;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.CallExpression;
+import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.PropertyExpression;
+import ast.expressions.StaticPropertyExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -143,8 +146,17 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_DIM:
 				errno = handleArrayIndexing((ArrayIndexing)startNode, endNode, childnum);
 				break;
+			case PHPCSVNodeTypes.TYPE_PROP:
+				errno = handleProperty((PropertyExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_STATIC_PROP:
+				errno = handleStaticProperty((StaticPropertyExpression)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_CALL:
 				errno = handleCall((CallExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLASS_CONST:
+				errno = handleClassConstant((ClassConstantExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
@@ -617,6 +629,52 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		return errno;
 	}
 	
+	private int handleProperty( PropertyExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change PropertyExpression.objectExpression to be an Expression instead
+				// of a generic ASTNode, and getObjectExpression() and setObjectExpression() accordingly
+				startNode.setObjectExpression(endNode);
+				break;
+			case 1: // prop child: string node
+				startNode.setPropertyName(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleStaticProperty( StaticPropertyExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // class child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change StaticPropertyExpression.classExpression to be an Expression instead
+				// of a generic ASTNode, and getClassExpression() and setClassExpression() accordingly
+				startNode.setClassExpression(endNode);
+				break;
+			case 1: // prop child: string node
+				startNode.setPropertyName(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
 	private int handleCall( CallExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
@@ -631,6 +689,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleClassConstant( ClassConstantExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // class child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change ClassConstantExpression.classExpression to be an Expression instead
+				// of a generic ASTNode, and getClassExpression() and setClassExpression() accordingly
+				startNode.setClassExpression(endNode);
+				break;
+			case 1: // const child: string node
+				startNode.setConstantName(endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -36,6 +36,7 @@ import ast.php.statements.PropertyElement;
 import ast.php.statements.StaticVariableDeclaration;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.MethodReference;
+import ast.php.statements.blockstarters.PHPDeclareStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
@@ -168,6 +169,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PROP_ELEM:
 				errno = handlePropertyElement((PropertyElement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_DECLARE:
+				errno = handleDeclare((PHPDeclareStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_CONST_ELEM:
 				errno = handleConstantElement((ConstantElement)startNode, endNode, childnum);
@@ -791,6 +795,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // stmts child: AST_STMT_LIST
 				startNode.setStatement((CompoundStatement)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleDeclare( PHPDeclareStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // declares child: AST_CONST_DECL node
+				startNode.setDeclares((ConstantDeclaration)endNode);
+				break;
+			case 1: // stmts child: AST_STMT_LIST or NULL node
+				if( endNode instanceof CompoundStatement)
+					startNode.setContent((CompoundStatement)endNode);
+				else
+					startNode.addChild(endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -30,6 +30,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
 import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
+import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
@@ -184,6 +185,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_TRAIT_ALIAS:
 				errno = handleTraitAlias((PHPTraitAlias)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_GROUP_USE:
+				errno = handleGroupUse((PHPGroupUseStatement)startNode, endNode, childnum);
 				break;
 
 			// nodes with exactly 3 children
@@ -937,6 +941,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// node; then, adapt PHPTraitAlias to use a string node and
 				// make a case distinction here to use setAlias() or addChild()
 				startNode.setAlias(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleGroupUse( PHPGroupUseStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // prefix child: string node
+				startNode.setPrefix(endNode);
+				break;
+			case 1: // uses child: AST_USE node
+				startNode.setUses((UseStatement)endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -52,6 +52,7 @@ import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
+import ast.statements.blockstarters.NamespaceStatement;
 import ast.statements.blockstarters.TryStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
@@ -174,6 +175,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_METHOD_REFERENCE:
 				errno = handleMethodReference((MethodReference)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_NAMESPACE:
+				errno = handleNamespace((NamespaceStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_USE_ELEM:
 				errno = handleUseElement((UseElement)startNode, endNode, childnum);
@@ -864,6 +868,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setMethodName(endNode);
 				break;
 				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleNamespace( NamespaceStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child: string or NULL node
+				startNode.setName(endNode);
+				break;
+			case 1: // stmts child: AST_STMT_LIST or NULL node
+				if( endNode instanceof CompoundStatement)
+					startNode.setContent((CompoundStatement)endNode);
+				else
+					startNode.addChild(endNode);
+				break;
+
 			default:
 				errno = 1;
 		}

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -37,6 +37,7 @@ import ast.php.statements.ConstantElement;
 import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
+import ast.php.statements.StaticVariableDeclaration;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.MethodReference;
 import ast.php.statements.blockstarters.PHPIfElement;
@@ -134,6 +135,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				retval = handleCoalesce(row, ast);
 				break;
 
+			case PHPCSVNodeTypes.TYPE_STATIC:
+				retval = handleStaticVariable(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_WHILE:
 				retval = handleWhile(row, ast);
 				break;
@@ -693,6 +697,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleCoalesce(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPCoalesceExpression newNode = new PHPCoalesceExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleStaticVariable(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		StaticVariableDeclaration newNode = new StaticVariableDeclaration();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -55,6 +55,7 @@ import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
 import ast.statements.blockstarters.ForStatement;
+import ast.statements.blockstarters.NamespaceStatement;
 import ast.statements.blockstarters.TryStatement;
 import ast.statements.blockstarters.WhileStatement;
 import ast.statements.jump.GotoStatement;
@@ -161,6 +162,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_METHOD_REFERENCE:
 				retval = handleMethodReference(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_NAMESPACE:
+				retval = handleNamespace(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_USE_ELEM:
 				retval = handleUseElement(row, ast);
@@ -905,6 +909,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleMethodReference(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		MethodReference newNode = new MethodReference();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleNamespace(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		NamespaceStatement newNode = new NamespaceStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -9,10 +9,13 @@ import ast.CodeLocation;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.CallExpression;
+import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.PropertyExpression;
+import ast.expressions.StaticPropertyExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -130,8 +133,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_DIM:
 				retval = handleArrayIndexing(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_PROP:
+				retval = handleProperty(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_STATIC_PROP:
+				retval = handleStaticProperty(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_CALL:
 				retval = handleCall(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLASS_CONST:
+				retval = handleClassConstant(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
@@ -680,9 +692,75 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		return id;
 	}
 	
+	private long handleProperty(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PropertyExpression newNode = new PropertyExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleStaticProperty(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		StaticPropertyExpression newNode = new StaticPropertyExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleCall(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		CallExpression newNode = new CallExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleClassConstant(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ClassConstantExpression newNode = new ClassConstantExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -37,11 +37,16 @@ import ast.php.statements.ConstantElement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
+import ast.php.statements.blockstarters.MethodReference;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
 import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPSwitchStatement;
+import ast.php.statements.blockstarters.PHPTraitAdaptations;
+import ast.php.statements.blockstarters.PHPTraitAlias;
+import ast.php.statements.blockstarters.PHPTraitPrecedence;
+import ast.php.statements.blockstarters.PHPUseTrait;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
 import ast.statements.blockstarters.CatchList;
@@ -146,6 +151,18 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_CONST_ELEM:
 				retval = handleConstantElement(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_USE_TRAIT:
+				retval = handleUseTrait(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_TRAIT_PRECEDENCE:
+				retval = handleTraitPrecedence(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_METHOD_REFERENCE:
+				retval = handleMethodReference(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_TRAIT_ALIAS:
+				retval = handleTraitAlias(row, ast);
+				break;
 
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
@@ -221,6 +238,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_NAME_LIST:
 				retval = handleIdentifierList(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_TRAIT_ADAPTATIONS:
+				retval = handleTraitAdaptations(row, ast);
 				break;
 
 			default:
@@ -829,6 +849,94 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 		return id;
 	}
+	
+	private long handleUseTrait(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPUseTrait newNode = new PHPUseTrait();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleTraitPrecedence(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPTraitPrecedence newNode = new PHPTraitPrecedence();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleMethodReference(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		MethodReference newNode = new MethodReference();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleTraitAlias(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPTraitAlias newNode = new PHPTraitAlias();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 
 
 	/* nodes with exactly 3 children */
@@ -1326,6 +1434,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleIdentifierList(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		IdentifierList newNode = new IdentifierList();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleTraitAdaptations(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPTraitAdaptations newNode = new PHPTraitAdaptations();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -40,6 +40,7 @@ import ast.php.statements.PropertyElement;
 import ast.php.statements.StaticVariableDeclaration;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.MethodReference;
+import ast.php.statements.blockstarters.PHPDeclareStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPIfStatement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
@@ -152,6 +153,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SWITCH_CASE:
 				retval = handleSwitchCase(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_DECLARE:
+				retval = handleDeclare(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_PROP_ELEM:
 				retval = handlePropertyElement(row, ast);
@@ -829,6 +833,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleSwitchCase(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPSwitchCase newNode = new PHPSwitchCase();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleDeclare(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPDeclareStatement newNode = new PHPDeclareStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -34,6 +34,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
 import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
+import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.blockstarters.ForEachStatement;
@@ -172,7 +173,10 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_TRAIT_ALIAS:
 				retval = handleTraitAlias(row, ast);
 				break;
-
+			case PHPCSVNodeTypes.TYPE_GROUP_USE:
+				retval = handleGroupUse(row, ast);
+				break;
+				
 			// nodes with exactly 3 children
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
 				retval = handleMethodCall(row, ast);
@@ -975,6 +979,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleTraitAlias(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPTraitAlias newNode = new PHPTraitAlias();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleGroupUse(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPGroupUseStatement newNode = new PHPGroupUseStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -49,6 +49,8 @@ import ast.php.statements.blockstarters.PHPTraitPrecedence;
 import ast.php.statements.blockstarters.PHPUseTrait;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.UseElement;
+import ast.statements.UseStatement;
 import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.CatchStatement;
 import ast.statements.blockstarters.DoStatement;
@@ -160,6 +162,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_METHOD_REFERENCE:
 				retval = handleMethodReference(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_USE_ELEM:
+				retval = handleUseElement(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_TRAIT_ALIAS:
 				retval = handleTraitAlias(row, ast);
 				break;
@@ -241,6 +246,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_TRAIT_ADAPTATIONS:
 				retval = handleTraitAdaptations(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_USE:
+				retval = handleUseStatement(row, ast);
 				break;
 
 			default:
@@ -916,6 +924,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		return id;
 	}
 	
+	private long handleUseElement(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		UseElement newNode = new UseElement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handleTraitAlias(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPTraitAlias newNode = new PHPTraitAlias();
@@ -1456,6 +1486,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleTraitAdaptations(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPTraitAdaptations newNode = new PHPTraitAdaptations();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleUseStatement(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		UseStatement newNode = new UseStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -7,6 +7,7 @@ import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
 import ast.expressions.ArgumentList;
+import ast.expressions.ArrayIndexing;
 import ast.expressions.CallExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
@@ -126,6 +127,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			case PHPCSVNodeTypes.TYPE_DIM:
+				retval = handleArrayIndexing(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_CALL:
 				retval = handleCall(row, ast);
 				break;
@@ -653,6 +657,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	
 	
 	/* nodes with exactly 2 children */
+	
+	private long handleArrayIndexing(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		ArrayIndexing newNode = new ArrayIndexing();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
 	
 	private long handleCall(KeyedCSVRow row, ASTUnderConstruction ast)
 	{

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -69,6 +69,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_USE_TRAIT = "AST_USE_TRAIT";
 	public static final String TYPE_TRAIT_PRECEDENCE = "AST_TRAIT_PRECEDENCE";
 	public static final String TYPE_METHOD_REFERENCE = "AST_METHOD_REFERENCE";
+	public static final String TYPE_NAMESPACE = "AST_NAMESPACE";
 	public static final String TYPE_USE_ELEM = "AST_USE_ELEM";
 	public static final String TYPE_TRAIT_ALIAS = "AST_TRAIT_ALIAS";
 

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -59,6 +59,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	
+	public static final String TYPE_STATIC = "AST_STATIC";
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
 	public static final String TYPE_IF_ELEM = "AST_IF_ELEM";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -69,6 +69,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_USE_TRAIT = "AST_USE_TRAIT";
 	public static final String TYPE_TRAIT_PRECEDENCE = "AST_TRAIT_PRECEDENCE";
 	public static final String TYPE_METHOD_REFERENCE = "AST_METHOD_REFERENCE";
+	public static final String TYPE_USE_ELEM = "AST_USE_ELEM";
 	public static final String TYPE_TRAIT_ALIAS = "AST_TRAIT_ALIAS";
 
 	// nodes with exactly 3 children
@@ -101,6 +102,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CLASS_CONST_DECL = "AST_CLASS_CONST_DECL";
 	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";
 	public static final String TYPE_TRAIT_ADAPTATIONS = "AST_TRAIT_ADAPTATIONS";
+	public static final String TYPE_USE = "AST_USE";
 
 	/* node flags */
 	// flags for toplevel nodes

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 
 	// nodes with exactly 2 children
+	public static final String TYPE_DIM = "AST_DIM";
 	public static final String TYPE_CALL = "AST_CALL";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -45,8 +45,10 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CLASS = "AST_CLASS";
 
 	// nodes with exactly 1 child
+	// expressions
 	public static final String TYPE_VAR = "AST_VAR";
 	
+	// statements
 	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_LABEL = "AST_LABEL";
 	public static final String TYPE_THROW = "AST_THROW";
@@ -55,11 +57,16 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CONTINUE = "AST_CONTINUE";
 
 	// nodes with exactly 2 children
+	// expressions
 	public static final String TYPE_DIM = "AST_DIM";
+	public static final String TYPE_PROP = "AST_PROP";
+	public static final String TYPE_STATIC_PROP = "AST_STATIC_PROP";
 	public static final String TYPE_CALL = "AST_CALL";
+	public static final String TYPE_CLASS_CONST = "AST_CLASS_CONST";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	
+	// statements
 	public static final String TYPE_STATIC = "AST_STATIC";
 	public static final String TYPE_WHILE = "AST_WHILE";
 	public static final String TYPE_DO_WHILE = "AST_DO_WHILE";
@@ -78,15 +85,18 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_GROUP_USE = "AST_GROUP_USE";
 
 	// nodes with exactly 3 children
+	// expressions
 	public static final String TYPE_METHOD_CALL = "AST_METHOD_CALL";
 	public static final String TYPE_STATIC_CALL = "AST_STATIC_CALL";
 	public static final String TYPE_CONDITIONAL = "AST_CONDITIONAL";
 
+	// statements
 	public static final String TYPE_TRY = "AST_TRY";
 	public static final String TYPE_CATCH = "AST_CATCH";
 	public static final String TYPE_PARAM = "AST_PARAM";
 
 	// nodes with exactly 4 children
+	// statements
 	public static final String TYPE_FOR = "AST_FOR";
 	public static final String TYPE_FOREACH = "AST_FOREACH";
 

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -65,6 +65,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_IF_ELEM = "AST_IF_ELEM";
 	public static final String TYPE_SWITCH = "AST_SWITCH";
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
+	public static final String TYPE_DECLARE = "AST_DECLARE";
 	public static final String TYPE_PROP_ELEM = "AST_PROP_ELEM";
 	public static final String TYPE_CONST_ELEM = "AST_CONST_ELEM";
 	public static final String TYPE_USE_TRAIT = "AST_USE_TRAIT";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -66,6 +66,10 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SWITCH_CASE = "AST_SWITCH_CASE";
 	public static final String TYPE_PROP_ELEM = "AST_PROP_ELEM";
 	public static final String TYPE_CONST_ELEM = "AST_CONST_ELEM";
+	public static final String TYPE_USE_TRAIT = "AST_USE_TRAIT";
+	public static final String TYPE_TRAIT_PRECEDENCE = "AST_TRAIT_PRECEDENCE";
+	public static final String TYPE_METHOD_REFERENCE = "AST_METHOD_REFERENCE";
+	public static final String TYPE_TRAIT_ALIAS = "AST_TRAIT_ALIAS";
 
 	// nodes with exactly 3 children
 	public static final String TYPE_METHOD_CALL = "AST_METHOD_CALL";
@@ -96,6 +100,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CONST_DECL = "AST_CONST_DECL";
 	public static final String TYPE_CLASS_CONST_DECL = "AST_CLASS_CONST_DECL";
 	public static final String TYPE_NAME_LIST = "AST_NAME_LIST";
+	public static final String TYPE_TRAIT_ADAPTATIONS = "AST_TRAIT_ADAPTATIONS";
 
 	/* node flags */
 	// flags for toplevel nodes

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -72,6 +72,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_NAMESPACE = "AST_NAMESPACE";
 	public static final String TYPE_USE_ELEM = "AST_USE_ELEM";
 	public static final String TYPE_TRAIT_ALIAS = "AST_TRAIT_ALIAS";
+	public static final String TYPE_GROUP_USE = "AST_GROUP_USE";
 
 	// nodes with exactly 3 children
 	public static final String TYPE_METHOD_CALL = "AST_METHOD_CALL";


### PR DESCRIPTION
**Support for traits**

This was a rather lengthy one. Traits are a feature quite specific to PHP, see http://php.net/manual/en/language.oop5.traits.php.

* `AST_USE_TRAIT` -> `ast.php.statements.blockstarters.PHPUseTrait`
* `AST_TRAIT_ADAPTATIONS` -> `ast.php.statements.blockstarters.PHPTraitAdaptations`
* `AST_TRAIT_ALIAS` -> `ast.php.statements.blockstarters.PHPTraitAlias`
* `AST_TRAIT_PRECEDENCE` -> `ast.php.statements.blockstarters.PHPTraitPrecedence`
* `AST_METHOD_REFERENCE` -> `ast.php.statements.blockstarters.MethodReference`

Additionally, created a new class `ast.php.statements.blockstarters.PHPTraitAdaptationElement` as a common ancestor for `PHPTraitAlias` and `PHPTraitPrecedence`.

Roughly, the hierarchy is:
* A `PHPUseTrait` node has an `IdentifierList` and (optionally) a `PHPTraitAdaptations` child (or `null` child);
* a `PHPTraitAdaptations` node has an arbitrary number of `PHPTraitAdaptationElement`'s as children;
* a `PHPTraitAlias` has a `MethodReference` and a `string` child;
* a `PHPTraitPrecedence` has a `MethodReference` and an `IdentifierList` child;
* a `MethodReference` has an `Identifier` and a `string` child.

**Support for use statements**

* `AST_USE` -> `ast.statements.UseStatement`
* `AST_USE_ELEM` -> `ast.statements.UseElement`

As opposed to the trait statements, I put these into the base `ast.statements` package, since these may also be useful for other languages. In particular, C++ also has support for namespaces, and these classes could then later also be used to add support for the `using ...;` directive (possibly with some modifications/extensions), as Joern already has some support for C++.

The really cool news here is that we finished mapping *all* PHP node types that may have an arbitrarily large number of children. We also finished all nodes with 3 or 4 children a while ago, so now only some nodes with 0, 1 or 2 children remain. :blush: 