### PR TITLE
Support for cast expressions, as well as pre- and post- increment and decrement expressions

### DIFF
--- a/src/ast/expressions/CastExpression.java
+++ b/src/ast/expressions/CastExpression.java
@@ -6,42 +6,36 @@ public class CastExpression extends Expression
 {
 
 	Expression castTarget = null;
-	Expression castExpression = null;
+	ASTNode castExpression = null; // TODO make this an expression
 
 	@Override
 	public void addChild(ASTNode expression)
 	{
 		if (castTarget == null)
-		{
-			castTarget = (Expression) expression;
-		} else
-		{
-			castExpression = (Expression) expression;
-		}
+			setCastTarget( (Expression)expression);
+		else
+			setCastExpression( (Expression)expression);
 	}
-
-	@Override
-	public int getChildCount()
+	
+	public Expression getCastTarget()
 	{
-		int childCount = 0;
-		if (castTarget != null)
-			childCount++;
-		if (castExpression != null)
-			childCount++;
-		return childCount;
+		return this.castTarget;
 	}
-
-	@Override
-	public ASTNode getChild(int i)
+	
+	public void setCastTarget(Expression castTarget)
 	{
-		if (i == 0)
-			return castTarget;
-		return castExpression;
+		this.castTarget = castTarget;
+		super.addChild(castTarget);
 	}
-
-	public ASTNode getCastTarget()
+	
+	public ASTNode getCastExpression()  // TODO return an expression
 	{
-		return castTarget;
+		return this.castExpression;
 	}
 
+	public void setCastExpression(ASTNode castExpression) // TODO take an expression
+	{
+		this.castExpression = castExpression;
+		super.addChild(castExpression);
+	}
 }

--- a/src/ast/expressions/IncDecOp.java
+++ b/src/ast/expressions/IncDecOp.java
@@ -1,5 +1,0 @@
-package ast.expressions;
-
-public class IncDecOp extends PostfixExpression
-{
-}

--- a/src/ast/expressions/PostDecOperationExpression.java
+++ b/src/ast/expressions/PostDecOperationExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class PostDecOperationExpression extends PostIncDecOperationExpression
+{
+}

--- a/src/ast/expressions/PostIncDecOperationExpression.java
+++ b/src/ast/expressions/PostIncDecOperationExpression.java
@@ -1,0 +1,17 @@
+package ast.expressions;
+
+public class PostIncDecOperationExpression extends PostfixExpression
+{
+	private Expression variableExpression = null;
+
+	public Expression getVariableExpression()
+	{
+		return this.variableExpression;
+	}
+
+	public void setVariableExpression(Expression variableExpression)
+	{
+		this.variableExpression = variableExpression;
+		super.addChild(variableExpression);
+	}
+}

--- a/src/ast/expressions/PostIncOperationExpression.java
+++ b/src/ast/expressions/PostIncOperationExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class PostIncOperationExpression extends PostIncDecOperationExpression
+{
+}

--- a/src/ast/expressions/PreDecOperationExpression.java
+++ b/src/ast/expressions/PreDecOperationExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class PreDecOperationExpression extends PreIncDecOperationExpression
+{
+}

--- a/src/ast/expressions/PreIncDecOperationExpression.java
+++ b/src/ast/expressions/PreIncDecOperationExpression.java
@@ -1,0 +1,17 @@
+package ast.expressions;
+
+public class PreIncDecOperationExpression extends PrefixExpression
+{
+	private Expression variableExpression = null;
+
+	public Expression getVariableExpression()
+	{
+		return this.variableExpression;
+	}
+
+	public void setVariableExpression(Expression variableExpression)
+	{
+		this.variableExpression = variableExpression;
+		super.addChild(variableExpression);
+	}
+}

--- a/src/ast/expressions/PreIncOperationExpression.java
+++ b/src/ast/expressions/PreIncOperationExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class PreIncOperationExpression extends PreIncDecOperationExpression
+{
+}

--- a/src/ast/expressions/PrefixExpression.java
+++ b/src/ast/expressions/PrefixExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class PrefixExpression extends Expression
+{
+}

--- a/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
+++ b/src/languages/c/parsing/Functions/builder/FunctionContentBuilder.java
@@ -28,7 +28,7 @@ import ast.expressions.Expression;
 import ast.expressions.ForInit;
 import ast.expressions.Identifier;
 import ast.expressions.IncDec;
-import ast.expressions.IncDecOp;
+import ast.expressions.PostIncDecOperationExpression;
 import ast.expressions.InclusiveOrExpression;
 import ast.expressions.InitializerList;
 import ast.expressions.MemberAccess;
@@ -656,7 +656,7 @@ public class FunctionContentBuilder extends ASTNodeBuilder
 
 	public void enterIncDecOp(IncDecOpContext ctx)
 	{
-		IncDecOp expr = new IncDecOp();
+		PostIncDecOperationExpression expr = new PostIncDecOperationExpression();
 		nodeToRuleContext.put(expr, ctx);
 		stack.push(expr);
 	}

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -34,6 +34,8 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PostDecOperationExpression;
 import ast.expressions.PostIncOperationExpression;
+import ast.expressions.PreDecOperationExpression;
+import ast.expressions.PreIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.UnaryMinusExpression;
@@ -1236,6 +1238,68 @@ public class TestPHPCSVASTBuilder
 		assertThat( node2, instanceOf(UnaryOperationExpression.class));
 		assertEquals( 1, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)7), ((UnaryOperationExpression)node2).getExpression());
+	}
+
+	/**
+	 * AST_PRE_INC nodes are used to denote pre-increment operation expressions.
+	 * 
+	 * Any AST_PRE_INC node has exactly exactly one child, representing the variable that
+	 * is to be incremented (e.g., could be AST_VAR, AST_PROP, AST_STATIC_PROP, AST_DIM, ...)
+	 * 
+	 * This test checks a pre-increment operation expression's child in the following PHP code:
+	 * 
+	 * ++$i;
+	 */
+	@Test
+	public void testPreIncCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_PRE_INC,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"i\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PreIncOperationExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PreIncOperationExpression)node).getVariableExpression());
+	}
+	
+	/**
+	 * AST_PRE_DEC nodes are used to denote pre-decrement operation expressions.
+	 * 
+	 * Any AST_PRE_DEC node has exactly exactly one child, representing the variable that
+	 * is to be decremented (e.g., could be AST_VAR, AST_PROP, AST_STATIC_PROP, AST_DIM, ...)
+	 * 
+	 * This test checks a pre-decrement operation expression's child in the following PHP code:
+	 * 
+	 * --$i;
+	 */
+	@Test
+	public void testPreDecCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_PRE_DEC,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"i\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PreDecOperationExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PreDecOperationExpression)node).getVariableExpression());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -32,6 +32,8 @@ import ast.expressions.IdentifierList;
 import ast.expressions.InstanceofExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
+import ast.expressions.PostDecOperationExpression;
+import ast.expressions.PostIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.UnaryMinusExpression;
@@ -1198,7 +1200,7 @@ public class TestPHPCSVASTBuilder
 	 * Any AST_UNARY_OP node has exactly exactly one child, representing the expression for which
 	 * the operation is to be performed.
 	 * 
-	 * This test checks a few of unary operation expressions' children in the following PHP code:
+	 * This test checks a few unary operation expressions' children in the following PHP code:
 	 * 
 	 * // bit operators
 	 * ~$foo;
@@ -1234,6 +1236,68 @@ public class TestPHPCSVASTBuilder
 		assertThat( node2, instanceOf(UnaryOperationExpression.class));
 		assertEquals( 1, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)7), ((UnaryOperationExpression)node2).getExpression());
