### PR TITLE
Support for various unary statements and expressions

### DIFF
--- a/src/ast/expressions/Constant.java
+++ b/src/ast/expressions/Constant.java
@@ -1,0 +1,15 @@
+package ast.expressions;
+
+public class Constant extends Expression
+{
+	private Identifier identifier = null;
+	
+	public void setIdentifier(Identifier identifier) {
+		this.identifier = identifier;
+		super.addChild(identifier);
+	}
+	
+	public Identifier getIdentifier() {
+		return this.identifier;
+	}
+}

--- a/src/ast/expressions/UnaryExpression.java
+++ b/src/ast/expressions/UnaryExpression.java
@@ -1,9 +1,23 @@
 package ast.expressions;
 
+import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
 public class UnaryExpression extends Expression
 {
+	ASTNode expression = null; // TODO make this an Expression once PHP mapping is finished
+	
+	public ASTNode getExpression() // TODO return Expression
+	{
+		return this.expression;
+	}
+
+	public void setExpression(ASTNode expression) // TODO take Expression
+	{
+		this.expression = expression;
+		super.addChild(expression);
+	}
+	
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);

--- a/src/ast/expressions/UnaryMinusExpression.java
+++ b/src/ast/expressions/UnaryMinusExpression.java
@@ -1,0 +1,8 @@
+package ast.expressions;
+
+public class UnaryMinusExpression extends UnaryOperationExpression
+{
+	// TODO remove this class once phpjoern uses version 20 of Niki's php-ast extension,
+	// as "unary minus" expressions will then be consistently mapped onto a UnaryOperationExpression
+	// with an appropriate flag.
+}

--- a/src/ast/expressions/UnaryOperationExpression.java
+++ b/src/ast/expressions/UnaryOperationExpression.java
@@ -2,7 +2,7 @@ package ast.expressions;
 
 import ast.walking.ASTNodeVisitor;
 
