### PR TITLE
Finished mapping of AST nodes

### DIFF
--- a/src/ast/expressions/DoubleExpression.java
+++ b/src/ast/expressions/DoubleExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class DoubleExpression extends PrimaryExpression
+{
+}

--- a/src/ast/expressions/IntegerExpression.java
+++ b/src/ast/expressions/IntegerExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class IntegerExpression extends PrimaryExpression
+{
+}

--- a/src/ast/expressions/PrimaryExpression.java
+++ b/src/ast/expressions/PrimaryExpression.java
@@ -2,7 +2,7 @@ package ast.expressions;
 
 import ast.walking.ASTNodeVisitor;
 
-public class PrimaryExpression extends PostfixExpression
+public class PrimaryExpression extends Expression
 {
 	public void accept(ASTNodeVisitor visitor)
 	{

--- a/src/ast/expressions/StringExpression.java
+++ b/src/ast/expressions/StringExpression.java
@@ -1,0 +1,5 @@
+package ast.expressions;
+
+public class StringExpression extends PrimaryExpression
+{
+}

--- a/src/ast/php/expressions/PHPIncludeOrEvalExpression.java
+++ b/src/ast/php/expressions/PHPIncludeOrEvalExpression.java
@@ -1,0 +1,15 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.UnaryExpression;
+
+public class PHPIncludeOrEvalExpression extends UnaryExpression
+{
+	public ASTNode getIncludeOrEvalExpression() { // TODO return an expression
+		return super.getExpression();
+	}
+	
+	public void setIncludeOrEvalExpression(ASTNode variable) { // TODO take an expression
+		super.setExpression(variable);
+	}
+}

--- a/src/ast/php/expressions/PHPMagicConstant.java
+++ b/src/ast/php/expressions/PHPMagicConstant.java
@@ -1,0 +1,7 @@
+package ast.php.expressions;
+
+import ast.expressions.Expression;
+
+public class PHPMagicConstant extends Expression
+{
+}

--- a/src/ast/php/expressions/PHPShellExecExpression.java
+++ b/src/ast/php/expressions/PHPShellExecExpression.java
@@ -1,0 +1,15 @@
+package ast.php.expressions;
+
+import ast.ASTNode;
+import ast.expressions.UnaryExpression;
+
+public class PHPShellExecExpression extends UnaryExpression
+{
+	public ASTNode getShellCommand() { // TODO return an expression
+		return super.getExpression();
+	}
+	
+	public void setShellCommand(ASTNode variable) { // TODO take an expression
+		super.setExpression(variable);
+	}
+}

--- a/src/ast/php/expressions/PHPTypeHint.java
+++ b/src/ast/php/expressions/PHPTypeHint.java
@@ -1,0 +1,7 @@
+package ast.php.expressions;
+
+import ast.expressions.Identifier;
+
+public class PHPTypeHint extends Identifier
+{
+}

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -60,6 +60,7 @@ import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIncludeOrEvalExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPMagicConstant;
 import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPShellExecExpression;
@@ -509,8 +510,97 @@ public class TestPHPCSVASTBuilder
 		assertEquals( "[foo]", ((PHPClassDef)node).getTopLevelFunc().getName());
 		assertEquals( ast.getNodeById((long)10), ((PHPClassDef)node).getTopLevelFunc().getContent());
 	}
+
 	
+	/* nodes without children (leafs) */
 	
+	/**
+	 * AST_MAGIC_CONST nodes are nodes holding magic constant names.
+	 * 
+	 * AST_MAGIC_CONST nodes have no children. They do however have a flag to distinguish
+	 * which magic constant is used.
+	 * The following flags exist:
+	 * - FLAG_MAGIC_LINE
+	 * - FLAG_MAGIC_FILE
+	 * - FLAG_MAGIC_DIR
+	 * - FLAG_MAGIC_NAMESPACE
+	 * - FLAG_MAGIC_FUNCTION
+	 * - FLAG_MAGIC_METHOD
+	 * - FLAG_MAGIC_CLASS
+	 * - FLAG_MAGIC_TRAIT
+	 * See http://php.net/manual/en/language.constants.predefined.php
+	 * 
+	 * This test checks a few magic constant expressions in the following PHP code:
+	 * 
+	 * __LINE__;
+	 * __FILE__;
+	 * __DIR__;
+	 * __NAMESPACE__;
+	 * __FUNCTION__;
+	 * __METHOD__;
+	 * __CLASS__;
+	 * __TRAIT__;
+	 */
+	@Test
+	public void testMagicConstantCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,AST_MAGIC_CONST,T_LINE,3,,0,1,,,\n";
+		nodeStr += "4,AST_MAGIC_CONST,T_FILE,4,,1,1,,,\n";
+		nodeStr += "5,AST_MAGIC_CONST,T_DIR,5,,2,1,,,\n";
+		nodeStr += "6,AST_MAGIC_CONST,T_NS_C,6,,3,1,,,\n";
+		nodeStr += "7,AST_MAGIC_CONST,T_FUNC_C,7,,4,1,,,\n";
+		nodeStr += "8,AST_MAGIC_CONST,T_METHOD_C,8,,5,1,,,\n";
+		nodeStr += "9,AST_MAGIC_CONST,T_CLASS_C,9,,6,1,,,\n";
+		nodeStr += "10,AST_MAGIC_CONST,T_TRAIT_C,10,,7,1,,,\n";
+		
+		String edgeStr = edgeHeader;
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)4);
+		ASTNode node3 = ast.getNodeById((long)5);
+		ASTNode node4 = ast.getNodeById((long)6);
+		ASTNode node5 = ast.getNodeById((long)7);
+		ASTNode node6 = ast.getNodeById((long)8);
+		ASTNode node7 = ast.getNodeById((long)9);
+		ASTNode node8 = ast.getNodeById((long)10);
+
+		assertThat( node, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_LINE, ((PHPMagicConstant)node).getFlags());
+
+		assertThat( node2, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node2.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_FILE, ((PHPMagicConstant)node2).getFlags());
+
+		assertThat( node3, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node3.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_DIR, ((PHPMagicConstant)node3).getFlags());
+
+		assertThat( node4, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node4.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_NAMESPACE, ((PHPMagicConstant)node4).getFlags());
+
+		assertThat( node5, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node5.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_FUNCTION, ((PHPMagicConstant)node5).getFlags());
+
+		assertThat( node6, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node6.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_METHOD, ((PHPMagicConstant)node6).getFlags());
+
+		assertThat( node7, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node7.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_CLASS, ((PHPMagicConstant)node7).getFlags());
+
+		assertThat( node8, instanceOf(PHPMagicConstant.class));
+		assertEquals( 0, node8.getChildCount());
+		assertEquals( PHPCSVNodeTypes.FLAG_MAGIC_TRAIT, ((PHPMagicConstant)node8).getFlags());
+	}
+
+
 	/* nodes with exactly 1 child */
 	
 	/**
@@ -754,13 +844,13 @@ public class TestPHPCSVASTBuilder
 	 * is going to be cast to a given type.
 	 * Note that there is no distinguished child for the type that the expression is being cast to.
 	 * Rather, the type of cast is determined by a flag. The following flags exist:
-	 * - TYPE_NULL
-	 * - TYPE_BOOL
-	 * - TYPE_LONG
-	 * - TYPE_DOUBLE
-	 * - TYPE_STRING
-	 * - TYPE_ARRAY
-	 * - TYPE_OBJECT
+	 * - FLAG_TYPE_NULL
+	 * - FLAG_TYPE_BOOL
+	 * - FLAG_TYPE_LONG
+	 * - FLAG_TYPE_DOUBLE
+	 * - FLAG_TYPE_STRING
+	 * - FLAG_TYPE_ARRAY
+	 * - FLAG_TYPE_OBJECT
 	 * Also see http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
 	 * for the different type casts that exist in PHP.
 	 * 

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -24,12 +24,14 @@ import ast.expressions.CastExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.Constant;
+import ast.expressions.DoubleExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
 import ast.expressions.InstanceofExpression;
+import ast.expressions.IntegerExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PostDecOperationExpression;
@@ -38,6 +40,7 @@ import ast.expressions.PreDecOperationExpression;
 import ast.expressions.PreIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.StringExpression;
 import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryPlusExpression;
@@ -158,6 +161,50 @@ public class TestPHPCSVASTBuilder
 	}
 	
 	
+	// primary expressions (leafs)
+	
+	/**
+	 * "integer", "double" or "string" nodes are nodes holding primary expressions such
+	 * as an integer, a floating point number or a string enclosed in single or double quotes.
+	 * 
+	 * These nodes have no children. Their concrete value is specified as the 'code' property.
+	 * 
+	 * This test checks a few primary expressions in the following PHP code:
+	 * 
+	 * 42;
+	 * 3.14;
+	 * "Hello World!";
+	 */
+	@Test
+	public void testPrimaryExpressionCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "3,integer,,1,42,0,1,,,\n";
+		nodeStr += "4,double,,1,3.14,1,1,,,\n";
+		nodeStr += "5,string,,1,\"Hello World!\",2,1,,,\n";
+		
+		String edgeStr = edgeHeader;
+
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)4);
+		ASTNode node3 = ast.getNodeById((long)5);
+
+		assertThat( node, instanceOf(IntegerExpression.class));
+		assertEquals( 0, node.getChildCount());
+		assertEquals( "42", ((IntegerExpression)node).getEscapedCodeStr());
+
+		assertThat( node2, instanceOf(DoubleExpression.class));
+		assertEquals( 0, node2.getChildCount());
+		assertEquals( "3.14", ((DoubleExpression)node2).getEscapedCodeStr());
+
+		assertThat( node3, instanceOf(StringExpression.class));
+		assertEquals( 0, node3.getChildCount());
+		assertEquals( "Hello World!", ((StringExpression)node3).getEscapedCodeStr());
+	}
+
+
 	/* special nodes */	
 	
 	/**

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -157,9 +157,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			// nodes without children (leafs)
 			// expressions
 			case PHPCSVNodeTypes.TYPE_MAGIC_CONST:
+			case PHPCSVNodeTypes.TYPE_TYPE:
 				errno = 2;
 				break;
-
 
 			// nodes with exactly 1 child
 			// expressions

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -50,6 +50,7 @@ import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
+import ast.php.expressions.PHPShellExecExpression;
 import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
@@ -180,6 +181,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SILENCE:
 				errno = handleSilence((PHPSilenceExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_SHELL_EXEC:
+				errno = handleShellExec((PHPShellExecExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_CLONE:
 				errno = handleClone((PHPCloneExpression)startNode, endNode, childnum);
@@ -777,6 +781,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// UnaryOperationExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+
+	private int handleShellExec( PHPShellExecExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryExpression.expression and getters and setters accordingly
+				startNode.setShellCommand(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -154,6 +154,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				errno = handleClass((PHPClassDef)startNode, endNode, childnum);
 				break;
 
+			// nodes without children (leafs)
+			// expressions
+			case PHPCSVNodeTypes.TYPE_MAGIC_CONST:
+				errno = 2;
+				break;
+
+
 			// nodes with exactly 1 child
 			// expressions
 			case PHPCSVNodeTypes.TYPE_VAR:
@@ -452,8 +459,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			throw new InvalidCSVFile("While trying to handle row "
 					+ row.toString() + ": Invalid childnum " + childnum
 					+ " for start node type " + type + ".");
-		
-		
+		else if( 2 == errno)
+			throw new InvalidCSVFile("While trying to handle row "
+					+ row.toString() + ": Cannot add child to leaf node "
+					+ type + ".");
+
 		return startId;
 	}
 	

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -46,6 +46,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPExitExpression;
+import ast.php.expressions.PHPIncludeOrEvalExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPPrintExpression;
@@ -193,6 +194,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PRINT:
 				errno = handlePrint((PHPPrintExpression)startNode, endNode, childnum);
+				break;
+			case PHPCSVNodeTypes.TYPE_INCLUDE_OR_EVAL:
+				errno = handleIncludeOrEval((PHPIncludeOrEvalExpression)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				errno = handleUnaryOperation((UnaryOperationExpression)startNode, endNode, childnum);
@@ -857,6 +861,25 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				// TODO cast to Exression once mapping is finished, and change
 				// UnaryExpression.expression and getters and setters accordingly
 				startNode.setExpression(endNode);
+				break;
+				
+			default:
+				errno = 1;
+		}
+		
+		return errno;		
+	}
+	
+	private int handleIncludeOrEval( PHPIncludeOrEvalExpression startNode, ASTNode endNode, int childnum)
+	{
+		int errno = 0;
+
+		switch (childnum)
+		{
+			case 0: // expr child
+				// TODO cast to Exression once mapping is finished, and change
+				// UnaryExpression.expression and getters and setters accordingly
+				startNode.setIncludeOrEvalExpression(endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -129,6 +129,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		String type = startNode.getProperty(PHPCSVNodeTypes.TYPE.getName());
 		switch (type)
 		{
+			// primary expressions (leafs)
+			case PHPCSVNodeTypes.TYPE_INTEGER:
+			case PHPCSVNodeTypes.TYPE_DOUBLE:
+			case PHPCSVNodeTypes.TYPE_STRING:
+				errno = 2;
+				break;
+			
 			// special nodes
 			case PHPCSVNodeTypes.TYPE_NAME:
 				errno = handleName((Identifier)startNode, endNode, childnum);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -49,6 +49,7 @@ import ast.php.expressions.PHPCoalesceExpression;
 import ast.php.expressions.PHPEmptyExpression;
 import ast.php.expressions.PHPEncapsListExpression;
 import ast.php.expressions.PHPExitExpression;
+import ast.php.expressions.PHPIncludeOrEvalExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPPrintExpression;
@@ -179,6 +180,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_PRINT:
 				retval = handlePrint(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_INCLUDE_OR_EVAL:
+				retval = handleIncludeOrEval(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_UNARY_OP:
 				retval = handleUnaryOperation(row, ast);
@@ -923,6 +927,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handlePrint(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPPrintExpression newNode = new PHPPrintExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleIncludeOrEval(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPIncludeOrEvalExpression newNode = new PHPIncludeOrEvalExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -52,6 +52,7 @@ import ast.php.expressions.PHPExitExpression;
 import ast.php.expressions.PHPIncludeOrEvalExpression;
 import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
+import ast.php.expressions.PHPMagicConstant;
 import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPShellExecExpression;
@@ -138,6 +139,12 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_CLASS:
 				retval = handleClass(row, ast);
+				break;
+
+			// nodes without children (leafs)
+			// expressions
+			case PHPCSVNodeTypes.TYPE_MAGIC_CONST:
+				retval = handleMagicConst(row, ast);
 				break;
 
 			// nodes with exactly 1 child
@@ -650,6 +657,31 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 		newNode.setName(name);
 		newNode.setDocComment(doccomment);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	
+	/* nodes without children (leafs) */
+	
+	private long handleMagicConst(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPMagicConstant newNode = new PHPMagicConstant();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
 
 		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
 		ast.addNodeWithId(newNode, id);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -17,12 +17,14 @@ import ast.expressions.CastExpression;
 import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.Constant;
+import ast.expressions.DoubleExpression;
 import ast.expressions.ExpressionList;
 import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
 import ast.expressions.InstanceofExpression;
+import ast.expressions.IntegerExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PostDecOperationExpression;
@@ -31,6 +33,7 @@ import ast.expressions.PreDecOperationExpression;
 import ast.expressions.PreIncOperationExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.StringExpression;
 import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryPlusExpression;
@@ -117,6 +120,17 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		switch (type)
 		{
+			// primary expressions (leafs)
+			case PHPCSVNodeTypes.TYPE_INTEGER:
+				retval = handleInteger(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_DOUBLE:
+				retval = handleDouble(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_STRING:
+				retval = handleString(row, ast);
+				break;
+		
 			// special nodes
 			case PHPCSVNodeTypes.TYPE_NAME:
 				retval = handleName(row, ast);
@@ -472,6 +486,81 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		return id;
 	}
 
+	
+	/* primary expressions (leafs) */
+
+	private long handleInteger(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		IntegerExpression newNode = new IntegerExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setCodeStr(code);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleDouble(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		DoubleExpression newNode = new DoubleExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setCodeStr(code);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleString(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		StringExpression newNode = new StringExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setCodeStr(code);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
 	
 	/* special nodes */
 	

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -53,6 +53,7 @@ import ast.php.expressions.PHPIssetExpression;
 import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
+import ast.php.expressions.PHPShellExecExpression;
 import ast.php.expressions.PHPSilenceExpression;
 import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
@@ -166,6 +167,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 				break;
 			case PHPCSVNodeTypes.TYPE_SILENCE:
 				retval = handleSilence(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_SHELL_EXEC:
+				retval = handleShellExec(row, ast);
 				break;
 			case PHPCSVNodeTypes.TYPE_CLONE:
 				retval = handleClone(row, ast);
@@ -831,6 +835,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleSilence(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPSilenceExpression newNode = new PHPSilenceExpression();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleShellExec(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPShellExecExpression newNode = new PHPShellExecExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -57,6 +57,7 @@ import ast.php.expressions.PHPPrintExpression;
 import ast.php.expressions.PHPReferenceExpression;
 import ast.php.expressions.PHPShellExecExpression;
 import ast.php.expressions.PHPSilenceExpression;
+import ast.php.expressions.PHPTypeHint;
 import ast.php.expressions.PHPUnpackExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.expressions.PHPYieldFromExpression;
@@ -145,6 +146,9 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 			// expressions
 			case PHPCSVNodeTypes.TYPE_MAGIC_CONST:
 				retval = handleMagicConst(row, ast);
+				break;
+			case PHPCSVNodeTypes.TYPE_TYPE:
+				retval = handleTypeHint(row, ast);
 				break;
 
 			// nodes with exactly 1 child
@@ -670,6 +674,28 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	private long handleMagicConst(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
 		PHPMagicConstant newNode = new PHPMagicConstant();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		newNode.setFlags(flags);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	private long handleTypeHint(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		PHPTypeHint newNode = new PHPTypeHint();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -59,6 +59,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_CLONE = "AST_CLONE";
 	public static final String TYPE_EXIT = "AST_EXIT";
 	public static final String TYPE_PRINT = "AST_PRINT";
+	public static final String TYPE_INCLUDE_OR_EVAL = "AST_INCLUDE_OR_EVAL";
 	public static final String TYPE_UNARY_OP = "AST_UNARY_OP";
 	public static final String TYPE_PRE_INC = "AST_PRE_INC";
 	public static final String TYPE_PRE_DEC = "AST_PRE_DEC";
@@ -154,11 +155,11 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_USE = "AST_USE";
 
 	/* node flags */
-	// flags for toplevel nodes
+	// flags for TYPE_TOPLEVEL nodes (exclusive)
 	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial
 	public static final String FLAG_TOPLEVEL_CLASS = "TOPLEVEL_CLASS"; // artificial
 	
-	// flags for cast operations
+	// flags for TYPE_CAST nodes (exclusive)
 	public static final String FLAG_TYPE_NULL = "TYPE_NULL";
 	public static final String FLAG_TYPE_BOOL = "TYPE_BOOL";
 	public static final String FLAG_TYPE_LONG = "TYPE_LONG";
@@ -166,4 +167,11 @@ public class PHPCSVNodeTypes
 	public static final String FLAG_TYPE_STRING = "TYPE_STRING";
 	public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY";
 	public static final String FLAG_TYPE_OBJECT = "TYPE_OBJECT";
+	
+	// flags for TYPE_INCLUDE_OR_EVAL nodes (exclusive)
+	public static final String FLAG_EXEC_EVAL = "EXEC_EVAL";
+	public static final String FLAG_EXEC_INCLUDE = "EXEC_INCLUDE";
+	public static final String FLAG_EXEC_INCLUDE_ONCE = "EXEC_INCLUDE_ONCE";
+	public static final String FLAG_EXEC_REQUIRE = "EXEC_REQUIRE";
+	public static final String FLAG_EXEC_REQUIRE_ONCE = "EXEC_REQUIRE_ONCE";
 }

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -47,7 +47,8 @@ public class PHPCSVNodeTypes
 	// nodes without children (leafs)
 	// expressions
 	public static final String TYPE_MAGIC_CONST = "AST_MAGIC_CONST";
-	
+	public static final String TYPE_TYPE = "AST_TYPE";
+
 	// nodes with exactly 1 child
 	// expressions
 	public static final String TYPE_VAR = "AST_VAR";
@@ -163,13 +164,17 @@ public class PHPCSVNodeTypes
 	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial
 	public static final String FLAG_TOPLEVEL_CLASS = "TOPLEVEL_CLASS"; // artificial
 	
+	// flags for TYPE_TYPE nodes (exclusive)
+	public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY";
+	public static final String FLAG_TYPE_CALLABLE = "TYPE_CALLABLE";
+
 	// flags for TYPE_CAST nodes (exclusive)
 	public static final String FLAG_TYPE_NULL = "TYPE_NULL";
 	public static final String FLAG_TYPE_BOOL = "TYPE_BOOL";
 	public static final String FLAG_TYPE_LONG = "TYPE_LONG";
 	public static final String FLAG_TYPE_DOUBLE = "TYPE_DOUBLE";
 	public static final String FLAG_TYPE_STRING = "TYPE_STRING";
-	public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY";
+	//public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY"; // *also* used (and thus already defined) by TYPE_TYPE
 	public static final String FLAG_TYPE_OBJECT = "TYPE_OBJECT";
 	
 	// flags for TYPE_MAGIC_CONST nodes (exclusive)

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -44,6 +44,10 @@ public class PHPCSVNodeTypes
 
 	public static final String TYPE_CLASS = "AST_CLASS";
 
+	// nodes without children (leafs)
+	// expressions
+	public static final String TYPE_MAGIC_CONST = "AST_MAGIC_CONST";
+	
 	// nodes with exactly 1 child
 	// expressions
 	public static final String TYPE_VAR = "AST_VAR";
@@ -168,6 +172,16 @@ public class PHPCSVNodeTypes
 	public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY";
 	public static final String FLAG_TYPE_OBJECT = "TYPE_OBJECT";
 	
+	// flags for TYPE_MAGIC_CONST nodes (exclusive)
+	public static final String FLAG_MAGIC_LINE = "T_LINE";
+	public static final String FLAG_MAGIC_FILE = "T_FILE";
+	public static final String FLAG_MAGIC_DIR = "T_DIR";
+	public static final String FLAG_MAGIC_NAMESPACE = "T_NS_C";
+	public static final String FLAG_MAGIC_FUNCTION = "T_FUNC_C";
+	public static final String FLAG_MAGIC_METHOD = "T_METHOD_C";
+	public static final String FLAG_MAGIC_CLASS = "T_CLASS_C";
+	public static final String FLAG_MAGIC_TRAIT = "T_TRAIT_C";
+
 	// flags for TYPE_INCLUDE_OR_EVAL nodes (exclusive)
 	public static final String FLAG_EXEC_EVAL = "EXEC_EVAL";
 	public static final String FLAG_EXEC_INCLUDE = "EXEC_INCLUDE";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -29,6 +29,11 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_FILE = "File";
 	public static final String TYPE_DIRECTORY = "Directory";
 
+	// primary expressions (leafs)
+	public static final String TYPE_INTEGER = "integer";
+	public static final String TYPE_DOUBLE = "double";
+	public static final String TYPE_STRING = "string";
+
 	// special nodes
 	public static final String TYPE_NAME = "AST_NAME";
 	public static final String TYPE_CLOSURE_VAR = "AST_CLOSURE_VAR";

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -55,6 +55,7 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_EMPTY = "AST_EMPTY";
 	public static final String TYPE_ISSET = "AST_ISSET";
 	public static final String TYPE_SILENCE = "AST_SILENCE";
+	public static final String TYPE_SHELL_EXEC = "AST_SHELL_EXEC";
 	public static final String TYPE_CLONE = "AST_CLONE";
 	public static final String TYPE_EXIT = "AST_EXIT";
 	public static final String TYPE_PRINT = "AST_PRINT";


### PR DESCRIPTION
Finally, we're there. These are the last remaining nodes. :blush:

**Support for shell command execution expressions and include/require/eval expressions**

* `AST_SHELL_EXEC` -> `ast.php.expressions.PHPShellExecExpression`
* `AST_INCLUDE_OR_EVAL` -> `ast.php.expressions.PHPIncludeOrEvalExpression`

These were the last remaining nodes with a single child. The evil ones. :wink:

`PHPShellExecExpression` is used for the backtick operator in PHP, that is, for code such as, e.g.,
```php
$output = `cat /var/www/html/.htpasswd`;
$output2 = `$attackerinput`;
```

I think that such expressions will potentially constitute high sources (e.g., the value of `$output` in the first line of the above code should better not propagate to low sinks) as well as high sinks (e.g., the attacker should not be able to influence the contents of this node, such as in the second line in the above example.) From a static analysis point of view, though, they should not pose any hard problems (control flow is clear, the variables being defined and used too.)

`PHPIncludeOrEvalExpression` is used for code such as the following:
```php
include 'foo.php';
include_once $userinput;
require getuserinput();
require_once "http://".$userinput."bar.php";
eval("{$evilinput}");
```

In all these cases, some PHP code is being executed by the PHP interpreter directly at the very location where this code occurs. In the first four cases, the contents of a file are being loaded and evaluated (do note that the file location may absolutely be a remote URL, potentially allowing for arbitrary script injection.) In the last case, the string given as argument is evaluated directly. To distinguish the nodes, exactly one of five flags is always set:
* `EXEC_INCLUDE`
* `EXEC_INCLUDE_ONCE`
* `EXEC_REQUIRE`
* `EXEC_REQUIRE_ONCE`
* `EXEC_EVAL`

These nodes are very problematic from a static analysis point of view. Since the expression that they evaluate may absolutely come from user input and be statically unknown, we cannot tell how they might influence control flow (for all we know, there could be some `goto` instruction in the evaluated code), or what variables in the current scope they define and/or use. In principle, we can only (over-)approximate. Not sure how well we will be able to cope with these, yet...

**Support for magic constants**

* `AST_MAGIC_CONST` -> `ast.php.expressions.PHPMagicConstant`

This node is used for magic constants, e.g., for code such as
```php
__LINE__;
__FILE__;
__DIR__;
__NAMESPACE__;
__FUNCTION__;
__METHOD__;
__CLASS__;
__TRAIT__;
```

This is one of two normal AST nodes that never have a child (we'll see the other one in the next section). The concrete constant represented by the node is, again, determined by an appropriate flag.

**Support for type hints**

* `AST_TYPE` -> `ast.php.expressions.PHPTypeHint`

We need this node for so-called "type hints" in PHP. Type hints can occur either for function parameters or for function return values, and `AST_TYPE` nodes are thus always children of either a parameter or a function node. For example, the following PHP code contains two type hints for parameters, and one for a return value:

```php
function foo( array $bar, callable $buz) : callable {}
```

(A `callable` is a reference to a function/method/closure.)

At this point I am a bit confused, because: `AST_TYPE` nodes are generated *only* for the two type hints `array` and `callable` (with an appropriate flag to distinguish them; this is the second kind of AST node that never has children.) Other perfectly valid type hints, such as `int`, `double` or `string`, will generate an `AST_NAME` (=`Identifier`) node instead. Now, having an `AST_NAME` node as a type hint makes perfect sense for "self-defined" types, such as a (potentially namespaced) class name, say, `Foo\Bar`. But why not consistently map types pre-defined by PHP to `AST_TYPE`, e.g., map `int`, `double` or `string` to `AST_TYPE` instead of `AST_NAME`? Or, conversely, simply map `array` and `callable` to `AST_NAME` too, and discard `AST_TYPE` nodes altogether? I do not know. It may be an inconsistent design in PHP ASTs; it may also be due to some intricate technical reason. I will ask @nikic, but the current mapping is, at any rate, faithful.

I made `PHPTypeHint` inherit from `Identifier`, to make it clear that such a node is a kind of "special" type identifier (and to accomodate function and parameter nodes in Joern, which have `Identifier` children for their type specifications, and are thus also able to also take a `PHPTypeHint` as child.)

**Support for primary expressions**

* `integer` -> `ast.expressions.IntegerExpression`
* `double` -> `ast.expressions.DoubleExpression`
* `string` -> `ast.expressions.StringExpression`

These are used to represent primary expressions:
```php
42;
3.14;
"Hello World!";
```

Accordingly, I made the three new node classes `IntegerExpression`, `DoubleExpression` and `StringExpression` extend `ast.expressions.PrimaryExpression`. I do not know whether we will actually need to distinguish between them, but since the information was there already, I thought, *"might as well!"*; and this way we are absolutely consistent with the output of the phpjoern tool.

Of course, these three nodes never have children either, just as `AST_MAGIC_CONST` and `AST_TYPE` don't. The reason I consider them separately is that, when using the php-ast API in PHP userland (as the phpjoern tool does), these primary expressions, which occur as leafs of a PHP AST, are not even instances of AST nodes (i.e., they are not instances of `ast\Node`); they are simply plain values. That is also the reason why they do not have a name starting with `AST_`, as the other nodes.

Thus, there are, all in all, three types of leafs:
1. Normal AST nodes with no children: `AST_MAGIC_CONST` and `AST_TYPE`;
2. Primary expressions: `integer`, `double` and `string`;
3. Normal AST nodes with an arbitrary number of children, which happen to have no children in a given situation. The list is quite long, see `tools.phpast2cfg.PHPCSVNodeTypes`. :wink:

 At any rate, the mapping is finished, finally! Next up, I will cleanup the code a little bit, and test generating and importing some ASTs for real-world code. However, you can start working on CFG edge generation right away, if you like: The constructs are all there. :smile:


