### PR TITLE
Support for assignments and for binary operation expressions

### DIFF
--- a/src/ast/expressions/AdditiveExpression.java
+++ b/src/ast/expressions/AdditiveExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class AdditiveExpression extends BinaryExpression
+public class AdditiveExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/AndExpression.java
+++ b/src/ast/expressions/AndExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class AndExpression extends BinaryExpression
+public class AndExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/AssignmentExpr.java
+++ b/src/ast/expressions/AssignmentExpr.java
@@ -1,6 +1,0 @@
-package ast.expressions;
-
-public class AssignmentExpr extends BinaryExpression
-{
-
-}

--- a/src/ast/expressions/AssignmentExpression.java
+++ b/src/ast/expressions/AssignmentExpression.java
@@ -1,0 +1,26 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class AssignmentExpression extends BinaryExpression
+{
+	public ASTNode getVariable() // TODO return an Expression
+	{          
+		return getLeft();
+	}          
+
+	public void setVariable(ASTNode variable) // TODO take an Expression
+	{          
+		setLeft(variable);
+	}          
+
+	public ASTNode getAssignExpression() // TODO return an Expression
+	{
+		return getRight();
+	}
+
+	public void setAssignExpression(ASTNode assignExpression) // TODO take an Expression
+	{
+		setRight(assignExpression);
+	}
+}

--- a/src/ast/expressions/AssignmentWithOpExpression.java
+++ b/src/ast/expressions/AssignmentWithOpExpression.java
@@ -1,0 +1,6 @@
+package ast.expressions;
+
+public class AssignmentWithOpExpression extends AssignmentExpression
+{
+
+}

--- a/src/ast/expressions/BinaryExpression.java
+++ b/src/ast/expressions/BinaryExpression.java
@@ -4,58 +4,42 @@ import ast.ASTNode;
 
 public class BinaryExpression extends Expression
 {
-	Expression subExpressions[] = new Expression[2];
-
-	public Expression getLeft()
+	ASTNode leftExpression = null; // TODO make this an Expression again, once PHP mapping is finished
+	ASTNode rightExpression = null; // TODO make this an Expression again, once PHP mapping is finished
+	
+	public ASTNode getLeft() // TODO return Expression
 	{
-		return subExpressions[0];
+		return this.leftExpression;
 	}
 
-	public Expression getRight()
+	protected void setLeft(ASTNode leftExpression) // TODO take Expression
 	{
-		return subExpressions[1];
+		this.leftExpression = leftExpression;
+		super.addChild(leftExpression);
+	}
+	
+	public ASTNode getRight() // TODO return Expression
+	{
+		return this.rightExpression;
 	}
 
-	private void setLeft(Expression aLeft)
+	protected void setRight(ASTNode rightExpression) // TODO take Expression
 	{
-		subExpressions[0] = aLeft;
-	}
-
-	private void setRight(Expression aRight)
-	{
-		subExpressions[1] = aRight;
+		this.rightExpression = rightExpression;
+		super.addChild(rightExpression);
 	}
 
 	@Override
 	public void addChild(ASTNode item)
 	{
-		Expression expression = (Expression) item;
+		// TODO cast this to an Expression again
+		//Expression expression = (Expression) item;
 		if (getLeft() == null)
-			setLeft(expression);
+			setLeft(item);
 		else if (getRight() == null)
-			setRight(expression);
+			setRight(item);
 		else
 			throw new RuntimeException(
 					"Error: attempting to add third child to binary expression");
-
-		super.addChild(item);
 	}
-
-	@Override
-	public int getChildCount()
-	{
-		int childCount = 0;
-		if (getLeft() != null)
-			childCount++;
-		if (getRight() != null)
-			childCount++;
-		return childCount;
-	}
-
-	@Override
-	public ASTNode getChild(int i)
-	{
-		return subExpressions[i];
-	}
-
 }

--- a/src/ast/expressions/BinaryOperationExpression.java
+++ b/src/ast/expressions/BinaryOperationExpression.java
@@ -1,0 +1,20 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class BinaryOperationExpression extends BinaryExpression
+{
+	// for binary operation expressions, change visibility of setLeft() and setRight()
+
+	@Override
+	public void setLeft(ASTNode leftExpression) // TODO take Expression
+	{
+		super.setLeft(leftExpression);
+	}
+
+	@Override
+	public void setRight(ASTNode rightExpression) // TODO take Expression
+	{
+		super.setRight(rightExpression);
+	}
+}

--- a/src/ast/expressions/BitAndExpression.java
+++ b/src/ast/expressions/BitAndExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class BitAndExpression extends BinaryExpression
+public class BitAndExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/EqualityExpression.java
+++ b/src/ast/expressions/EqualityExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class EqualityExpression extends BinaryExpression
+public class EqualityExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/ExclusiveOrExpression.java
+++ b/src/ast/expressions/ExclusiveOrExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class ExclusiveOrExpression extends BinaryExpression
+public class ExclusiveOrExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/GreaterExpression.java
+++ b/src/ast/expressions/GreaterExpression.java
@@ -1,0 +1,8 @@
+package ast.expressions;
+
+public class GreaterExpression extends RelationalExpression
+{
+	// TODO remove this class once phpjoern uses version 20 of Niki's php-ast extension,
+	// as "greater than" expressions will then be consistently mapped onto a BinaryOperationExpression
+	// with an appropriate flag.
+}

--- a/src/ast/expressions/GreaterOrEqualExpression.java
+++ b/src/ast/expressions/GreaterOrEqualExpression.java
@@ -1,0 +1,8 @@
+package ast.expressions;
+
+public class GreaterOrEqualExpression extends RelationalExpression
+{
+	// TODO remove this class once phpjoern uses version 20 of Niki's php-ast extension,
+	// as "greater or equal than" expressions will then be consistently mapped onto a BinaryOperationExpression
+	// with an appropriate flag.
+}

--- a/src/ast/expressions/InclusiveOrExpression.java
+++ b/src/ast/expressions/InclusiveOrExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class InclusiveOrExpression extends BinaryExpression
+public class InclusiveOrExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/MultiplicativeExpression.java
+++ b/src/ast/expressions/MultiplicativeExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class MultiplicativeExpression extends BinaryExpression
+public class MultiplicativeExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/OrExpression.java
+++ b/src/ast/expressions/OrExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class OrExpression extends BinaryExpression
+public class OrExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/RelationalExpression.java
+++ b/src/ast/expressions/RelationalExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class RelationalExpression extends BinaryExpression
+public class RelationalExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/expressions/ShiftExpression.java
+++ b/src/ast/expressions/ShiftExpression.java
@@ -1,5 +1,5 @@
 package ast.expressions;
 
-public class ShiftExpression extends BinaryExpression
+public class ShiftExpression extends BinaryOperationExpression
 {
 }

--- a/src/ast/php/expressions/PHPAssignmentByRefExpression.java
+++ b/src/ast/php/expressions/PHPAssignmentByRefExpression.java
@@ -1,0 +1,8 @@
+package ast.php.expressions;
+
+import ast.expressions.AssignmentExpression;
+
+public class PHPAssignmentByRefExpression extends AssignmentExpression
+{
+
+}

