### PR TITLE
Support for new and instanceof operators and for generators

### DIFF
--- a/src/ast/expressions/ClassConstantExpression.java
+++ b/src/ast/expressions/ClassConstantExpression.java
@@ -2,7 +2,7 @@ package ast.expressions;
 
 import ast.ASTNode;
 
-public class ClassConstantExpression extends Expression
+public class ClassConstantExpression extends MemberAccess
 {
 	private ASTNode classExpression = null; // TODO make this an Expression
 	private ASTNode constantName = null;

--- a/src/ast/expressions/InstanceofExpression.java
+++ b/src/ast/expressions/InstanceofExpression.java
@@ -1,0 +1,31 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class InstanceofExpression extends Expression
+{
+	ASTNode instanceExpression = null; // TODO make this an Expression once PHP mapping is finished
+	Identifier classIdentifier = null;
+
+	public ASTNode getInstanceExpression() // TODO return Expression
+	{
+		return this.instanceExpression;
+	}
+
+	public void setInstanceExpression(ASTNode instanceExpression) // TODO take Expression
+	{
+		this.instanceExpression = instanceExpression;
+		super.addChild(instanceExpression);
+	}
+	
+	public Identifier getClassIdentifier()
+	{
+		return this.classIdentifier;
+	}
+
+	public void setClassIdentifier(Identifier classIdentifier)
+	{
+		this.classIdentifier = classIdentifier;
+		super.addChild(classIdentifier);
+	}
+}

--- a/src/ast/expressions/NewExpression.java
+++ b/src/ast/expressions/NewExpression.java
@@ -1,0 +1,19 @@
+package ast.expressions;
+
+import ast.ASTNode;
+
+public class NewExpression extends CallExpression
+{
+	private ASTNode targetClass = null; // TODO change type to Expression once the mapping is finished
+	
+	public ASTNode getTargetClass() // TODO change type to Expression
+	{
+		return this.targetClass;
+	}
+	
+	public void setTargetClass(ASTNode targetClass) // TODO change type to Expression
+	{
+		this.targetClass = targetClass;
+		super.addChild(targetClass);
+	}
+}

--- a/src/ast/expressions/PropertyExpression.java
+++ b/src/ast/expressions/PropertyExpression.java
@@ -2,7 +2,7 @@ package ast.expressions;
 
 import ast.ASTNode;
 
-public class PropertyExpression extends Expression
+public class PropertyExpression extends MemberAccess
 {
 	private ASTNode objectExpression = null; // TODO make this an Expression
 	private ASTNode propertyName = null;

--- a/src/ast/expressions/StaticPropertyExpression.java
+++ b/src/ast/expressions/StaticPropertyExpression.java
@@ -2,7 +2,7 @@ package ast.expressions;
 
 import ast.ASTNode;
 
-public class StaticPropertyExpression extends Expression
+public class StaticPropertyExpression extends MemberAccess
 {
 	private ASTNode classExpression = null; // TODO make this an Expression
 	private ASTNode propertyName = null;

--- a/src/ast/php/expressions/PHPYieldExpression.java
+++ b/src/ast/php/expressions/PHPYieldExpression.java
@@ -1,0 +1,32 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPYieldExpression extends Expression
+{
+	private ASTNode value = null; // TODO change type to Expression once mapping is finished
+	private ASTNode key = null; // TODO change type to Expression once mapping is finished
+
+	public ASTNode getValue()
+	{
+		return this.value;
+	}
+
+	public void setValue(ASTNode value)
+	{
+		this.value = value;
+		super.addChild(value);
+	}
+	
+	public ASTNode getKey()
+	{
+		return this.key;
+	}
+	
+	public void setKey(ASTNode key)
+	{
+		this.key = key;
+		super.addChild(key);
+	}
+}

--- a/src/ast/php/expressions/PHPYieldFromExpression.java
+++ b/src/ast/php/expressions/PHPYieldFromExpression.java
@@ -1,0 +1,20 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPYieldFromExpression extends Expression
+{
+	private ASTNode fromExpression = null; // TODO change type to Expression once mapping is finished
+
+	public ASTNode getFromExpression()
+	{
+		return this.fromExpression;
+	}
+
+	public void setFromExpression(ASTNode fromExpression)
+	{
+		this.fromExpression = fromExpression;
+		super.addChild(fromExpression);
+	}
+}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -21,6 +21,7 @@ import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPYieldExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPParameter;
@@ -318,6 +319,53 @@ public class TestPHPCSVASTBuilderMinimal
 
 
 	/* nodes with exactly 2 children */
+	
+	/**
+	 * function foo() {
+	 *   yield;
+	 * }
+	 */
+	@Test
+	public void testMinimalYieldCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_FUNC_DECL,,3,,0,1,5,foo,\n";
+		nodeStr += "4,AST_PARAM_LIST,,3,,0,3,,,\n";
+		nodeStr += "5,NULL,,3,,1,3,,,\n";
+		nodeStr += "6,AST_STMT_LIST,,3,,2,3,,,\n";
+		nodeStr += "7,AST_YIELD,,4,,0,3,,,\n";
+		nodeStr += "8,NULL,,4,,0,3,,,\n";
+		nodeStr += "9,NULL,,4,,1,3,,,\n";
+		nodeStr += "10,NULL,,3,,3,3,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "3,5,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "7,9,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "3,10,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)7);
+		
+		assertThat( node, instanceOf(PHPYieldExpression.class));
+		assertEquals( 2, node.getChildCount());
+		// TODO ((PHPYieldExpression)node).getValue() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPYieldExpression accepts arbitrary ASTNode's for values,
+		// when we actually only want to accept expressions. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPYieldExpression)node).getValue().getProperty("type"));
+		// TODO ((PHPYieldExpression)node).getKey() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPYieldExpression accepts arbitrary ASTNode's for keys,
+		// when we actually only want to accept expressions. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPYieldExpression)node).getKey().getProperty("type"));
+	}
 	
 	/**
 	 * while($foo);

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -35,6 +35,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPYieldExpression;
+import ast.php.expressions.PHPYieldFromExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -133,6 +134,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
 				errno = handleVariable((Variable)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
+				errno = handleYieldFrom((PHPYieldFromExpression)startNode, endNode, childnum);
 				break;
 			
 			// statements
@@ -536,6 +540,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // name child
 				startNode.setNameChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleYieldFrom( PHPYieldFromExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setFromExpression(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -34,6 +34,7 @@ import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -203,6 +204,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_INSTANCEOF:
 				errno = handleInstanceof((InstanceofExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_YIELD:
+				errno = handleYield((PHPYieldExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
@@ -1038,6 +1042,30 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // class child: Identifier node
 				startNode.setClassIdentifier((Identifier)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleYield( PHPYieldExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // value child: Expression or plain or NULL node
+				// TODO in time, we should be able to ALWAYS cast endNode to Expression,
+				// unless it is a NULL node: test that!
+				startNode.setValue(endNode);
+				break;
+			case 1: // key child: Expression or plain or NULL node
+				// TODO in time, we should be able to ALWAYS cast endNode to Expression,
+				// unless it is a NULL node: test that!
+				startNode.setKey(endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -15,6 +15,7 @@ import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.InstanceofExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
@@ -199,6 +200,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_NEW:
 				errno = handleNew((NewExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_INSTANCEOF:
+				errno = handleInstanceof((InstanceofExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
@@ -1011,6 +1015,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleInstanceof( InstanceofExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change InstanceofExpression.instanceExpression to be an Expression instead
+				// of a generic ASTNode, and getInstanceExpression() and setInstanceExpression() accordingly
+				startNode.setInstanceExpression(endNode);
+				break;
+			case 1: // class child: Identifier node
+				startNode.setClassIdentifier((Identifier)endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -15,6 +15,7 @@ import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
@@ -195,6 +196,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				errno = handleArrayElement((PHPArrayElement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_NEW:
+				errno = handleNew((NewExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				errno = handleCoalesce((PHPCoalesceExpression)startNode, endNode, childnum);
@@ -722,7 +726,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // expr child: Expression node
 				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change CallExpression.target to be an Expression instead
+				// then, change CallExpression.targetFunc to be an Expression instead
 				// of a generic ASTNode, and getTargetFunc() and setTargetFunc() accordingly
 				startNode.setTargetFunc(endNode);
 				break;
@@ -984,6 +988,29 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO in time, we should be able to ALWAYS cast endNode to Expression,
 				// unless it is a NULL node: test that!
 				startNode.setKey(endNode);
+				break;
+
+			default:
+				errno = 1;
+		}
+
+		return errno;
+	}
+	
+	private int handleNew( NewExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // class child: Expression node
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change NewExpression.targetClass to be an Expression instead
+				// of a generic ASTNode, and getTargetClass() and setTargetClass() accordingly
+				startNode.setTargetClass(endNode);
+				break;
+			case 1: // args child: ArgumentList node
+				startNode.setArgumentList((ArgumentList)endNode);
 				break;
 
 			default:
@@ -1403,7 +1430,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case 1: // method child: "string" node
 				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change CallExpression.target to be an Expression instead
+				// then, change CallExpression.targetFunc to be an Expression instead
 				// of a generic ASTNode, and getTargetFunc() and setTargetFunc() accordingly
 				startNode.setTargetFunc(endNode);
 				break;

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -38,6 +38,7 @@ import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -190,6 +191,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_INSTANCEOF:
 				retval = handleInstanceof(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_YIELD:
+				retval = handleYield(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				retval = handleCoalesce(row, ast);
@@ -1050,6 +1054,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleInstanceof(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		InstanceofExpression newNode = new InstanceofExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleYield(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPYieldExpression newNode = new PHPYieldExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -39,6 +39,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPYieldExpression;
+import ast.php.expressions.PHPYieldFromExpression;
 import ast.php.expressions.StaticCallExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
@@ -120,6 +121,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
 				retval = handleVariable(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
+				retval = handleYieldFrom(row, ast);
 				break;
 			
 			// statements
@@ -567,6 +571,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleVariable(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Variable newNode = new Variable();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleYieldFrom(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPYieldFromExpression newNode = new PHPYieldFromExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -20,6 +20,7 @@ import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
@@ -182,6 +183,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_ARRAY_ELEM:
 				retval = handleArrayElement(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_NEW:
+				retval = handleNew(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				retval = handleCoalesce(row, ast);
@@ -998,6 +1002,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleArrayElement(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPArrayElement newNode = new PHPArrayElement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleNew(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		NewExpression newNode = new NewExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -20,6 +20,7 @@ import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
+import ast.expressions.InstanceofExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
@@ -186,6 +187,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_NEW:
 				retval = handleNew(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_INSTANCEOF:
+				retval = handleInstanceof(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_COALESCE:
 				retval = handleCoalesce(row, ast);
@@ -1024,6 +1028,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleNew(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		NewExpression newNode = new NewExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleInstanceof(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		InstanceofExpression newNode = new InstanceofExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -71,9 +71,10 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_GREATER_EQUAL = "AST_GREATER_EQUAL";
 	public static final String TYPE_AND = "AST_AND";
 	public static final String TYPE_OR = "AST_OR";
+	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_NEW = "AST_NEW";
 	public static final String TYPE_INSTANCEOF = "AST_INSTANCEOF";
-	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
+	public static final String TYPE_YIELD = "AST_YIELD";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	
 	// statements

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -47,6 +47,7 @@ public class PHPCSVNodeTypes
 	// nodes with exactly 1 child
 	// expressions
 	public static final String TYPE_VAR = "AST_VAR";
+	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	
 	// statements
 	public static final String TYPE_RETURN = "AST_RETURN";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -72,6 +72,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_AND = "AST_AND";
 	public static final String TYPE_OR = "AST_OR";
 	public static final String TYPE_NEW = "AST_NEW";
+	public static final String TYPE_INSTANCEOF = "AST_INSTANCEOF";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -71,6 +71,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_GREATER_EQUAL = "AST_GREATER_EQUAL";
 	public static final String TYPE_AND = "AST_AND";
 	public static final String TYPE_OR = "AST_OR";
+	public static final String TYPE_NEW = "AST_NEW";
 	public static final String TYPE_ARRAY_ELEM = "AST_ARRAY_ELEM";
 	public static final String TYPE_COALESCE = "AST_COALESCE";
 	


### PR DESCRIPTION
**Support for new and instanceof operators**

* `AST_NEW` -> `ast.expressions.NewExpression`
* `AST_INSTANCEOF` -> `ast.expressions.InstanceofExpression`

I created the corresponding classes in the `ast.expressions` package since these nodes should be relevant for most object-oriented languages. Well... C++ does not have an `instanceof` operator, but Java for instance does.

**Support for generators**

* `AST_YIELD` -> `ast.php.expressions.PHPYieldExpression`
* `AST_YIELD_FROM` -> `ast.php.expressions.PHPYieldFromExpression`

Also see http://php.net/manual/en/language.generators.syntax.php.

In this case I decided to put the nodes into the `ast.php.expressions` package. The only other language that I know of that has built-in generators with `yield` and `yield from` keywords is Python, so I felt it was a rather specific feature. It is, sometimes, a close call. Feel free to move nodes from or to `ast.expressions` and `ast.php.expressions` if you like. :blush: 

The good news: We finished *all* nodes with 2 children! Now, only some nodes with either 0 or 1 children remain. We're almost there. :smile: 