-public class UnaryOp extends Expression
+public class UnaryOperationExpression extends UnaryExpression
 {
 	public void accept(ASTNodeVisitor visitor)
 	{

--- a/src/ast/expressions/UnaryPlusExpression.java
+++ b/src/ast/expressions/UnaryPlusExpression.java
@@ -1,0 +1,8 @@
+package ast.expressions;
+
+public class UnaryPlusExpression extends UnaryOperationExpression
+{
+	// TODO remove this class once phpjoern uses version 20 of Niki's php-ast extension,
+	// as "unary plus" expressions will then be consistently mapped onto a UnaryOperationExpression
+	// with an appropriate flag.
+}

--- a/src/ast/php/expressions/PHPCloneExpression.java
+++ b/src/ast/php/expressions/PHPCloneExpression.java
@@ -1,0 +1,7 @@
+package ast.php.expressions;
+
+import ast.expressions.UnaryExpression;
+
+public class PHPCloneExpression extends UnaryExpression
+{
+}

--- a/src/ast/php/expressions/PHPEmptyExpression.java
+++ b/src/ast/php/expressions/PHPEmptyExpression.java
@@ -2,6 +2,6 @@ package ast.php.expressions;
 
 import ast.expressions.UnaryExpression;
 
-public class PHPUnpackExpression extends UnaryExpression
+public class PHPEmptyExpression extends UnaryExpression
 {
 }

--- a/src/ast/php/expressions/PHPExitExpression.java
+++ b/src/ast/php/expressions/PHPExitExpression.java
@@ -1,0 +1,7 @@
+package ast.php.expressions;
+
+import ast.expressions.UnaryExpression;
+
+public class PHPExitExpression extends UnaryExpression
+{
+}

--- a/src/ast/php/expressions/PHPIssetExpression.java
+++ b/src/ast/php/expressions/PHPIssetExpression.java
@@ -1,0 +1,15 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.UnaryExpression;
+
+public class PHPIssetExpression extends UnaryExpression
+{
+	public ASTNode getVariableExpression() { // TODO return an expression
+		return super.getExpression();
+	}
+	
+	public void setVariableExpression(ASTNode variable) { // TODO take an expression
+		super.setExpression(variable);
+	}
+}

--- a/src/ast/php/expressions/PHPPrintExpression.java
+++ b/src/ast/php/expressions/PHPPrintExpression.java
@@ -1,0 +1,7 @@
+package ast.php.expressions;
+
+import ast.expressions.UnaryExpression;
+
+public class PHPPrintExpression extends UnaryExpression
+{
+}

--- a/src/ast/php/expressions/PHPReferenceExpression.java
+++ b/src/ast/php/expressions/PHPReferenceExpression.java
@@ -1,0 +1,19 @@
+package ast.php.expressions;
+
+import ast.expressions.Variable;
+
+public class PHPReferenceExpression extends Variable
+{
+	private Variable variable = null;
+
+	public Variable getVariable()
+	{
+		return this.variable;
+	}
+
+	public void setVariable(Variable variable)
+	{
+		this.variable = variable;
+		super.addChild(variable);
+	}
+}

--- a/src/ast/php/expressions/PHPSilenceExpression.java
+++ b/src/ast/php/expressions/PHPSilenceExpression.java
@@ -1,0 +1,10 @@
+package ast.php.expressions;
+
+import ast.expressions.UnaryOperationExpression;
+
+public class PHPSilenceExpression extends UnaryOperationExpression
+{
+	// TODO remove this class once phpjoern uses version 20 of Niki's php-ast extension,
+	// as "silence" expressions will then be consistently mapped onto a UnaryOperationExpression
+	// with an appropriate flag.
+}

--- a/src/ast/php/expressions/PHPUnpackExpression.java
+++ b/src/ast/php/expressions/PHPUnpackExpression.java
@@ -1,0 +1,20 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.Expression;
+
+public class PHPUnpackExpression extends Expression
+{
+	private ASTNode unpackExpression = null; // TODO change type to Expression once mapping is finished
+
+	public ASTNode getUnpackExpression()
+	{
+		return this.unpackExpression;
+	}
+
+	public void setUnpackExpression(ASTNode unpackExpression)
+	{
+		this.unpackExpression = unpackExpression;
+		super.addChild(unpackExpression);
+	}
+}

--- a/src/ast/php/statements/PHPEchoStatement.java
+++ b/src/ast/php/statements/PHPEchoStatement.java
@@ -1,0 +1,20 @@
+package ast.php.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+
+public class PHPEchoStatement extends Statement
+{
+	private ASTNode echoExpression = null; // TODO make into Expression once mapping is finished
+
+	public ASTNode getEchoExpression() // TODO return Expression
+	{
+		return this.echoExpression;
+	}
+
+	public void setEchoExpression(ASTNode echoExpression) // TODO take Expression
+	{
+		this.echoExpression = echoExpression;
+		super.addChild(echoExpression);
+	}
+}

--- a/src/ast/php/statements/PHPGlobalStatement.java
+++ b/src/ast/php/statements/PHPGlobalStatement.java
@@ -1,0 +1,20 @@
+package ast.php.statements;
+
+import ast.expressions.Variable;
+import ast.logical.statements.Statement;
+
+public class PHPGlobalStatement extends Statement
+{
+	private Variable variable = null;
+
+	public Variable getVariable()
+	{
+		return this.variable;
+	}
+
+	public void setVariable(Variable variable)
+	{
+		this.variable = variable;
+		super.addChild(variable);
+	}
+}

--- a/src/ast/php/statements/PHPHaltCompilerStatement.java
+++ b/src/ast/php/statements/PHPHaltCompilerStatement.java
@@ -1,0 +1,20 @@
+package ast.php.statements;
+
+import ast.ASTNode;
+import ast.logical.statements.Statement;
+
+public class PHPHaltCompilerStatement extends Statement
+{
+	private ASTNode offset = null; // TODO make into PrimaryExpression (or maybe even more specific: IntegerExpression) once mapping is finished
+
+	public ASTNode getOffset() // TODO return PrimaryExpression
+	{
+		return this.offset;
+	}
+
+	public void setOffset(ASTNode offset) // TODO take PrimaryExpression
+	{
+		this.offset = offset;
+		super.addChild(offset);
+	}
+}

--- a/src/ast/php/statements/PHPUnsetStatement.java
+++ b/src/ast/php/statements/PHPUnsetStatement.java
@@ -1,0 +1,20 @@
+package ast.php.statements;
+
+import ast.expressions.Expression;
+import ast.logical.statements.Statement;
+
+public class PHPUnsetStatement extends Statement
+{
+	private Expression variableExpression = null;
+
+	public Expression getVariableExpression()
+	{
+		return this.variableExpression;
+	}
+
+	public void setVariableExpression(Expression variableExpression)
+	{
+		this.variableExpression = variableExpression;
+		super.addChild(variableExpression);
+	}
+}

--- a/src/ast/php/statements/blockstarters/ForEachStatement.java
+++ b/src/ast/php/statements/blockstarters/ForEachStatement.java
@@ -1,6 +1,7 @@
 package ast.php.statements.blockstarters;
 
 import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.expressions.Variable;
 import ast.logical.statements.BlockStarter;
 
@@ -8,7 +9,7 @@ public class ForEachStatement extends BlockStarter
 {
 	private ASTNode iteratedObject = null; // TODO make this an Expression sometime
 	private Variable key = null;
-	private Variable value = null;
+	private Expression value = null;
 
 	@Override
 	public ASTNode getCondition()
@@ -32,26 +33,25 @@ public class ForEachStatement extends BlockStarter
 		super.addChild(expression);
 	}
 
-	public ASTNode getValueVar()
+	public Expression getValueExpression()
 	{
 		return this.value;
 	}
 
-	public void setValueVar(Variable value)
+	public void setValueExpression(Expression value)
 	{
 		this.value = value;
 		super.addChild(value);
 	}
 	
-	public ASTNode getKeyVar()
+	public Variable getKeyVariable()
 	{
 		return this.key;
 	}
 
-	public void setKeyVar(ASTNode key)
+	public void setKeyVariable(Variable key)
 	{
-		if (key instanceof Variable)
-			this.key = (Variable)key;
+		this.key = key;
 		super.addChild(key);
 	}
 }

--- a/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
+++ b/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
@@ -42,7 +42,7 @@ import ast.expressions.Sizeof;
 import ast.expressions.SizeofExpr;
 import ast.expressions.SizeofOperand;
 import ast.expressions.UnaryExpression;
-import ast.expressions.UnaryOp;
+import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryOperator;
 import ast.logical.statements.BlockCloser;
 import ast.logical.statements.BlockStarter;
@@ -869,7 +869,7 @@ public class FunctionContentBuilder extends ASTNodeBuilder
 
 	public void enterUnaryOpAndCastExpr(Unary_op_and_cast_exprContext ctx)
 	{
-		UnaryOp expr = new UnaryOp();
+		UnaryOperationExpression expr = new UnaryOperationExpression();
 		nodeToRuleContext.put(expr, ctx);
 		stack.push(expr);
 	}

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -54,6 +54,7 @@ import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
@@ -974,6 +975,53 @@ public class TestPHPCSVASTBuilder
 		assertThat( node2, instanceOf(PHPExitExpression.class));
 		assertEquals( 1, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)7), ((PHPExitExpression)node2).getExpression());