--- a/src/ast/walking/ASTNodeVisitor.java
+++ b/src/ast/walking/ASTNodeVisitor.java
@@ -5,7 +5,7 @@ import java.util.Stack;
 import ast.ASTNode;
 import ast.declarations.ClassDefStatement;
 import ast.expressions.Argument;
-import ast.expressions.AssignmentExpr;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.Identifier;
 import ast.expressions.MemberAccess;
@@ -88,7 +88,7 @@ public abstract class ASTNodeVisitor
 		defaultHandler(expression);
 	}
 
-	public void visit(AssignmentExpr expression)
+	public void visit(AssignmentExpression expression)
 	{
 		defaultHandler(expression);
 	}

--- a/src/languages/c/parsing/ASTNodeFactory.java
+++ b/src/languages/c/parsing/ASTNodeFactory.java
@@ -3,7 +3,7 @@ package languages.c.parsing;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 import ast.ASTNode;
-import ast.expressions.AssignmentExpr;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.BinaryExpression;
 import ast.expressions.Expression;
 import ast.expressions.Identifier;
@@ -51,9 +51,9 @@ public class ASTNodeFactory
 		return retval;
 	}
 
-	public static AssignmentExpr create(InitDeclWithAssignContext ctx)
+	public static AssignmentExpression create(InitDeclWithAssignContext ctx)
 	{
-		AssignmentExpr assign = new AssignmentExpr();
+		AssignmentExpression assign = new AssignmentExpression();
 		initializeFromContext(assign, ctx);
 		if (ctx.getChildCount() == 3)
 			assign.setOperator(ctx.getChild(1).getText());

--- a/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
+++ b/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
@@ -15,7 +15,7 @@ import ast.expressions.AndExpression;
 import ast.expressions.Argument;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
-import ast.expressions.AssignmentExpr;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.BitAndExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.Callee;
@@ -261,7 +261,7 @@ public class FunctionContentBuilder extends ASTNodeBuilder
 
 	public void enterAssignment(Assign_exprContext ctx)
 	{
-		AssignmentExpr expr = new AssignmentExpr();
+		AssignmentExpression expr = new AssignmentExpression();
 		nodeToRuleContext.put(expr, ctx);
 		stack.push(expr);
 	}
@@ -560,7 +560,7 @@ public class FunctionContentBuilder extends ASTNodeBuilder
 		IdentifierDecl identifierDecl = (IdentifierDecl) stack.pop();
 
 		Expression lastChild = (Expression) identifierDecl.popLastChild();
-		AssignmentExpr assign = ASTNodeFactory.create(ctx);
+		AssignmentExpression assign = ASTNodeFactory.create(ctx);
 
 		// This is a bit of a hack. As we go up,
 		// we introduce an artificial assignment-node.

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import ast.ASTNode;
+import ast.expressions.AndExpression;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
@@ -22,8 +23,11 @@ import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
+import ast.expressions.GreaterExpression;
+import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.Variable;
@@ -1821,6 +1825,170 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node20.getChildCount());
 		assertEquals( ast.getNodeById((long)99), ((BinaryOperationExpression)node20).getLeft());
 		assertEquals( ast.getNodeById((long)101), ((BinaryOperationExpression)node20).getRight());
+	}
+	
+	/**
+	 * AST_GREATER nodes are used to denote binary operation "greater than" expressions.
+	 * 
+	 * TODO once version 20 of Niki's php-ast extension is stable, update phpjoern parser and make
+	 * this a normal AST_BINARY_OP node.
+	 * 
+	 * Any AST_GREATER node has exactly two children:
+	 * 1) an expression on the left-hand side
+	 * 2) an expression on the right-hand side
+	 * 
+	 * This test checks a "greater than" expression's children in the following PHP code:
+	 * 
+	 * // comparison operators
+	 * $x > $y;
+	 */
+	@Test
+	public void testGreaterCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_GREATER,,4,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "5,string,,4,\"x\",0,1,,,\n";
+		nodeStr += "6,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "7,string,,4,\"y\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(GreaterExpression.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((GreaterExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((GreaterExpression)node).getRight());
+	}
+	
+	/**
+	 * AST_GREATER_EQUAL nodes are used to denote binary operation "greater or equal than" expressions.
+	 * 
+	 * TODO once version 20 of Niki's php-ast extension is stable, update phpjoern parser and make
+	 * this a normal AST_BINARY_OP node.
+	 * 
+	 * Any AST_GREATER_EQUAL node has exactly two children:
+	 * 1) an expression on the left-hand side
+	 * 2) an expression on the right-hand side
+	 * 
+	 * This test checks a "greater or equal than" expression's children in the following PHP code:
+	 * 
+	 * // comparison operators
+	 * $x >= $y;
+	 */
+	@Test
+	public void testGreaterOrEqualCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_GREATER_EQUAL,,4,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "5,string,,4,\"x\",0,1,,,\n";
+		nodeStr += "6,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "7,string,,4,\"y\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(GreaterOrEqualExpression.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((GreaterOrEqualExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((GreaterOrEqualExpression)node).getRight());
+	}
+	
+	/**
+	 * AST_AND nodes are used to denote binary operation "boolean and" expressions.
+	 * 
+	 * TODO once version 20 of Niki's php-ast extension is stable, update phpjoern parser and make
+	 * this a normal AST_BINARY_OP node.
+	 * 
+	 * Any AST_AND node has exactly two children:
+	 * 1) an expression on the left-hand side
+	 * 2) an expression on the right-hand side
+	 * 
+	 * This test checks a "boolean and" expression's children in the following PHP code:
+	 * 
+	 * // boolean operators
+	 * $x && $y;
+	 */
+	@Test
+	public void testAndCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_AND,,4,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "5,string,,4,\"x\",0,1,,,\n";
+		nodeStr += "6,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "7,string,,4,\"y\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(AndExpression.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((AndExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((AndExpression)node).getRight());
+	}
+	
+	/**
+	 * AST_OR nodes are used to denote binary operation "boolean or" expressions.
+	 * 
+	 * TODO once version 20 of Niki's php-ast extension is stable, update phpjoern parser and make
+	 * this a normal AST_BINARY_OP node.
+	 * 
+	 * Any AST_OR node has exactly two children:
+	 * 1) an expression on the left-hand side
+	 * 2) an expression on the right-hand side
+	 * 
+	 * This test checks a "boolean or" expression's children in the following PHP code:
+	 * 
+	 * // boolean operators
+	 * $x || $y;
+	 */
+	@Test
+	public void testOrCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_OR,,4,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "5,string,,4,\"x\",0,1,,,\n";
+		nodeStr += "6,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "7,string,,4,\"y\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(OrExpression.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((OrExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((OrExpression)node).getRight());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -17,6 +17,7 @@ import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
 import ast.expressions.AssignmentWithOpExpression;
+import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -1453,6 +1454,373 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)12), ((AssignmentWithOpExpression)node3).getVariable());
 		assertEquals( ast.getNodeById((long)14), ((AssignmentWithOpExpression)node3).getAssignExpression());