+	}
+	
+	/**
+	 * AST_POST_INC nodes are used to denote post-increment operation expressions.
+	 * 
+	 * Any AST_POST_INC node has exactly exactly one child, representing the variable that
+	 * is to be incremented (e.g., could be AST_VAR, AST_PROP, AST_STATIC_PROP, AST_DIM, ...)
+	 * 
+	 * This test checks a post-increment operation expression's child in the following PHP code:
+	 * 
+	 * $i++;
+	 */
+	@Test
+	public void testPostIncCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_POST_INC,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"i\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PostIncOperationExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PostIncOperationExpression)node).getVariableExpression());
+	}
+	
+	/**
+	 * AST_POST_DEC nodes are used to denote post-decrement operation expressions.
+	 * 
+	 * Any AST_POST_DEC node has exactly exactly one child, representing the variable that
+	 * is to be decremented (e.g., could be AST_VAR, AST_PROP, AST_STATIC_PROP, AST_DIM, ...)
+	 * 
+	 * This test checks a post-decrement operation expression's child in the following PHP code:
+	 * 
+	 * $i--;
+	 */
+	@Test
+	public void testPostDecCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_POST_DEC,,3,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
+		nodeStr += "5,string,,3,\"i\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		
+		assertThat( node, instanceOf(PostDecOperationExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((PostDecOperationExpression)node).getVariableExpression());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -20,6 +20,7 @@ import ast.expressions.AssignmentExpression;
 import ast.expressions.AssignmentWithOpExpression;
 import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
+import ast.expressions.CastExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.Constant;
@@ -111,6 +112,7 @@ import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.ASTUnderConstruction;
 import tools.phpast2cfg.PHPCSVEdgeInterpreter;
 import tools.phpast2cfg.PHPCSVNodeInterpreter;
+import tools.phpast2cfg.PHPCSVNodeTypes;
 
 public class TestPHPCSVASTBuilder
 {
@@ -737,6 +739,172 @@ public class TestPHPCSVASTBuilder
 		assertThat( node, instanceOf(UnaryMinusExpression.class));
 		assertEquals( 1, node.getChildCount());
 		assertEquals( ast.getNodeById((long)4), ((UnaryMinusExpression)node).getExpression());
+	}
+	
+	/**
+	 * AST_CAST nodes are used to denote cast expressions.
+	 * 
+	 * Any AST_CAST node has exactly exactly one child, representing the expression whose evaluation
+	 * is going to be cast to a given type.
+	 * Note that there is no distinguished child for the type that the expression is being cast to.
+	 * Rather, the type of cast is determined by a flag. The following flags exist:
+	 * - TYPE_NULL
+	 * - TYPE_BOOL
+	 * - TYPE_LONG
+	 * - TYPE_DOUBLE
+	 * - TYPE_STRING
+	 * - TYPE_ARRAY
+	 * - TYPE_OBJECT
+	 * Also see http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
+	 * for the different type casts that exist in PHP.
+	 * 
+	 * This test checks a few cast expressions' children in the following PHP code:
+	 * 
+	 * // NULL
+	 * (unset)$n;
+	 * // bool
+	 * (bool)0;
+	 * (boolean)1;
+	 * // long
+	 * (int)2;
+	 * (integer)3;
+	 * // double
+	 * (float)3.14;
+	 * (double)4.2;
+	 * (real)6.6;
+	 * // string
+	 * (string)"hello";
+	 * // array
+	 * (array)$a;
+	 * // object
+	 * (object)$o;
+	 */
+	@Test
+	public void testCastCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
+		nodeStr += "3,AST_CAST,TYPE_NULL,4,,0,1,,,\n";
+		nodeStr += "4,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "5,string,,4,\"n\",0,1,,,\n";
+		nodeStr += "6,AST_CAST,TYPE_BOOL,6,,1,1,,,\n";
+		nodeStr += "7,integer,,6,0,0,1,,,\n";
+		nodeStr += "8,AST_CAST,TYPE_BOOL,7,,2,1,,,\n";
+		nodeStr += "9,integer,,7,1,0,1,,,\n";
+		nodeStr += "10,AST_CAST,TYPE_LONG,9,,3,1,,,\n";
+		nodeStr += "11,integer,,9,2,0,1,,,\n";
+		nodeStr += "12,AST_CAST,TYPE_LONG,10,,4,1,,,\n";
+		nodeStr += "13,integer,,10,3,0,1,,,\n";
+		nodeStr += "14,AST_CAST,TYPE_DOUBLE,12,,5,1,,,\n";
+		nodeStr += "15,double,,12,3.14,0,1,,,\n";
+		nodeStr += "16,AST_CAST,TYPE_DOUBLE,13,,6,1,,,\n";
+		nodeStr += "17,double,,13,4.2,0,1,,,\n";
+		nodeStr += "18,AST_CAST,TYPE_DOUBLE,14,,7,1,,,\n";
+		nodeStr += "19,double,,14,6.6,0,1,,,\n";
+		nodeStr += "20,AST_CAST,TYPE_STRING,16,,8,1,,,\n";
+		nodeStr += "21,string,,16,\"hello\",0,1,,,\n";
+		nodeStr += "22,AST_CAST,TYPE_ARRAY,18,,9,1,,,\n";
+		nodeStr += "23,AST_VAR,,18,,0,1,,,\n";
+		nodeStr += "24,string,,18,\"a\",0,1,,,\n";
+		nodeStr += "25,AST_CAST,TYPE_OBJECT,20,,10,1,,,\n";
+		nodeStr += "26,AST_VAR,,20,,0,1,,,\n";
+		nodeStr += "27,string,,20,\"o\",0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "4,5,PARENT_OF\n";
+		edgeStr += "3,4,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "6,7,PARENT_OF\n";
+		edgeStr += "2,6,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "2,8,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "2,10,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "2,12,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "2,14,PARENT_OF\n";
+		edgeStr += "16,17,PARENT_OF\n";
+		edgeStr += "2,16,PARENT_OF\n";
+		edgeStr += "18,19,PARENT_OF\n";
+		edgeStr += "2,18,PARENT_OF\n";
+		edgeStr += "20,21,PARENT_OF\n";
+		edgeStr += "2,20,PARENT_OF\n";
+		edgeStr += "23,24,PARENT_OF\n";
+		edgeStr += "22,23,PARENT_OF\n";
+		edgeStr += "2,22,PARENT_OF\n";
+		edgeStr += "26,27,PARENT_OF\n";
+		edgeStr += "25,26,PARENT_OF\n";
+		edgeStr += "2,25,PARENT_OF\n";
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)6);
+		ASTNode node3 = ast.getNodeById((long)8);
+		ASTNode node4 = ast.getNodeById((long)10);
+		ASTNode node5 = ast.getNodeById((long)12);
+		ASTNode node6 = ast.getNodeById((long)14);
+		ASTNode node7 = ast.getNodeById((long)16);
+		ASTNode node8 = ast.getNodeById((long)18);
+		ASTNode node9 = ast.getNodeById((long)20);
+		ASTNode node10 = ast.getNodeById((long)22);
+		ASTNode node11 = ast.getNodeById((long)25);
+
+		assertThat( node, instanceOf(CastExpression.class));
+		assertEquals( 1, node.getChildCount());
+		assertEquals( ast.getNodeById((long)4), ((CastExpression)node).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_NULL, ((CastExpression)node).getFlags());
+		
+		assertThat( node2, instanceOf(CastExpression.class));
+		assertEquals( 1, node2.getChildCount());
+		assertEquals( ast.getNodeById((long)7), ((CastExpression)node2).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_BOOL, ((CastExpression)node2).getFlags());
+
+		assertThat( node3, instanceOf(CastExpression.class));
+		assertEquals( 1, node3.getChildCount());
+		assertEquals( ast.getNodeById((long)9), ((CastExpression)node3).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_BOOL, ((CastExpression)node3).getFlags());
+		
+		assertThat( node4, instanceOf(CastExpression.class));
+		assertEquals( 1, node4.getChildCount());
+		assertEquals( ast.getNodeById((long)11), ((CastExpression)node4).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_LONG, ((CastExpression)node4).getFlags());
+		
+		assertThat( node5, instanceOf(CastExpression.class));
+		assertEquals( 1, node5.getChildCount());
+		assertEquals( ast.getNodeById((long)13), ((CastExpression)node5).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_LONG, ((CastExpression)node5).getFlags());
+		
+		assertThat( node6, instanceOf(CastExpression.class));
+		assertEquals( 1, node6.getChildCount());
+		assertEquals( ast.getNodeById((long)15), ((CastExpression)node6).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_DOUBLE, ((CastExpression)node6).getFlags());
+		
+		assertThat( node7, instanceOf(CastExpression.class));
+		assertEquals( 1, node7.getChildCount());
+		assertEquals( ast.getNodeById((long)17), ((CastExpression)node7).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_DOUBLE, ((CastExpression)node7).getFlags());
+		
+		assertThat( node8, instanceOf(CastExpression.class));
+		assertEquals( 1, node8.getChildCount());
+		assertEquals( ast.getNodeById((long)19), ((CastExpression)node8).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_DOUBLE, ((CastExpression)node8).getFlags());
+		
+		assertThat( node9, instanceOf(CastExpression.class));
+		assertEquals( 1, node9.getChildCount());
+		assertEquals( ast.getNodeById((long)21), ((CastExpression)node9).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_STRING, ((CastExpression)node9).getFlags());
+		
+		assertThat( node10, instanceOf(CastExpression.class));
+		assertEquals( 1, node10.getChildCount());
+		assertEquals( ast.getNodeById((long)23), ((CastExpression)node10).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_ARRAY, ((CastExpression)node10).getFlags());
+		
+		assertThat( node11, instanceOf(CastExpression.class));
+		assertEquals( 1, node11.getChildCount());
+		assertEquals( ast.getNodeById((long)26), ((CastExpression)node11).getCastExpression());
+		assertEquals( PHPCSVNodeTypes.FLAG_TYPE_OBJECT, ((CastExpression)node11).getFlags());
 	}
 	
 	/**

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -8,6 +8,7 @@ import ast.expressions.AssignmentExpression;
 import ast.expressions.AssignmentWithOpExpression;
 import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
+import ast.expressions.CastExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.Constant;
@@ -163,6 +164,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_MINUS:
 				errno = handleUnaryMinus((UnaryMinusExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_CAST:
+				errno = handleCast((CastExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_EMPTY:
 				errno = handleEmpty((PHPEmptyExpression)startNode, endNode, childnum);
@@ -681,6 +685,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// UnaryOperationExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleCast( CastExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// CastExpression.castExpression and getters and setters accordingly
+				startNode.setCastExpression(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -23,6 +23,8 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PostDecOperationExpression;
 import ast.expressions.PostIncOperationExpression;
+import ast.expressions.PreDecOperationExpression;
+import ast.expressions.PreIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.UnaryMinusExpression;
@@ -190,6 +192,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_PRE_INC:
+				errno = handlePreInc((PreIncOperationExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_PRE_DEC:
+				errno = handlePreDec((PreDecOperationExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_POST_INC:
 				errno = handlePostInc((PostIncOperationExpression)startNode, endNode, childnum);
@@ -845,6 +853,40 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// UnaryOperationExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handlePreInc( PreIncOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setVariableExpression((Expression)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+
+	private int handlePreDec( PreDecOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setVariableExpression((Expression)endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -21,6 +21,8 @@ import ast.expressions.IdentifierList;
 import ast.expressions.InstanceofExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
+import ast.expressions.PostDecOperationExpression;
+import ast.expressions.PostIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.UnaryMinusExpression;
@@ -188,6 +190,12 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_POST_INC:
+				errno = handlePostInc((PostIncOperationExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_POST_DEC:
+				errno = handlePostDec((PostDecOperationExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				errno = handleYieldFrom((PHPYieldFromExpression)startNode, endNode, childnum);
@@ -837,6 +845,40 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// UnaryOperationExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handlePostInc( PostIncOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setVariableExpression((Expression)endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+
+	private int handlePostDec( PostDecOperationExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				startNode.setVariableExpression((Expression)endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -13,6 +13,7 @@ import ast.expressions.AssignmentExpression;
 import ast.expressions.AssignmentWithOpExpression;
 import ast.expressions.BinaryOperationExpression;
 import ast.expressions.CallExpression;
+import ast.expressions.CastExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.Constant;
@@ -149,6 +150,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_MINUS:
 				retval = handleUnaryMinus(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_CAST:
+				retval = handleCast(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_EMPTY:
 				retval = handleEmpty(row, ast);
@@ -723,6 +727,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleUnaryMinus(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		UnaryMinusExpression newNode = new UnaryMinusExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleCast(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		CastExpression newNode = new CastExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -25,6 +25,8 @@ import ast.expressions.IdentifierList;
 import ast.expressions.InstanceofExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
+import ast.expressions.PostDecOperationExpression;
+import ast.expressions.PostIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.UnaryMinusExpression;
@@ -174,6 +176,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_POST_INC:
+				retval = handlePostInc(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_POST_DEC:
+				retval = handlePostDec(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_YIELD_FROM:
 				retval = handleYieldFrom(row, ast);
@@ -903,6 +911,50 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleUnaryOperation(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		UnaryOperationExpression newNode = new UnaryOperationExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+
+	private long handlePostInc(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PostIncOperationExpression newNode = new PostIncOperationExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+
+	private long handlePostDec(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PostDecOperationExpression newNode = new PostDecOperationExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -27,6 +27,8 @@ import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PostDecOperationExpression;
 import ast.expressions.PostIncOperationExpression;
+import ast.expressions.PreDecOperationExpression;
+import ast.expressions.PreIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.UnaryMinusExpression;
@@ -176,6 +178,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_PRE_INC:
+				retval = handlePreInc(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_PRE_DEC:
+				retval = handlePreDec(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_POST_INC:
 				retval = handlePostInc(row, ast);
@@ -930,6 +938,50 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		return id;
 	}
 
+	private long handlePreInc(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PreIncOperationExpression newNode = new PreIncOperationExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+
+	private long handlePreDec(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PreDecOperationExpression newNode = new PreDecOperationExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	private long handlePostInc(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PostIncOperationExpression newNode = new PostIncOperationExpression();

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -59,6 +59,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_EXIT = "AST_EXIT";
 	public static final String TYPE_PRINT = "AST_PRINT";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
+	public static final String TYPE_POST_INC = "AST_POST_INC";
+	public static final String TYPE_POST_DEC = "AST_POST_DEC";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";
 	
 	// statements

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -51,6 +51,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_UNPACK = "AST_UNPACK";
 	public static final String TYPE_UNARY_PLUS = "AST_UNARY_PLUS";
 	public static final String TYPE_UNARY_MINUS = "AST_UNARY_MINUS";
+	public static final String TYPE_CAST = "AST_CAST";
 	public static final String TYPE_EMPTY = "AST_EMPTY";
 	public static final String TYPE_ISSET = "AST_ISSET";
 	public static final String TYPE_SILENCE = "AST_SILENCE";
@@ -151,4 +152,13 @@ public class PHPCSVNodeTypes
 	// flags for toplevel nodes
 	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial
 	public static final String FLAG_TOPLEVEL_CLASS = "TOPLEVEL_CLASS"; // artificial
+	
+	// flags for cast operations
+	public static final String FLAG_TYPE_NULL = "TYPE_NULL";
+	public static final String FLAG_TYPE_BOOL = "TYPE_BOOL";
+	public static final String FLAG_TYPE_LONG = "TYPE_LONG";
+	public static final String FLAG_TYPE_DOUBLE = "TYPE_DOUBLE";
+	public static final String FLAG_TYPE_STRING = "TYPE_STRING";
+	public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY";
+	public static final String FLAG_TYPE_OBJECT = "TYPE_OBJECT";
 }

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -59,6 +59,8 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_EXIT = "AST_EXIT";
 	public static final String TYPE_PRINT = "AST_PRINT";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
+	public static final String TYPE_PRE_INC = "AST_PRE_INC";
+	public static final String TYPE_PRE_DEC = "AST_PRE_DEC";
 	public static final String TYPE_POST_INC = "AST_POST_INC";
 	public static final String TYPE_POST_DEC = "AST_POST_DEC";
 	public static final String TYPE_YIELD_FROM = "AST_YIELD_FROM";

--- a/src/udg/useDefAnalysis/ASTDefUseAnalyzer.java
+++ b/src/udg/useDefAnalysis/ASTDefUseAnalyzer.java
@@ -105,7 +105,7 @@ public class ASTDefUseAnalyzer
 		{
 		case "AssignmentExpression":
 			return new AssignmentEnvironment();
-		case "IncDecOp":
+		case "PostIncDecOperationExpression":
 			return new IncDecEnvironment();
 		case "IdentifierDecl":
 		case "Parameter":


### PR DESCRIPTION
**Support for cast expressions**

* `AST_CAST` -> `ast.expressions.CastExpression`

Firstly one should note that `CastExpression` has two children in C world (a target expression and a cast expression), while it has only a single child in PHP world (a cast expression). Indeed, there exists only a finite, small set of possible type casts in PHP:

```php
// NULL
(unset)$n;
// bool
(bool)0;
(boolean)1;
// long
(int)2;
(integer)3;
// double
(float)3.14;
(double)4.2;
(real)6.6;
// string
(string)"hello";
// array
(array)$a;
// object
(object)$o;
```

Also see http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting.

That is, there exist only seven different type casts (with some type casts having several synonyms.) Accordingly, a cast expression is represented with a single child that represents the cast expression, and one of the seven flags `TYPE_NULL`, `TYPE_BOOL`, `TYPE_LONG`, `TYPE_DOUBLE`, `TYPE_STRING`, `TYPE_ARRAY`, or `TYPE_OBJECT`.

Still, as cast targets are general enough to have them in a base class, I left `CastExpression` with its two already existing fields, `castTarget` and `castExpression`. It should simply be noted that `castTarget` is not at all used in PHP world.

Additionally, I refactored `CastExpression` to include setters for the `castTarget` and `castExpression` fields (i.e., `setCastTarget()` and `setCastExpression()`, respectively), and had them call `super.addChild()` respectively, as is being done in all other nodes too. Then I modified the already existing override `addChild(ASTNode)` to call these setters. Since the children nodes are thereby *actually* being added to the node's list of children (they weren't before!), overriding `getChild(int)` and `getChildCount()` became superfluous, and I thus removed these overrides. We have here a similar situation as for `BinaryExpression` (see PR #86); I maintain that neither of these two methods should need to be overridden, ever. If they are, it is a sign that something went awry earlier, and this was indeed the case here: The super-method `ASTNode.addChild(ASTNode)` was never called.

I will also add an appropriate comment to #80 to remember perhaps using `getCastExpression()` instead of `getChild(1)` in C world; at the same time, a method `getTargetExpression()` existed already.

Thereby, the design of this class is now consistent with that of other classes, with the children being actually added to the node's list of children and without overrides for `getChild(int)` and `getChildCount()`.

**Support for post- increment and decrement expressions**

* `AST_POST_INC` -> `ast.expressions.PostIncOperationExpression`
* `AST_POST_DEC` -> `ast.expressions.PostDecOperationExpression`

This is to express the code
```php
$i++;
$i--;
```

I again renamed a node, namely, `ast.expressions.IncDecOp` into `ast.expressions.PostIncDecOperationExpression`, with the two above-mentioned new classes inheriting from this already existing class. This is mostly to be consistent with `UnaryOperationExpression` (called `UnaryOp` before.) The `Post` was added to distinguish it from the `PreIncDecOperationExpression`, which we will discuss in the next section. I will add an appropriate comment to https://github.com/fabsx00/python-joern/issues/13.

I also added a new field `variableExpression` to `PostIncDecOperationExpression`, with according getters and setters. I will add a comment to #80 to suggest refactoring C world to accordingly override `addChild(ASTNode)` and use `getVariableExpression()` instead of `getChild(0)`.

**Support for pre- increment and decrement expressions**

* `AST_PRE_INC` -> `ast.expressions.PreIncOperationExpression`
* `AST_PRE_DEC` -> `ast.expressions.PreDecOperationExpression`

This is to express code such as
```php
++$i;
--$i;
```

This is quite analogous to the previous section: The two above-mentioned classes are new and they extend `ast.expressions.PreIncDecOperationExpression`, which in turn extends `PrefixExpression`.

The main difference here is that `PreIncDecOperationExpression` and `PrefixExpression` did not exist, yet. As can be expected, their implementation is completely analogous to that of `PostIncDecOperationExpression`, resp. `PostfixExpression`.

We are almost done now, but not quite, as I had hoped on Friday. The moving consumes a lot of time... But there remain only 2 nodes with 1 child to be mapped, 2 nodes with no child, and the primary types such as `integer`, `double` or `string`. I should be able to finish this tomorrow, unless some unforeseen event prevents me from working on this. :blush: 