+	}
+	
+	/**
+	 * AST_PRINT nodes are used to denote 'print' expressions.
+	 * 
+	 * Any AST_PRINT node has exactly exactly one child, representing the expression whose
+	 * evaluation yields a string to be printed.
+	 * See http://php.net/manual/en/function.print.php
+	 * 
+	 * This test checks a few 'print' expressions' children in the following PHP code:
+	 * 
+	 * print($foo);
+	 * print(bar());
+	 */
+	@Test
+	public void testPrintCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_PRINT,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "6,AST_PRINT,,4,,1,1,,,\n";
+		nodeStr += "7,AST_CALL,,4,,0,1,,,\n";
+		nodeStr += "8,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "9,string,,4,\"bar\",0,1,,,\n";
+		nodeStr += "10,AST_ARG_LIST,,4,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "7,10,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)6);
+
+		assertThat( node, instanceOf(PHPPrintExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PHPPrintExpression)node).getExpression());
+		
+		assertThat( node2, instanceOf(PHPPrintExpression.class));
+		assertEquals( 1, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)7), ((PHPPrintExpression)node2).getExpression());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -33,6 +33,7 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.UnaryOperationExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.Parameter;
@@ -666,6 +667,50 @@ public class TestPHPCSVASTBuilder
 		assertEquals( ast.getNodeById((long)15), ((PHPUnpackExpression)node2).getUnpackExpression());
 	}
 
+	/**
+	 * AST_UNARY_OP nodes are used to denote unary operation expressions.
+	 * 
+	 * Any AST_UNARY_OP node has exactly exactly one child, representing the expression for which
+	 * the operation is to be performed.
+	 * 
+	 * This test checks a few of unary operation expressions' children in the following PHP code:
+	 * 
+	 * // bit operators
+	 * ~$foo;
+	 * // boolean operators
+	 * !$foo;
+	 */
+	@Test
+	public void testUnaryOperationCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_UNARY_OP,UNARY_BITWISE_NOT,4,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "5,string,,4,\"foo\",0,1,,,\n";
+		nodeStr += "6,AST_UNARY_OP,UNARY_BOOL_NOT,6,,1,1,,,\n";
+		nodeStr += "7,AST_VAR,,6,,0,1,,,\n";
+		nodeStr += "8,string,,6,\"foo\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)6);
+		
+		assertThat( node, instanceOf(UnaryOperationExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((UnaryOperationExpression)node).getExpression());
+		
+		assertThat( node2, instanceOf(UnaryOperationExpression.class));
+		assertEquals( 1, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)7), ((UnaryOperationExpression)node2).getExpression());
+	}
+	
 	/**
 	 * AST_YIELD_FROM nodes are used to denote 'yield from' expressions used in generators.
 	 * See http://php.net/manual/en/language.generators.syntax.php

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -47,6 +47,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPAssignmentByRefExpression;
+import ast.php.expressions.PHPCloneExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
@@ -878,6 +879,52 @@ public class TestPHPCSVASTBuilder
 		assertThat( node2, instanceOf(PHPSilenceExpression.class));
 		assertEquals( 1, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)9), ((PHPSilenceExpression)node2).getExpression());
+	}
+	
+	/**
+	 * AST_CLONE nodes are used to denote 'clone' operation expressions.
+	 * 
+	 * Any AST_CLONE node has exactly exactly one child, representing the expression whose
+	 * evaluation yields the object to be cloned.
+	 * 
+	 * This test checks a few 'clone' operation expressions' children in the following PHP code:
+	 * 
+	 * clone($foo);
+	 * clone(bar());
+	 */
+	@Test
+	public void testCloneCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_CLONE,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"foo\",0,1,,,\n";
+		nodeStr += "6,AST_CLONE,,4,,1,1,,,\n";
+		nodeStr += "7,AST_CALL,,4,,0,1,,,\n";
+		nodeStr += "8,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "9,string,,4,\"bar\",0,1,,,\n";
+		nodeStr += "10,AST_ARG_LIST,,4,,1,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "7,10,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)6);
+
+		assertThat( node, instanceOf(PHPCloneExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PHPCloneExpression)node).getExpression());
+		
+		assertThat( node2, instanceOf(PHPCloneExpression.class));
+		assertEquals( 1, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)7), ((PHPCloneExpression)node2).getExpression());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -793,7 +793,7 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node, instanceOf(ForEachStatement.class));
 		assertEquals( 4, node.getChildCount());