+	}
+	
+	/**
+	 * AST_BINARY_OP nodes are used to denote binary operation expressions.
+	 * 
+	 * Any AST_BINARY_OP node has exactly two children:
+	 * 1) an expression on the left-hand side
+	 * 2) an expression on the right-hand side
+	 * 
+	 * This test checks a plethora of binary operation expressions' children in the following PHP code:
+	 * 
+	 * // bit operators
+	 * $or1 | $or2;
+	 * $and1 & $and2;
+	 * $msg ^ $otp;
+	 * $x << $y;
+	 * $x >> $y;
+	 * // string operators
+	 * $str1 . $str2;
+	 * // arithmetic operators
+	 * $x + $y;
+	 * $x - $y;
+	 * $x * $y;
+	 * $x / $y;
+	 * $x % $y;
+	 * $x ** $y;
+	 * // boolean operators
+	 * $x xor $y;
+	 * // comparison operators
+	 * $x === $y;
+	 * $x !== $y;
+	 * $x == $y;
+	 * $x != $y;
+	 * $x < $y;
+	 * $x <= $y;
+	 * $x <=> $y;
+	 */
+	@Test
+	public void testBinaryOperationCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_BINARY_OP,BINARY_BITWISE_OR,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"or1\",0,1,,,\n";
+		nodeStr += "6,AST_VAR,,3,,1,1,,,\n";
+		nodeStr += "7,string,,3,\"or2\",0,1,,,\n";
+		nodeStr += "8,AST_BINARY_OP,BINARY_BITWISE_AND,4,,1,1,,,\n";
+		nodeStr += "9,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "10,string,,4,\"and1\",0,1,,,\n";
+		nodeStr += "11,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "12,string,,4,\"and2\",0,1,,,\n";
+		nodeStr += "13,AST_BINARY_OP,BINARY_BITWISE_XOR,5,,2,1,,,\n";
+		nodeStr += "14,AST_VAR,,5,,0,1,,,\n";
+		nodeStr += "15,string,,5,\"msg\",0,1,,,\n";
+		nodeStr += "16,AST_VAR,,5,,1,1,,,\n";
+		nodeStr += "17,string,,5,\"otp\",0,1,,,\n";
+		nodeStr += "18,AST_BINARY_OP,BINARY_CONCAT,7,,3,1,,,\n";
+		nodeStr += "19,AST_VAR,,7,,0,1,,,\n";
+		nodeStr += "20,string,,7,\"str1\",0,1,,,\n";
+		nodeStr += "21,AST_VAR,,7,,1,1,,,\n";
+		nodeStr += "22,string,,7,\"str2\",0,1,,,\n";
+		nodeStr += "23,AST_BINARY_OP,BINARY_ADD,9,,4,1,,,\n";
+		nodeStr += "24,AST_VAR,,9,,0,1,,,\n";
+		nodeStr += "25,string,,9,\"x\",0,1,,,\n";
+		nodeStr += "26,AST_VAR,,9,,1,1,,,\n";
+		nodeStr += "27,string,,9,\"y\",0,1,,,\n";
+		nodeStr += "28,AST_BINARY_OP,BINARY_SUB,10,,5,1,,,\n";
+		nodeStr += "29,AST_VAR,,10,,0,1,,,\n";
+		nodeStr += "30,string,,10,\"x\",0,1,,,\n";
+		nodeStr += "31,AST_VAR,,10,,1,1,,,\n";
+		nodeStr += "32,string,,10,\"y\",0,1,,,\n";
+		nodeStr += "33,AST_BINARY_OP,BINARY_MUL,11,,6,1,,,\n";
+		nodeStr += "34,AST_VAR,,11,,0,1,,,\n";
+		nodeStr += "35,string,,11,\"x\",0,1,,,\n";
+		nodeStr += "36,AST_VAR,,11,,1,1,,,\n";
+		nodeStr += "37,string,,11,\"y\",0,1,,,\n";
+		nodeStr += "38,AST_BINARY_OP,BINARY_DIV,12,,7,1,,,\n";
+		nodeStr += "39,AST_VAR,,12,,0,1,,,\n";
+		nodeStr += "40,string,,12,\"x\",0,1,,,\n";
+		nodeStr += "41,AST_VAR,,12,,1,1,,,\n";
+		nodeStr += "42,string,,12,\"y\",0,1,,,\n";
+		nodeStr += "43,AST_BINARY_OP,BINARY_MOD,13,,8,1,,,\n";
+		nodeStr += "44,AST_VAR,,13,,0,1,,,\n";
+		nodeStr += "45,string,,13,\"x\",0,1,,,\n";
+		nodeStr += "46,AST_VAR,,13,,1,1,,,\n";
+		nodeStr += "47,string,,13,\"y\",0,1,,,\n";
+		nodeStr += "48,AST_BINARY_OP,BINARY_POW,14,,9,1,,,\n";
+		nodeStr += "49,AST_VAR,,14,,0,1,,,\n";
+		nodeStr += "50,string,,14,\"x\",0,1,,,\n";
+		nodeStr += "51,AST_VAR,,14,,1,1,,,\n";
+		nodeStr += "52,string,,14,\"y\",0,1,,,\n";
+		nodeStr += "53,AST_BINARY_OP,BINARY_SHIFT_LEFT,15,,10,1,,,\n";
+		nodeStr += "54,AST_VAR,,15,,0,1,,,\n";
+		nodeStr += "55,string,,15,\"x\",0,1,,,\n";
+		nodeStr += "56,AST_VAR,,15,,1,1,,,\n";
+		nodeStr += "57,string,,15,\"y\",0,1,,,\n";
+		nodeStr += "58,AST_BINARY_OP,BINARY_SHIFT_RIGHT,16,,11,1,,,\n";
+		nodeStr += "59,AST_VAR,,16,,0,1,,,\n";
+		nodeStr += "60,string,,16,\"x\",0,1,,,\n";
+		nodeStr += "61,AST_VAR,,16,,1,1,,,\n";
+		nodeStr += "62,string,,16,\"y\",0,1,,,\n";
+		nodeStr += "63,AST_BINARY_OP,BINARY_BOOL_XOR,18,,12,1,,,\n";
+		nodeStr += "64,AST_VAR,,18,,0,1,,,\n";
+		nodeStr += "65,string,,18,\"x\",0,1,,,\n";
+		nodeStr += "66,AST_VAR,,18,,1,1,,,\n";
+		nodeStr += "67,string,,18,\"y\",0,1,,,\n";
+		nodeStr += "68,AST_BINARY_OP,BINARY_IS_IDENTICAL,20,,13,1,,,\n";
+		nodeStr += "69,AST_VAR,,20,,0,1,,,\n";
+		nodeStr += "70,string,,20,\"x\",0,1,,,\n";
+		nodeStr += "71,AST_VAR,,20,,1,1,,,\n";
+		nodeStr += "72,string,,20,\"y\",0,1,,,\n";
+		nodeStr += "73,AST_BINARY_OP,BINARY_IS_NOT_IDENTICAL,21,,14,1,,,\n";
+		nodeStr += "74,AST_VAR,,21,,0,1,,,\n";
+		nodeStr += "75,string,,21,\"x\",0,1,,,\n";
+		nodeStr += "76,AST_VAR,,21,,1,1,,,\n";
+		nodeStr += "77,string,,21,\"y\",0,1,,,\n";
+		nodeStr += "78,AST_BINARY_OP,BINARY_IS_EQUAL,22,,15,1,,,\n";
+		nodeStr += "79,AST_VAR,,22,,0,1,,,\n";
+		nodeStr += "80,string,,22,\"x\",0,1,,,\n";
+		nodeStr += "81,AST_VAR,,22,,1,1,,,\n";
+		nodeStr += "82,string,,22,\"y\",0,1,,,\n";
+		nodeStr += "83,AST_BINARY_OP,BINARY_IS_NOT_EQUAL,23,,16,1,,,\n";
+		nodeStr += "84,AST_VAR,,23,,0,1,,,\n";
+		nodeStr += "85,string,,23,\"x\",0,1,,,\n";
+		nodeStr += "86,AST_VAR,,23,,1,1,,,\n";
+		nodeStr += "87,string,,23,\"y\",0,1,,,\n";
+		nodeStr += "88,AST_BINARY_OP,BINARY_IS_SMALLER,24,,17,1,,,\n";
+		nodeStr += "89,AST_VAR,,24,,0,1,,,\n";
+		nodeStr += "90,string,,24,\"x\",0,1,,,\n";
+		nodeStr += "91,AST_VAR,,24,,1,1,,,\n";
+		nodeStr += "92,string,,24,\"y\",0,1,,,\n";
+		nodeStr += "93,AST_BINARY_OP,BINARY_IS_SMALLER_OR_EQUAL,25,,18,1,,,\n";
+		nodeStr += "94,AST_VAR,,25,,0,1,,,\n";
+		nodeStr += "95,string,,25,\"x\",0,1,,,\n";
+		nodeStr += "96,AST_VAR,,25,,1,1,,,\n";
+		nodeStr += "97,string,,25,\"y\",0,1,,,\n";
+		nodeStr += "98,AST_BINARY_OP,BINARY_SPACESHIP,26,,19,1,,,\n";
+		nodeStr += "99,AST_VAR,,26,,0,1,,,\n";
+		nodeStr += "100,string,,26,\"x\",0,1,,,\n";
+		nodeStr += "101,AST_VAR,,26,,1,1,,,\n";
+		nodeStr += "102,string,,26,\"y\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "9,10,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "8,11,PARENT_OF\n";
+		edgeStr += "2,8,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "16,17,PARENT_OF\n";
+		edgeStr += "13,16,PARENT_OF\n";
+		edgeStr += "2,13,PARENT_OF\n";
+		edgeStr += "19,20,PARENT_OF\n";
+		edgeStr += "18,19,PARENT_OF\n";
+		edgeStr += "21,22,PARENT_OF\n";
+		edgeStr += "18,21,PARENT_OF\n";
+		edgeStr += "2,18,PARENT_OF\n";
+		edgeStr += "24,25,PARENT_OF\n";
+		edgeStr += "23,24,PARENT_OF\n";
+		edgeStr += "26,27,PARENT_OF\n";
+		edgeStr += "23,26,PARENT_OF\n";
+		edgeStr += "2,23,PARENT_OF\n";
+		edgeStr += "29,30,PARENT_OF\n";
+		edgeStr += "28,29,PARENT_OF\n";
+		edgeStr += "31,32,PARENT_OF\n";
+		edgeStr += "28,31,PARENT_OF\n";
+		edgeStr += "2,28,PARENT_OF\n";
+		edgeStr += "34,35,PARENT_OF\n";
+		edgeStr += "33,34,PARENT_OF\n";
+		edgeStr += "36,37,PARENT_OF\n";
+		edgeStr += "33,36,PARENT_OF\n";
+		edgeStr += "2,33,PARENT_OF\n";
+		edgeStr += "39,40,PARENT_OF\n";
+		edgeStr += "38,39,PARENT_OF\n";
+		edgeStr += "41,42,PARENT_OF\n";
+		edgeStr += "38,41,PARENT_OF\n";
+		edgeStr += "2,38,PARENT_OF\n";
+		edgeStr += "44,45,PARENT_OF\n";
+		edgeStr += "43,44,PARENT_OF\n";
+		edgeStr += "46,47,PARENT_OF\n";
+		edgeStr += "43,46,PARENT_OF\n";
+		edgeStr += "2,43,PARENT_OF\n";
+		edgeStr += "49,50,PARENT_OF\n";
+		edgeStr += "48,49,PARENT_OF\n";
+		edgeStr += "51,52,PARENT_OF\n";
+		edgeStr += "48,51,PARENT_OF\n";
+		edgeStr += "2,48,PARENT_OF\n";
+		edgeStr += "54,55,PARENT_OF\n";
+		edgeStr += "53,54,PARENT_OF\n";
+		edgeStr += "56,57,PARENT_OF\n";
+		edgeStr += "53,56,PARENT_OF\n";
+		edgeStr += "2,53,PARENT_OF\n";
+		edgeStr += "59,60,PARENT_OF\n";
+		edgeStr += "58,59,PARENT_OF\n";
+		edgeStr += "61,62,PARENT_OF\n";
+		edgeStr += "58,61,PARENT_OF\n";
+		edgeStr += "2,58,PARENT_OF\n";
+		edgeStr += "64,65,PARENT_OF\n";
+		edgeStr += "63,64,PARENT_OF\n";
+		edgeStr += "66,67,PARENT_OF\n";
+		edgeStr += "63,66,PARENT_OF\n";
+		edgeStr += "2,63,PARENT_OF\n";
+		edgeStr += "69,70,PARENT_OF\n";
+		edgeStr += "68,69,PARENT_OF\n";
+		edgeStr += "71,72,PARENT_OF\n";
+		edgeStr += "68,71,PARENT_OF\n";
+		edgeStr += "2,68,PARENT_OF\n";
+		edgeStr += "74,75,PARENT_OF\n";
+		edgeStr += "73,74,PARENT_OF\n";
+		edgeStr += "76,77,PARENT_OF\n";
+		edgeStr += "73,76,PARENT_OF\n";
+		edgeStr += "2,73,PARENT_OF\n";
+		edgeStr += "79,80,PARENT_OF\n";
+		edgeStr += "78,79,PARENT_OF\n";
+		edgeStr += "81,82,PARENT_OF\n";
+		edgeStr += "78,81,PARENT_OF\n";
+		edgeStr += "2,78,PARENT_OF\n";
+		edgeStr += "84,85,PARENT_OF\n";
+		edgeStr += "83,84,PARENT_OF\n";
+		edgeStr += "86,87,PARENT_OF\n";
+		edgeStr += "83,86,PARENT_OF\n";
+		edgeStr += "2,83,PARENT_OF\n";
+		edgeStr += "89,90,PARENT_OF\n";
+		edgeStr += "88,89,PARENT_OF\n";
+		edgeStr += "91,92,PARENT_OF\n";
+		edgeStr += "88,91,PARENT_OF\n";
+		edgeStr += "2,88,PARENT_OF\n";
+		edgeStr += "94,95,PARENT_OF\n";
+		edgeStr += "93,94,PARENT_OF\n";
+		edgeStr += "96,97,PARENT_OF\n";
+		edgeStr += "93,96,PARENT_OF\n";
+		edgeStr += "2,93,PARENT_OF\n";
+		edgeStr += "99,100,PARENT_OF\n";
+		edgeStr += "98,99,PARENT_OF\n";
+		edgeStr += "101,102,PARENT_OF\n";
+		edgeStr += "98,101,PARENT_OF\n";
+		edgeStr += "2,98,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)8);
+		ASTNode node3 = ast.getNodeById((long)13);
+		ASTNode node4 = ast.getNodeById((long)18);
+		ASTNode node5 = ast.getNodeById((long)23);
+		ASTNode node6 = ast.getNodeById((long)28);
+		ASTNode node7 = ast.getNodeById((long)33);
+		ASTNode node8 = ast.getNodeById((long)38);
+		ASTNode node9 = ast.getNodeById((long)43);
+		ASTNode node10 = ast.getNodeById((long)48);
+		ASTNode node11 = ast.getNodeById((long)53);
+		ASTNode node12 = ast.getNodeById((long)58);
+		ASTNode node13 = ast.getNodeById((long)63);
+		ASTNode node14 = ast.getNodeById((long)68);
+		ASTNode node15 = ast.getNodeById((long)73);
+		ASTNode node16 = ast.getNodeById((long)78);
+		ASTNode node17 = ast.getNodeById((long)83);
+		ASTNode node18 = ast.getNodeById((long)88);
+		ASTNode node19 = ast.getNodeById((long)93);
+		ASTNode node20 = ast.getNodeById((long)98);
+		
+		assertThat( node, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((BinaryOperationExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((BinaryOperationExpression)node).getRight());
+		
+		assertThat( node2, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)9), ((BinaryOperationExpression)node2).getLeft());
+		assertEquals( ast.getNodeById((long)11), ((BinaryOperationExpression)node2).getRight());
+		
+		assertThat( node3, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node3.getChildCount());
+		assertEquals( ast.getNodeById((long)14), ((BinaryOperationExpression)node3).getLeft());
+		assertEquals( ast.getNodeById((long)16), ((BinaryOperationExpression)node3).getRight());
+		
+		assertThat( node4, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node4.getChildCount());
+		assertEquals( ast.getNodeById((long)19), ((BinaryOperationExpression)node4).getLeft());
+		assertEquals( ast.getNodeById((long)21), ((BinaryOperationExpression)node4).getRight());
+		
+		assertThat( node5, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node5.getChildCount());
+		assertEquals( ast.getNodeById((long)24), ((BinaryOperationExpression)node5).getLeft());
+		assertEquals( ast.getNodeById((long)26), ((BinaryOperationExpression)node5).getRight());
+		
+		assertThat( node6, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node6.getChildCount());
+		assertEquals( ast.getNodeById((long)29), ((BinaryOperationExpression)node6).getLeft());
+		assertEquals( ast.getNodeById((long)31), ((BinaryOperationExpression)node6).getRight());
+		
+		assertThat( node7, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node7.getChildCount());
+		assertEquals( ast.getNodeById((long)34), ((BinaryOperationExpression)node7).getLeft());
+		assertEquals( ast.getNodeById((long)36), ((BinaryOperationExpression)node7).getRight());
+		
+		assertThat( node8, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node8.getChildCount());
+		assertEquals( ast.getNodeById((long)39), ((BinaryOperationExpression)node8).getLeft());
+		assertEquals( ast.getNodeById((long)41), ((BinaryOperationExpression)node8).getRight());
+		
+		assertThat( node9, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node9.getChildCount());
+		assertEquals( ast.getNodeById((long)44), ((BinaryOperationExpression)node9).getLeft());
+		assertEquals( ast.getNodeById((long)46), ((BinaryOperationExpression)node9).getRight());
+		
+		assertThat( node10, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node10.getChildCount());
+		assertEquals( ast.getNodeById((long)49), ((BinaryOperationExpression)node10).getLeft());
+		assertEquals( ast.getNodeById((long)51), ((BinaryOperationExpression)node10).getRight());
+		
+		assertThat( node11, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node11.getChildCount());
+		assertEquals( ast.getNodeById((long)54), ((BinaryOperationExpression)node11).getLeft());
+		assertEquals( ast.getNodeById((long)56), ((BinaryOperationExpression)node11).getRight());
+		
+		assertThat( node12, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node12.getChildCount());
+		assertEquals( ast.getNodeById((long)59), ((BinaryOperationExpression)node12).getLeft());
+		assertEquals( ast.getNodeById((long)61), ((BinaryOperationExpression)node12).getRight());
+		
+		assertThat( node13, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node13.getChildCount());
+		assertEquals( ast.getNodeById((long)64), ((BinaryOperationExpression)node13).getLeft());
+		assertEquals( ast.getNodeById((long)66), ((BinaryOperationExpression)node13).getRight());
+		
+		assertThat( node14, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node14.getChildCount());
+		assertEquals( ast.getNodeById((long)69), ((BinaryOperationExpression)node14).getLeft());
+		assertEquals( ast.getNodeById((long)71), ((BinaryOperationExpression)node14).getRight());
+		
+		assertThat( node15, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node15.getChildCount());
+		assertEquals( ast.getNodeById((long)74), ((BinaryOperationExpression)node15).getLeft());
+		assertEquals( ast.getNodeById((long)76), ((BinaryOperationExpression)node15).getRight());
+		
+		assertThat( node16, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node16.getChildCount());
+		assertEquals( ast.getNodeById((long)79), ((BinaryOperationExpression)node16).getLeft());
+		assertEquals( ast.getNodeById((long)81), ((BinaryOperationExpression)node16).getRight());
+		
+		assertThat( node17, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node17.getChildCount());
+		assertEquals( ast.getNodeById((long)84), ((BinaryOperationExpression)node17).getLeft());
+		assertEquals( ast.getNodeById((long)86), ((BinaryOperationExpression)node17).getRight());
+		
+		assertThat( node18, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node18.getChildCount());
+		assertEquals( ast.getNodeById((long)89), ((BinaryOperationExpression)node18).getLeft());
+		assertEquals( ast.getNodeById((long)91), ((BinaryOperationExpression)node18).getRight());
+		
+		assertThat( node19, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node19.getChildCount());
+		assertEquals( ast.getNodeById((long)94), ((BinaryOperationExpression)node19).getLeft());
+		assertEquals( ast.getNodeById((long)96), ((BinaryOperationExpression)node19).getRight());
+		
+		assertThat( node20, instanceOf(BinaryOperationExpression.class));
+		assertEquals( 2, node20.getChildCount());
+		assertEquals( ast.getNodeById((long)99), ((BinaryOperationExpression)node20).getLeft());
+		assertEquals( ast.getNodeById((long)101), ((BinaryOperationExpression)node20).getRight());
 	}
 	
 	/**

--- a/src/tests/parseTreeToAST/CodeNestingTest.java
+++ b/src/tests/parseTreeToAST/CodeNestingTest.java
@@ -9,7 +9,7 @@ import ast.declarations.ClassDefStatement;
 import ast.declarations.IdentifierDecl;
 import ast.expressions.Argument;
 import ast.expressions.ArgumentList;
-import ast.expressions.AssignmentExpr;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.CallExpression;
 import ast.logical.statements.Condition;
 import ast.logical.statements.BlockStarter;
@@ -58,7 +58,7 @@ public class CodeNestingTest
 		CompoundStatement item = (CompoundStatement) FunctionContentTestUtil
 				.parseAndWalk(input);
 		BlockStarter starter = (BlockStarter) item.getStatements().get(0);
-		AssignmentExpr condition = (AssignmentExpr) ((Condition)starter.getCondition())
+		AssignmentExpression condition = (AssignmentExpression) ((Condition)starter.getCondition())
 				.getExpression();
 		System.out.println(condition.getEscapedCodeStr());
 		assertTrue(condition.getEscapedCodeStr().equals("foo = bar"));
@@ -151,7 +151,7 @@ public class CodeNestingTest
 				.getStatements().get(0);
 		IdentifierDecl decl = (IdentifierDecl) declStatement.getChild(0);
 
-		AssignmentExpr assign = (AssignmentExpr) decl
+		AssignmentExpression assign = (AssignmentExpression) decl
 				.getChild(decl.getChildCount() - 1);
 		assertTrue(assign.getLeft().getEscapedCodeStr().equals("m"));
 		assertTrue(assign.getRight().getEscapedCodeStr()

--- a/src/tests/parseTreeToAST/ExpressionParsingTest.java
+++ b/src/tests/parseTreeToAST/ExpressionParsingTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import ast.declarations.IdentifierDecl;
 import ast.expressions.AdditiveExpression;
 import ast.expressions.AndExpression;
-import ast.expressions.AssignmentExpr;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.BitAndExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.CastExpression;
@@ -36,7 +36,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		ExpressionStatement statementItem = (ExpressionStatement) contentItem
 				.getStatements().get(0);
-		AssignmentExpr expr = (AssignmentExpr) statementItem.getExpression();
+		AssignmentExpression expr = (AssignmentExpression) statementItem.getExpression();
 
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 		assertTrue(expr.getRight().getEscapedCodeStr().equals("y"));
@@ -50,7 +50,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		ExpressionStatement statementItem = (ExpressionStatement) contentItem
 				.getStatements().get(0);
-		AssignmentExpr expr = (AssignmentExpr) statementItem.getExpression();
+		AssignmentExpression expr = (AssignmentExpression) statementItem.getExpression();
 		assertTrue(expr.getLeft().getEscapedCodeStr().equals("x"));
 		assertTrue(expr.getRight().getEscapedCodeStr().equals("y = z"));
 	}
@@ -76,7 +76,7 @@ public class ExpressionParsingTest
 				.parseAndWalk(input);
 		ExpressionStatement statementItem = (ExpressionStatement) contentItem
 				.getStatements().get(0);
-		AssignmentExpr expr = (AssignmentExpr) statementItem.getExpression();
+		AssignmentExpression expr = (AssignmentExpression) statementItem.getExpression();
 		ConditionalExpression right = (ConditionalExpression) expr.getRight();
 		assertTrue(right.getChild(0).getEscapedCodeStr().equals("cond"));
 	}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -5,6 +5,7 @@ import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
 import ast.expressions.AssignmentWithOpExpression;
+import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -172,6 +173,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ASSIGN_OP:
 				errno = handleAssignWithOp((AssignmentWithOpExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_BINARY_OP:
+				errno = handleBinaryOperation((BinaryOperationExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
@@ -809,6 +813,32 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// then, change BinaryExpression.right to be an Expression instead
 				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
 				startNode.setAssignExpression(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleBinaryOperation( BinaryOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // left child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getLeft() and setLeft() accordingly
+				startNode.setLeft(endNode);
+				break;
+			case 1: // right child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getRight() and setRight() accordingly
+				startNode.setRight(endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
+import ast.expressions.AssignmentWithOpExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -168,6 +169,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ASSIGN_REF:
 				errno = handleAssignByRef((PHPAssignmentByRefExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_ASSIGN_OP:
+				errno = handleAssignWithOp((AssignmentWithOpExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
@@ -763,6 +767,32 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	}
 	
 	private int handleAssignByRef( PHPAssignmentByRefExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // var child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getVariable() and setVariable() accordingly
+				startNode.setVariable(endNode);
+				break;
+			case 1: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
+				startNode.setAssignExpression(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleAssignWithOp( AssignmentWithOpExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -22,6 +22,7 @@ import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
+import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
@@ -164,6 +165,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ASSIGN:
 				errno = handleAssign((AssignmentExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_ASSIGN_REF:
+				errno = handleAssignByRef((PHPAssignmentByRefExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
@@ -733,6 +737,32 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	}
 	
 	private int handleAssign( AssignmentExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // var child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getVariable() and setVariable() accordingly
+				startNode.setVariable(endNode);
+				break;
+			case 1: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
+				startNode.setAssignExpression(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleAssignByRef( PHPAssignmentByRefExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -3,6 +3,7 @@ package tools.phpast2cfg;
 import ast.ASTNode;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -119,10 +120,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 1 child
+			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
 				errno = handleVariable((Variable)startNode, endNode, childnum);
 				break;
-				
+			
+			// statements
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				errno = handleReturn((ReturnStatement)startNode, endNode, childnum);
 				break;
@@ -143,6 +146,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			// expressions
 			case PHPCSVNodeTypes.TYPE_DIM:
 				errno = handleArrayIndexing((ArrayIndexing)startNode, endNode, childnum);
 				break;
@@ -158,6 +162,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_CLASS_CONST:
 				errno = handleClassConstant((ClassConstantExpression)startNode, endNode, childnum);
 				break;
+			case PHPCSVNodeTypes.TYPE_ASSIGN:
+				errno = handleAssign((AssignmentExpression)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
 				break;
@@ -165,6 +172,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
 				break;
 
+			// statements
 			case PHPCSVNodeTypes.TYPE_STATIC:
 				errno = handleStaticVariable((StaticVariableDeclaration)startNode, endNode, childnum);
 				break;
@@ -215,6 +223,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 3 children
+			// expressions
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
 				errno = handleMethodCall((MethodCallExpression)startNode, endNode, childnum);
 				break;
@@ -224,7 +233,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_CONDITIONAL:
 				errno = handleConditional((ConditionalExpression)startNode, endNode, childnum);
 				break;
-				
+			
+			// statements
 			case PHPCSVNodeTypes.TYPE_TRY:
 				errno = handleTry((TryStatement)startNode, endNode, childnum);
 				break;
@@ -236,6 +246,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			
 			// nodes with exactly 4 children
+			// statements
 			case PHPCSVNodeTypes.TYPE_FOR:
 				errno = handleFor((ForStatement)startNode, endNode, childnum);
 				break;
@@ -712,6 +723,32 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // const child: string node
 				startNode.setConstantName(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleAssign( AssignmentExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // var child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getVariable() and setVariable() accordingly
+				startNode.setVariable(endNode);
+				break;
+			case 1: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
+				startNode.setAssignExpression(endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1,6 +1,7 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
+import ast.expressions.AndExpression;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
@@ -10,8 +11,11 @@ import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
+import ast.expressions.GreaterExpression;
+import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.Variable;
@@ -176,6 +180,18 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_BINARY_OP:
 				errno = handleBinaryOperation((BinaryOperationExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_GREATER:
+				errno = handleGreater((GreaterExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_GREATER_EQUAL:
+				errno = handleGreaterOrEqual((GreaterOrEqualExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_AND:
+				errno = handleAnd((AndExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_OR:
+				errno = handleOr((OrExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
@@ -823,6 +839,110 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	}
 	
 	private int handleBinaryOperation( BinaryOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // left child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getLeft() and setLeft() accordingly
+				startNode.setLeft(endNode);
+				break;
+			case 1: // right child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getRight() and setRight() accordingly
+				startNode.setRight(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleGreater( GreaterExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // left child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getLeft() and setLeft() accordingly
+				startNode.setLeft(endNode);
+				break;
+			case 1: // right child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getRight() and setRight() accordingly
+				startNode.setRight(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleGreaterOrEqual( GreaterOrEqualExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // left child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getLeft() and setLeft() accordingly
+				startNode.setLeft(endNode);
+				break;
+			case 1: // right child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getRight() and setRight() accordingly
+				startNode.setRight(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleAnd( AndExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // left child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.left to be an Expression instead
+				// of a generic ASTNode, and getLeft() and setLeft() accordingly
+				startNode.setLeft(endNode);
+				break;
+			case 1: // right child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change BinaryExpression.right to be an Expression instead
+				// of a generic ASTNode, and getRight() and setRight() accordingly
+				startNode.setRight(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleOr( OrExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -8,6 +8,7 @@ import ast.ASTNode;
 import ast.CodeLocation;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
+import ast.expressions.AssignmentExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -106,10 +107,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 1 child
+			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
 				retval = handleVariable(row, ast);
 				break;
 			
+			// statements
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				retval = handleReturn(row, ast);
 				break;
@@ -130,6 +133,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 2 children
+			// expressions
 			case PHPCSVNodeTypes.TYPE_DIM:
 				retval = handleArrayIndexing(row, ast);
 				break;
@@ -145,6 +149,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			case PHPCSVNodeTypes.TYPE_CLASS_CONST:
 				retval = handleClassConstant(row, ast);
 				break;
+			case PHPCSVNodeTypes.TYPE_ASSIGN:
+				retval = handleAssign(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
 				break;
@@ -152,6 +159,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				retval = handleCoalesce(row, ast);
 				break;
 
+			// statements
 			case PHPCSVNodeTypes.TYPE_STATIC:
 				retval = handleStaticVariable(row, ast);
 				break;
@@ -202,6 +210,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 				
 			// nodes with exactly 3 children
+			// expressions
 			case PHPCSVNodeTypes.TYPE_METHOD_CALL:
 				retval = handleMethodCall(row, ast);
 				break;
@@ -212,6 +221,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				retval = handleConditional(row, ast);
 				break;
 				
+			// statements
 			case PHPCSVNodeTypes.TYPE_TRY:
 				retval = handleTry(row, ast);
 				break;
@@ -223,6 +233,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 
 			// nodes with exactly 4 children
+			// statements
 			case PHPCSVNodeTypes.TYPE_FOR:
 				retval = handleFor(row, ast);
 				break;
@@ -761,6 +772,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleClassConstant(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		ClassConstantExpression newNode = new ClassConstantExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleAssign(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		AssignmentExpression newNode = new AssignmentExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,6 +6,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
+import ast.expressions.AndExpression;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
@@ -15,8 +16,11 @@ import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.ExpressionList;
+import ast.expressions.GreaterExpression;
+import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.Variable;
@@ -163,6 +167,18 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_BINARY_OP:
 				retval = handleBinaryOperation(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_GREATER:
+				retval = handleGreater(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_GREATER_EQUAL:
+				retval = handleGreaterOrEqual(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_AND:
+				retval = handleAnd(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_OR:
+				retval = handleOr(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
@@ -872,6 +888,94 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleBinaryOperation(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		BinaryOperationExpression newNode = new BinaryOperationExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleGreater(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		GreaterExpression newNode = new GreaterExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleGreaterOrEqual(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		GreaterOrEqualExpression newNode = new GreaterOrEqualExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleAnd(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		AndExpression newNode = new AndExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleOr(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		OrExpression newNode = new OrExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -10,6 +10,7 @@ import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
 import ast.expressions.AssignmentWithOpExpression;
+import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -159,6 +160,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ASSIGN_OP:
 				retval = handleAssignWithOp(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_BINARY_OP:
+				retval = handleBinaryOperation(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
@@ -846,6 +850,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleAssignWithOp(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		AssignmentWithOpExpression newNode = new AssignmentWithOpExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleBinaryOperation(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		BinaryOperationExpression newNode = new BinaryOperationExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -9,6 +9,7 @@ import ast.CodeLocation;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
 import ast.expressions.AssignmentExpression;
+import ast.expressions.AssignmentWithOpExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
@@ -155,6 +156,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ASSIGN_REF:
 				retval = handleAssignByRef(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_ASSIGN_OP:
+				retval = handleAssignWithOp(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
@@ -820,6 +824,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleAssignByRef(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPAssignmentByRefExpression newNode = new PHPAssignmentByRefExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleAssignWithOp(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		AssignmentWithOpExpression newNode = new AssignmentWithOpExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -26,6 +26,7 @@ import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
+import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
@@ -151,6 +152,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ASSIGN:
 				retval = handleAssign(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_ASSIGN_REF:
+				retval = handleAssignByRef(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
@@ -794,6 +798,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleAssign(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		AssignmentExpression newNode = new AssignmentExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleAssignByRef(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPAssignmentByRefExpression newNode = new PHPAssignmentByRefExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -66,6 +66,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_ASSIGN = "AST_ASSIGN";
 	public static final String TYPE_ASSIGN_REF = "AST_ASSIGN_REF";
 	public static final String TYPE_ASSIGN_OP = "AST_ASSIGN_OP";
+	public static final String TYPE_BINARY_OP = "AST_BINARY_OP";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -63,6 +63,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_STATIC_PROP = "AST_STATIC_PROP";
 	public static final String TYPE_CALL = "AST_CALL";
 	public static final String TYPE_CLASS_CONST = "AST_CLASS_CONST";
+	public static final String TYPE_ASSIGN = "AST_ASSIGN";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -65,6 +65,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CLASS_CONST = "AST_CLASS_CONST";
 	public static final String TYPE_ASSIGN = "AST_ASSIGN";
 	public static final String TYPE_ASSIGN_REF = "AST_ASSIGN_REF";
+	public static final String TYPE_ASSIGN_OP = "AST_ASSIGN_OP";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -67,6 +67,10 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_ASSIGN_REF = "AST_ASSIGN_REF";
 	public static final String TYPE_ASSIGN_OP = "AST_ASSIGN_OP";
 	public static final String TYPE_BINARY_OP = "AST_BINARY_OP";
+	public static final String TYPE_GREATER = "AST_GREATER";
+	public static final String TYPE_GREATER_EQUAL = "AST_GREATER_EQUAL";
+	public static final String TYPE_AND = "AST_AND";
+	public static final String TYPE_OR = "AST_OR";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -64,6 +64,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CALL = "AST_CALL";
 	public static final String TYPE_CLASS_CONST = "AST_CLASS_CONST";
 	public static final String TYPE_ASSIGN = "AST_ASSIGN";
+	public static final String TYPE_ASSIGN_REF = "AST_ASSIGN_REF";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	

--- a/src/udg/useDefAnalysis/ASTDefUseAnalyzer.java
+++ b/src/udg/useDefAnalysis/ASTDefUseAnalyzer.java
@@ -103,7 +103,7 @@ public class ASTDefUseAnalyzer
 
 		switch (nodeType)
 		{
-		case "AssignmentExpr":
+		case "AssignmentExpression":
 			return new AssignmentEnvironment();
 		case "IncDecOp":
 			return new IncDecEnvironment();


### PR DESCRIPTION
**Support for assignments**

* `AST_ASSIGN` -> `ast.expressions.AssignmentExpression`
* `AST_ASSIGN_REF` -> `ast.php.expressions.PHPAssignmentByRefExpression`
* `AST_ASSIGN_OP` -> `ast.expressions.AssignmentWithOpExpression`

A few comments on this:

1. I renamed the already existing class `AssignmentExpr` into `AssignmentExpression` and fixed C world accordingly. The reason is consistency: All other node classes whose name matches `^.*Expr.*$` have a name that matches `^.*Expression$`, except for `AssignmentExpr` and `SizeofExpr`. (In the same spirit I would suggest renaming `SizeofExpr` too, but since there is no `sizeof` operator in PHP, I did not touch this node. I will add a comment to issue #80, though.)

2. I refactored the class `BinaryExpression` (which is the parent of `AssignmentExpression`) to *not* override `getChildCount()` and `getChild(int)` any longer. I think that when maintaining an AST node's children cleanly, overriding either of these two methods inherited from `ASTNode` should *never* be necessary, as the super-methods in `ASTNode` should always do the right thing. Whenever such an override *is* present and necessary in a node class, it is a sign that something else was done uncleanly before. In this particular case however, removing these methods does not break anything, as the super-methods return the same values as the overriding methods did anyway. Thus I suppose these overrides were some kind of legacy restover from earlier versions of Joern, and are not needed any longer.

3. I also enriched the class `AssignmentExpression` with public methods `getVariable()` and `getAssignExpression()` (and corresponding setters) which only relay to the protected methods `getLeft()` and `getRight()` (accordingly for the setters) from the `BinaryExpression` parent class, for added comfort and consistency.

4. As opposed to C, PHP supports references only in a limited way (mostly, in assignments and as function parameters): For assignments, there is an explicit "assignment by reference" operator `=&` (often written as `$a = &$b` in the C spirit, but actually, the form `$a =& $b` is technically more accurate; both forms are acceptable in PHP and generate identical ASTs). Since this operator is quite php-specific, I introduced an `ast.php.expressions.PHPAssignmentByRefExpression` which extends `ast.expressions.AssignmentExpression`.

5. In the case of the "combined assignment and binary operation" operators (e.g., `+=`, `*=`, `.=`, etc.), I declared a new base class `ast.expressions.AssignmentWithOpExpression`, since such assignment operations exist in other high-level languages as well (say, Java).

**Support for binary operation expressions**

* `AST_BINARY_OP` -> `ast.expressions.BinaryOperationExpression`

I introduced a new class `BinaryOperationExpression` which extends `BinaryExpression`, and made this new class a common parent for the following nodes in the `ast.expressions` package (these nodes previously extended `BinaryExpression` directly):
- `AdditiveExpression`
- `AndExpression`
- `BitAndExpression`
- `EqualityExpression`
- `ExclusiveOrExpression`
- `InclusiveOrExpression`
- `MultiplicativeExpression`
- `OrExpression`
- `RelationalExpression`
- `ShiftExpression`

Thereby, the class `BinaryExpression` now only has two *direct* children: `AssignmentExpression` and `BinaryOperationExpression`. This gives us a more fine-grained understanding of the various kinds of nodes that exist by making a clear distinction between *assignment* expressions and *binary operation* expressions, both of which are binary expressions.

This change was also necessary because PHP ASTs do *not* use a distinguished kind of node for each kind of binary expression, as Joern does in C world; rather, (almost) all binary expressions are consistently represented as an `AST_BINARY_OP` node. The concrete operation that the node represents is specified via a flag on this node. Also see https://github.com/nikic/php-ast#flags.
Generally I think that's a good thing, because there are even more kinds of binary operation expressions in PHP than there are in C, and having a distinguished node for each of them would generate a lot of overhead. This "flag" approach is, by the way, also used for `AST_ASSIGN_OP` nodes (see bullet point 5 of the previous *Support for assignments* section.)

The following is a list of PHP's binary operators that will map to an `AST_BINARY_OP` node. This list makes every claim to completeness:

```php
// bit operators
$or1 | $or2;
$and1 & $and2;
$msg ^ $otp;
$x << $y;
$x >> $y;
// string operators
$str1 . $str2;
// arithmetic operators
$x + $y;
$x - $y;
$x * $y;
$x / $y;
$x % $y;
$x ** $y;
// boolean operators
$x xor $y;
// comparison operators
$x === $y;
$x !== $y;
$x == $y;
$x != $y;
$x < $y;
$x <= $y;
$x <=> $y;
```

**Support for "greater", "greater or equal", "and" and "or" expressions**

* `AST_AND` -> `ast.expressions.AndExpression`
* `AST_OR` -> `ast.expressions.OrExpression`
* `AST_GREATER` -> `ast.expressions.GreaterExpression`
* `AST_GREATER_EQUAL` -> `ast.expressions.GreaterOrEqualExpression`

Here I added two new `GreaterExpression` and `GreaterOrEqualExpression` classes inheriting from the already existing `RelationalExpression`.

Thereby we also added support for the last remaining binary operators:
```php
// boolean operators
$x && $y;
$x || $y;
// comparison operators
$x > $y;
$x >= $y;
```

Looking at this, you might wonder: *"What? Why are there distinguished node kinds for these four binary operation expressions, when all other binary operation expressions are mapped to the same node kind with an appropriate flag? Why should greater and greater or equal have distinguished nodes, when less and less or equal don't? Or and and or when xor doesn't? That's completely inconsistent!"*

You would be absolutely right. We are looking here at an inconsistent design of PHP ASTs. Remember that PHP ASTs are new, under development and their structure non-final. This inconsistency is quite probably due to some historic reason, but that's the way it is. However, this structure shall change in the future, and these four nodes will also be mapped to `AST_BINARY_OP` nodes with appropriate flags. In fact, Niki's php-ast extension already introduced this change in version 20 of the PHP ASTs: See https://github.com/nikic/php-ast#version-changelog (we are currently still using version 10). However, as version 20 is still marked as unstable and subject to change, I do not want to use it yet (I ought to upgrade to version 15 at some point, though, which will make next to no difference.) Hence, in the future, these four nodes will not be necessary any longer, as the corresponding expressions will be mapped to `BinaryOperationExpression` just as the other binary operation expressions are, too.