-		assertNull( ((ForEachStatement)node).getKeyVar());
+		assertNull( ((ForEachStatement)node).getKeyVariable());
 		assertNull( ((ForEachStatement)node).getStatement());
 	}
 

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -20,6 +20,7 @@ import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
 import ast.php.expressions.PHPArrayExpression;
+import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.functionDef.Closure;
@@ -213,6 +214,33 @@ public class TestPHPCSVASTBuilderMinimal
 	
 	
 	/* nodes with exactly 1 child */
+	
+	/**
+	 * exit;
+	 */
+	@Test
+	public void testMinimalExitCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_EXIT,,3,,0,1,,,\n";
+		nodeStr += "4,NULL,,3,,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+
+		assertThat( node, instanceOf(PHPExitExpression.class));
+		assertEquals( 1, node.getChildCount());
+		// TODO ((PHPExitExpression)node).getExpression() should
+		// actually return null, not a null node. This currently does not work exactly
+		// as expected because PHPExitExpression accepts arbitrary ASTNode's for exit expressions,
+		// when we actually only want to accept expressions. Once the mapping is
+		// finished, we can fix that.
+		assertEquals( "NULL", ((PHPExitExpression)node).getExpression().getProperty("type"));
+	}
 	
 	/**
 	 * function foo() {

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -50,6 +50,7 @@ import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
 import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
+import ast.php.statements.PHPHaltCompilerStatement;
 import ast.php.statements.PHPUnsetStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
@@ -158,6 +159,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_REF:
 				errno = handleReference((PHPReferenceExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_HALT_COMPILER:
+				errno = handleHaltCompiler((PHPHaltCompilerStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_THROW:
 				errno = handleThrow((ThrowStatement)startNode, endNode, childnum);
@@ -655,6 +659,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // var child
 				startNode.setVariable((Variable)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleHaltCompiler( PHPHaltCompilerStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // offset child
+				startNode.setOffset(endNode);
+				// TODO in time, we should be able to cast endNode to PrimaryExpression (or IntegerExpression);
+				// then, change PHPHaltCompilerStatement.offset to be a PrimaryExpression instead
+				// of a generic ASTNode, and getOffset() and setOffset() accordingly
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -43,6 +43,7 @@ import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
@@ -177,6 +178,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_EXIT:
 				errno = handleExit((PHPExitExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_PRINT:
+				errno = handlePrint((PHPPrintExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
@@ -763,6 +767,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	}
 	
 	private int handleExit( PHPExitExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handlePrint( PHPPrintExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -22,6 +22,7 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.UnaryOperationExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -148,6 +149,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNPACK:
 				errno = handleUnpack((PHPUnpackExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNARY_OP:
+				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				errno = handleYieldFrom((PHPYieldFromExpression)startNode, endNode, childnum);
@@ -607,6 +611,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// PHPUnpackExpression.unpackExpression and getters and setters accordingly
 				startNode.setUnpackExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleUnaryOperation( UnaryOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryOperationExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -10,6 +10,7 @@ import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
+import ast.expressions.Constant;
 import ast.expressions.Expression;
 import ast.expressions.ExpressionList;
 import ast.expressions.GreaterExpression;
@@ -140,6 +141,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
 				errno = handleVariable((Variable)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CONST:
+				errno = handleConstant((Constant)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				errno = handleYieldFrom((PHPYieldFromExpression)startNode, endNode, childnum);
@@ -560,7 +564,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // name child
+				// TODO cast to PrimaryType once mapping is finished, and change
+				// Variable.name and getters and setters accordingly
 				startNode.setNameChild(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleConstant( Constant startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // name child
+				startNode.setIdentifier((Identifier)endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -36,6 +36,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPAssignmentByRefExpression;
+import ast.php.expressions.PHPCloneExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
@@ -169,6 +170,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SILENCE:
 				errno = handleSilence((PHPSilenceExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLONE:
+				errno = handleClone((PHPCloneExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
@@ -717,6 +721,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	}
 	
 	private int handleSilence( PHPSilenceExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryOperationExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleClone( PHPCloneExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -10,6 +10,7 @@ import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
+import ast.expressions.Expression;
 import ast.expressions.ExpressionList;
 import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
@@ -48,6 +49,7 @@ import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
 import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
+import ast.php.statements.PHPUnsetStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.StaticVariableDeclaration;
@@ -143,6 +145,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// statements
 			case PHPCSVNodeTypes.TYPE_GLOBAL:
 				errno = handleGlobal((PHPGlobalStatement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNSET:
+				errno = handleUnset((PHPUnsetStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				errno = handleReturn((ReturnStatement)startNode, endNode, childnum);
@@ -578,6 +583,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // var child
 				startNode.setVariable((Variable)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleUnset( PHPUnsetStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // var child
+				startNode.setVariableExpression((Expression)endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -40,6 +40,7 @@ import ast.php.expressions.PHPCloneExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
+import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
@@ -173,6 +174,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLONE:
 				errno = handleClone((PHPCloneExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_EXIT:
+				errno = handleExit((PHPExitExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
@@ -747,7 +751,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		{
 			case 0: // expr child
 				// TODO cast to Exression once mapping is finished, and change
-				// UnaryOperationExpression.expression and getters and setters accordingly
+				// UnaryExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleExit( PHPExitExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
 				break;
 				

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -48,6 +48,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
 import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
+import ast.php.statements.PHPEchoStatement;
 import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PHPHaltCompilerStatement;
@@ -162,6 +163,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_HALT_COMPILER:
 				errno = handleHaltCompiler((PHPHaltCompilerStatement)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_ECHO:
+				errno = handleEcho((PHPEchoStatement)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_THROW:
 				errno = handleThrow((ThrowStatement)startNode, endNode, childnum);
@@ -679,6 +683,26 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO in time, we should be able to cast endNode to PrimaryExpression (or IntegerExpression);
 				// then, change PHPHaltCompilerStatement.offset to be a PrimaryExpression instead
 				// of a generic ASTNode, and getOffset() and setOffset() accordingly
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
+	}
+	
+	private int handleEcho( PHPEchoStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setEchoExpression(endNode);
+				// TODO in time, we should be able to cast endNode to Expression;
+				// then, change PHPEchoStatement.echoExpression to be an Expression instead
+				// of a generic ASTNode, and getEchoExpression() and setEchoExpression() accordingly
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -22,7 +22,9 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
+import ast.expressions.UnaryPlusExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -38,6 +40,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
+import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.PHPYieldFromExpression;
@@ -149,6 +152,15 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNPACK:
 				errno = handleUnpack((PHPUnpackExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNARY_PLUS:
+				errno = handleUnaryPlus((UnaryPlusExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNARY_MINUS:
+				errno = handleUnaryMinus((UnaryMinusExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_SILENCE:
+				errno = handleSilence((PHPSilenceExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
@@ -611,6 +623,63 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// PHPUnpackExpression.unpackExpression and getters and setters accordingly
 				startNode.setUnpackExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleUnaryPlus( UnaryPlusExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryOperationExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleUnaryMinus( UnaryMinusExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryOperationExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleSilence( PHPSilenceExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryOperationExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -37,6 +37,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
+import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.PHPYieldFromExpression;
 import ast.php.expressions.StaticCallExpression;
@@ -144,6 +145,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CONST:
 				errno = handleConstant((Constant)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNPACK:
+				errno = handleUnpack((PHPUnpackExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				errno = handleYieldFrom((PHPYieldFromExpression)startNode, endNode, childnum);
@@ -593,6 +597,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		return errno;		
 	}
 	
+	private int handleUnpack( PHPUnpackExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// PHPUnpackExpression.unpackExpression and getters and setters accordingly
+				startNode.setUnpackExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
 	private int handleYieldFrom( PHPYieldFromExpression startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
@@ -600,6 +623,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// PHPYieldFromExpression.fromExpression and getters and setters accordingly
 				startNode.setFromExpression(endNode);
 				break;
 				

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -37,7 +37,9 @@ import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
+import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPSilenceExpression;
@@ -158,6 +160,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_MINUS:
 				errno = handleUnaryMinus((UnaryMinusExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_EMPTY:
+				errno = handleEmpty((PHPEmptyExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_ISSET:
+				errno = handleIsset((PHPIssetExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_SILENCE:
 				errno = handleSilence((PHPSilenceExpression)startNode, endNode, childnum);
@@ -622,7 +630,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // expr child
 				// TODO cast to Exression once mapping is finished, and change
 				// PHPUnpackExpression.unpackExpression and getters and setters accordingly
-				startNode.setUnpackExpression(endNode);
+				startNode.setExpression(endNode);
 				break;
 				
 			default:
@@ -661,6 +669,44 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// UnaryOperationExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleEmpty( PHPEmptyExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryExpression.expression and getters and setters accordingly
+				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleIsset( PHPIssetExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryExpression.expression and getters and setters accordingly
+				startNode.setVariableExpression(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -46,6 +46,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
 import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
+import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
@@ -140,6 +141,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			
 			// statements
+			case PHPCSVNodeTypes.TYPE_GLOBAL:
+				errno = handleGlobal((PHPGlobalStatement)startNode, endNode, childnum);
+				break;
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				errno = handleReturn((ReturnStatement)startNode, endNode, childnum);
 				break;
@@ -564,6 +568,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		}
 		
 		return errno;		
+	}
+	
+	private int handleGlobal( PHPGlobalStatement startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // var child
+				startNode.setVariable((Variable)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;
 	}
 	
 	private int handleReturn( ReturnStatement startNode, ASTNode endNode, int childnum)

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -40,6 +40,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
+import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.PHPYieldFromExpression;
 import ast.php.expressions.StaticCallExpression;
@@ -130,6 +131,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CONST:
 				retval = handleConstant(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNPACK:
+				retval = handleUnpack(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				retval = handleYieldFrom(row, ast);
@@ -617,6 +621,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleConstant(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Constant newNode = new Constant();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleUnpack(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPUnpackExpression newNode = new PHPUnpackExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -53,6 +53,7 @@ import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
 import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
+import ast.php.statements.PHPHaltCompilerStatement;
 import ast.php.statements.PHPUnsetStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
@@ -144,6 +145,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_REF:
 				retval = handleReference(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_HALT_COMPILER:
+				retval = handleHaltCompiler(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_THROW:
 				retval = handleThrow(row, ast);
@@ -715,6 +719,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleReference(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPReferenceExpression newNode = new PHPReferenceExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleHaltCompiler(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPHaltCompilerStatement newNode = new PHPHaltCompilerStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -26,7 +26,9 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
+import ast.expressions.UnaryPlusExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -41,6 +43,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
+import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.PHPYieldFromExpression;
@@ -135,6 +138,15 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNPACK:
 				retval = handleUnpack(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNARY_PLUS:
+				retval = handleUnaryPlus(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNARY_MINUS:
+				retval = handleUnaryMinus(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_SILENCE:
+				retval = handleSilence(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
@@ -647,6 +659,72 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleUnpack(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPUnpackExpression newNode = new PHPUnpackExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleUnaryPlus(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		UnaryPlusExpression newNode = new UnaryPlusExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleUnaryMinus(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		UnaryMinusExpression newNode = new UnaryMinusExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleSilence(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPSilenceExpression newNode = new PHPSilenceExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -51,6 +51,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
 import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
+import ast.php.statements.PHPEchoStatement;
 import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PHPHaltCompilerStatement;
@@ -148,6 +149,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_HALT_COMPILER:
 				retval = handleHaltCompiler(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_ECHO:
+				retval = handleEcho(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_THROW:
 				retval = handleThrow(row, ast);
@@ -741,6 +745,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleHaltCompiler(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPHaltCompilerStatement newNode = new PHPHaltCompilerStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleEcho(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPEchoStatement newNode = new PHPEchoStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -38,6 +38,7 @@ import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.PHPYieldFromExpression;
 import ast.php.expressions.StaticCallExpression;
@@ -140,6 +141,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_LABEL:
 				retval = handleLabel(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_REF:
+				retval = handleReference(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_THROW:
 				retval = handleThrow(row, ast);
@@ -689,6 +693,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleLabel(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Label newNode = new Label();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleReference(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPReferenceExpression newNode = new PHPReferenceExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -46,6 +46,7 @@ import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
@@ -163,6 +164,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_EXIT:
 				retval = handleExit(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_PRINT:
+				retval = handlePrint(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
@@ -829,6 +833,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleExit(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPExitExpression newNode = new PHPExitExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handlePrint(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPPrintExpression newNode = new PHPPrintExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -15,6 +15,7 @@ import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
+import ast.expressions.Constant;
 import ast.expressions.ExpressionList;
 import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
@@ -126,6 +127,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
 				retval = handleVariable(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CONST:
+				retval = handleConstant(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				retval = handleYieldFrom(row, ast);
@@ -591,6 +595,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleVariable(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		Variable newNode = new Variable();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleConstant(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		Constant newNode = new Constant();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -39,6 +39,7 @@ import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPAssignmentByRefExpression;
+import ast.php.expressions.PHPCloneExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
@@ -155,6 +156,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SILENCE:
 				retval = handleSilence(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CLONE:
+				retval = handleClone(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
@@ -777,6 +781,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleSilence(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPSilenceExpression newNode = new PHPSilenceExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleClone(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPCloneExpression newNode = new PHPCloneExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -26,6 +26,7 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.UnaryOperationExpression;
 import ast.expressions.Variable;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -134,6 +135,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNPACK:
 				retval = handleUnpack(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNARY_OP:
+				retval = handleUnaryOperation(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				retval = handleYieldFrom(row, ast);
@@ -643,6 +647,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleUnpack(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPUnpackExpression newNode = new PHPUnpackExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleUnaryOperation(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		UnaryOperationExpression newNode = new UnaryOperationExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -40,7 +40,9 @@ import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
 import ast.php.expressions.PHPAssignmentByRefExpression;
 import ast.php.expressions.PHPCoalesceExpression;
+import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
+import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPSilenceExpression;
@@ -144,6 +146,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_MINUS:
 				retval = handleUnaryMinus(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_EMPTY:
+				retval = handleEmpty(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_ISSET:
+				retval = handleIsset(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_SILENCE:
 				retval = handleSilence(row, ast);
@@ -703,6 +711,50 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleUnaryMinus(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		UnaryMinusExpression newNode = new UnaryMinusExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleEmpty(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPEmptyExpression newNode = new PHPEmptyExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleIsset(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPIssetExpression newNode = new PHPIssetExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -50,6 +50,7 @@ import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
 import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
+import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
@@ -127,6 +128,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			
 			// statements
+			case PHPCSVNodeTypes.TYPE_GLOBAL:
+				retval = handleGlobal(row, ast);
+				break;
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				retval = handleReturn(row, ast);
 				break;
@@ -593,6 +597,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleYieldFrom(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPYieldFromExpression newNode = new PHPYieldFromExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleGlobal(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPGlobalStatement newNode = new PHPGlobalStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -43,6 +43,7 @@ import ast.php.expressions.PHPCloneExpression;
 import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
+import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPReferenceExpression;
@@ -159,6 +160,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLONE:
 				retval = handleClone(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_EXIT:
+				retval = handleExit(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
@@ -803,6 +807,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleClone(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPCloneExpression newNode = new PHPCloneExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleExit(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPExitExpression newNode = new PHPExitExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -52,6 +52,7 @@ import ast.php.statements.ConstantDeclaration;
 import ast.php.statements.ConstantElement;
 import ast.php.statements.PHPGlobalStatement;
 import ast.php.statements.PHPGroupUseStatement;
+import ast.php.statements.PHPUnsetStatement;
 import ast.php.statements.PropertyDeclaration;
 import ast.php.statements.PropertyElement;
 import ast.php.statements.StaticVariableDeclaration;
@@ -130,6 +131,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// statements
 			case PHPCSVNodeTypes.TYPE_GLOBAL:
 				retval = handleGlobal(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_UNSET:
+				retval = handleUnset(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_RETURN:
 				retval = handleReturn(row, ast);
@@ -619,6 +623,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleGlobal(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPGlobalStatement newNode = new PHPGlobalStatement();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleUnset(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPUnsetStatement newNode = new PHPUnsetStatement();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -51,6 +51,7 @@ public class PHPCSVNodeTypes
 	
 	// statements
 	public static final String TYPE_GLOBAL = "AST_GLOBAL";
+	public static final String TYPE_UNSET = "AST_UNSET";
 	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_LABEL = "AST_LABEL";
 	public static final String TYPE_THROW = "AST_THROW";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_LABEL = "AST_LABEL";
 	public static final String TYPE_REF = "AST_REF";
+	public static final String TYPE_HALT_COMPILER = "AST_HALT_COMPILER";
 	public static final String TYPE_THROW = "AST_THROW";
 	public static final String TYPE_GOTO = "AST_GOTO";
 	public static final String TYPE_BREAK = "AST_BREAK";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -49,6 +49,9 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_VAR = "AST_VAR";
 	public static final String TYPE_CONST = "AST_CONST";
 	public static final String TYPE_UNPACK = "AST_UNPACK";
+	public static final String TYPE_UNARY_PLUS = "AST_UNARY_PLUS";
+	public static final String TYPE_UNARY_MINUS = "AST_UNARY_MINUS";
+	public static final String TYPE_SILENCE = "AST_SILENCE";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -51,6 +51,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_UNPACK = "AST_UNPACK";
 	public static final String TYPE_UNARY_PLUS = "AST_UNARY_PLUS";
 	public static final String TYPE_UNARY_MINUS = "AST_UNARY_MINUS";
+	public static final String TYPE_EMPTY = "AST_EMPTY";
+	public static final String TYPE_ISSET = "AST_ISSET";
 	public static final String TYPE_SILENCE = "AST_SILENCE";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -48,6 +48,7 @@ public class PHPCSVNodeTypes
 	// expressions
 	public static final String TYPE_VAR = "AST_VAR";
 	public static final String TYPE_CONST = "AST_CONST";
+	public static final String TYPE_UNPACK = "AST_UNPACK";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	
 	// statements

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -54,6 +54,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_EMPTY = "AST_EMPTY";
 	public static final String TYPE_ISSET = "AST_ISSET";
 	public static final String TYPE_SILENCE = "AST_SILENCE";
+	public static final String TYPE_CLONE = "AST_CLONE";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -56,6 +56,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_LABEL = "AST_LABEL";
 	public static final String TYPE_REF = "AST_REF";
 	public static final String TYPE_HALT_COMPILER = "AST_HALT_COMPILER";
+	public static final String TYPE_ECHO = "AST_ECHO";
 	public static final String TYPE_THROW = "AST_THROW";
 	public static final String TYPE_GOTO = "AST_GOTO";
 	public static final String TYPE_BREAK = "AST_BREAK";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -47,6 +47,7 @@ public class PHPCSVNodeTypes
 	// nodes with exactly 1 child
 	// expressions
 	public static final String TYPE_VAR = "AST_VAR";
+	public static final String TYPE_CONST = "AST_CONST";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	
 	// statements

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_ISSET = "AST_ISSET";
 	public static final String TYPE_SILENCE = "AST_SILENCE";
 	public static final String TYPE_CLONE = "AST_CLONE";
+	public static final String TYPE_EXIT = "AST_EXIT";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -49,6 +49,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_VAR = "AST_VAR";
 	public static final String TYPE_CONST = "AST_CONST";
 	public static final String TYPE_UNPACK = "AST_UNPACK";
+	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	
 	// statements

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -54,6 +54,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_UNSET = "AST_UNSET";
 	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_LABEL = "AST_LABEL";
+	public static final String TYPE_REF = "AST_REF";
 	public static final String TYPE_THROW = "AST_THROW";
 	public static final String TYPE_GOTO = "AST_GOTO";
 	public static final String TYPE_BREAK = "AST_BREAK";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -56,6 +56,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_SILENCE = "AST_SILENCE";
 	public static final String TYPE_CLONE = "AST_CLONE";
 	public static final String TYPE_EXIT = "AST_EXIT";
+	public static final String TYPE_PRINT = "AST_PRINT";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -50,6 +50,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	
 	// statements
+	public static final String TYPE_GLOBAL = "AST_GLOBAL";
 	public static final String TYPE_RETURN = "AST_RETURN";
 	public static final String TYPE_LABEL = "AST_LABEL";
 	public static final String TYPE_THROW = "AST_THROW";

--- a/src/udg/useDefAnalysis/ASTDefUseAnalyzer.java
+++ b/src/udg/useDefAnalysis/ASTDefUseAnalyzer.java
@@ -130,7 +130,7 @@ public class ASTDefUseAnalyzer
 		case "ArrayIndexing":
 			return new ArrayIndexingEnvironment();
 
-		case "UnaryOp":
+		case "UnaryOperationExpression":
 			return new UnaryOpEnvironment();
 
 		case "Identifier":


### PR DESCRIPTION
Well, this was a productive day. :blush: 

**Support for `unset()`, `__halt_compiler()`, `global` and `echo` statements**

* `AST_UNSET` -> `ast.php.statements.PHPUnsetStatement`
* `AST_HALT_COMPILER` -> `ast.php.statements.PHPHaltCompilerStatement`
* `AST_GLOBAL` -> `ast.php.statements.PHPGlobalStatement`
* `AST_ECHO` -> `ast.php.statements.PHPEchoStatement`

All of these are quite PHP specific. They are all language constructs, though `unset()` and `__halt_compiler()` look like function calls.

All of them have a single child (`Expression` for `unset()` and `echo`, `Variable` for `global`, `PrimaryExpression` for `__halt_compiler()`). In almost all cases the child corresponds to the argument, except for `__halt_compiler()` where the offset it is actually computed by the parser and added as a child.

Also see
* http://php.net/manual/en/function.unset.php
* http://php.net/manual/en/function.halt-compiler.php
* http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global
* http://php.net/manual/en/function.echo.php

**Support for `empty()`, `isset()`, `clone()`, `exit()`, and `print()` expressions**

* `AST_EMPTY` -> `ast.php.expressions.PHPEmptyExpression`
* `AST_ISSET` -> `ast.php.expressions.PHPIssetExpression`
* `AST_CLONE` -> `ast.php.expressions.PHPCloneExpression`
* `AST_EXIT` -> `ast.php.expressions.PHPExitExpression`
* ` AST_PRINT` -> `ast.php.expressions.PHPPrintExpression`

PHP-specific expressions. These are also all language constructs, though they all look like function calls. (actually, `clone` and `print` may also be written without parentheses.)

These all extend the existing class `ast.expressions.UnaryExpression`. I also added a field `expression` to `UnaryExpression` with corresponding getters and setters, which is nicer than using `getChild(0)`. Consistenly with previous such cases, I will add a comment to #80 to suggest overriding `addChild(ASTNode)` such that it calls that setter so that C world can also use the `getExpression()` method.

**Support for the unpack operator**

* `AST_UNPACK` -> `ast.php.expressions.PHPUnpackExpression`

Also extends `UnaryExpression`, but doesn't look like a function call at all :wink: For example when you have a call like
```php
foo( ...[4,2]);
```
...then there is a `PHPUnpackExpression` with a `PHPArrayExpression` child representing the unpacking of `[4,2]`. This is mostly useful in combination with variadic functions.

See https://wiki.php.net/rfc/argument_unpacking.

**Support for unary operation expressions**

* `AST_UNARY_OP` -> `ast.expressions.UnaryOperationExpression`

I renamed already existing `UnaryOp` into `UnaryOperationExpression` for consistency (cf. `BinaryOperationExpression`). I will add a corresponding comment to https://github.com/fabsx00/python-joern/issues/13. `UnaryOperationExpression` now also extends `UnaryExpression`, as `BinaryOperationExpression` extends `BinaryExpression`.

This node is used for the following unary operators:
```php
// bit operators
~$foo;
// boolean operators
!$foo;
```

Additionally, I mapped the following node types to new classes:

* `AST_UNARY_PLUS` -> `ast.expressions.UnaryPlusExpression`
* `AST_UNARY_MINUS` -> `ast.expressions.UnaryMinusExpression`
* `AST_SILENCE` -> `ast.php.expressions.PHPSilenceExpression`

These three new classes all extend  `UnaryOperationExpression` and are used for the following unary operators:

```php
// arithmetic operators
+$x;
-$x;
// error control operators
@foo();
```

See http://php.net/manual/en/language.operators.errorcontrol.php for details on the silence operator.

This is again a case of a slightly inconsistent design of PHP ASTs as we had with binary operation expressions too, in PR #86. And as in that case, these operators will also be consistently mapped onto a `UnaryOperationExpression` in version 20 of php-ast, see https://github.com/nikic/php-ast#version-changelog.

**Support for constants**

* `AST_CONST` -> `ast.expressions.Constant`

A new class `Constant` with an `Identifier` child (since references to constants may be namespaced, a simple string child does not suffice). Straightforward. :)

**Support for variable references**

* `AST_REF` -> `ast.php.expressions.PHPReferenceExpression`

This is a node that is needed when representing expressions such as
```php
foreach( $iterable as $somekey => &$someval) { ... }
```
Here a `PHPReferenceExpression` is created with a `Variable` child representing the variable `$someval`.

This node is kind of special in that it is exclusively needed as a potential child of a `PHPForEachStatement` node.

Finally, a good and a bad news. :wink:
The good news: There remains only a handful of nodes to be mapped and I should be able to do it in a single working day.
The bad news: I just realized that I have to prepare a camera-ready version of our paper from my previous project (which was accepted at SAC! :smile:), and the deadline for that is on Monday 7th. Plus, we have the moving, so I may not be able to take care of the last mappings until Monday. I think that we will have the finished mapping on Monday evening either way, though, modulo code cleanup. :)
