### PR TITLE
Massive code cleanup

### DIFF
--- a/src/ast/NullNode.java
+++ b/src/ast/NullNode.java
@@ -1,0 +1,13 @@
+package ast;
+
+/*
+ * This is a dummy "placeholder" node.
+ * It is mainly used as dummy child for nodes with a fixed number of children
+ * that do not need a certain child in a given context, to keep
+ * the number of their children constant
+ * (e.g., a function node that does not specify its return type in
+ * its declaration; see TestPHPCSVASTBuilderMinimal for more examples.)
+ */
+public class NullNode extends ASTNode
+{
+}

--- a/src/ast/expressions/ArgumentList.java
+++ b/src/ast/expressions/ArgumentList.java
@@ -3,31 +3,30 @@ package ast.expressions;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import ast.ASTNode;
 import ast.statements.ExpressionHolder;
 
-public class ArgumentList extends ExpressionHolder implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
+public class ArgumentList extends ExpressionHolder implements Iterable<Expression>
 {
 	
-	private LinkedList<ASTNode> arguments = new LinkedList<ASTNode>(); // TODO LinkedList<Expression>
+	private LinkedList<Expression> arguments = new LinkedList<Expression>();
 
 	public int size()
 	{
 		return this.arguments.size();
 	}
 	
-	public ASTNode getArgument(int i) { // TODO return type: Expression
+	public Expression getArgument(int i) {
 		return this.arguments.get(i);
 	}
 
-	public void addArgument(ASTNode argument) // TODO take an Expression
+	public void addArgument(Expression argument)
 	{
 		this.arguments.add(argument);
 		super.addChild(argument);
 	}
 	
 	@Override
-	public Iterator<ASTNode> iterator() {
+	public Iterator<Expression> iterator() {
 		return this.arguments.iterator();
 	}
 }

--- a/src/ast/expressions/ArrayIndexing.java
+++ b/src/ast/expressions/ArrayIndexing.java
@@ -1,29 +1,27 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class ArrayIndexing extends Expression
 {
-	private ASTNode array = null; // TODO make this an Expression
-	private ASTNode index = null; // TODO make this an Expression
+	private Expression array = null;
+	private Expression index = null;
 
-	public ASTNode getArrayExpression() // TODO return an Expression
+	public Expression getArrayExpression()
 	{
 		return this.array;
 	}
 
-	public void setArrayExpression(ASTNode array) // TODO take an Expression
+	public void setArrayExpression(Expression array)
 	{
 		this.array = array;
 		super.addChild(array);
 	}
 	
-	public ASTNode getIndexExpression() // TODO return an Expression
+	public Expression getIndexExpression()
 	{
 		return this.index;
 	}
 
-	public void setIndexExpression(ASTNode index) // TODO take an Expression
+	public void setIndexExpression(Expression index)
 	{
 		this.index = index;
 		super.addChild(index);

--- a/src/ast/expressions/AssignmentExpression.java
+++ b/src/ast/expressions/AssignmentExpression.java
@@ -1,26 +1,5 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class AssignmentExpression extends BinaryExpression
 {
-	public ASTNode getVariable() // TODO return an Expression
-	{          
-		return getLeft();
-	}          
-
-	public void setVariable(ASTNode variable) // TODO take an Expression
-	{          
-		setLeft(variable);
-	}          
-
-	public ASTNode getAssignExpression() // TODO return an Expression
-	{
-		return getRight();
-	}
-
-	public void setAssignExpression(ASTNode assignExpression) // TODO take an Expression
-	{
-		setRight(assignExpression);
-	}
 }

--- a/src/ast/expressions/BinaryExpression.java
+++ b/src/ast/expressions/BinaryExpression.java
@@ -4,26 +4,26 @@ import ast.ASTNode;
 
 public class BinaryExpression extends Expression
 {
-	ASTNode leftExpression = null; // TODO make this an Expression again, once PHP mapping is finished
-	ASTNode rightExpression = null; // TODO make this an Expression again, once PHP mapping is finished
+	Expression leftExpression = null;
+	Expression rightExpression = null;
 	
-	public ASTNode getLeft() // TODO return Expression
+	public Expression getLeft()
 	{
 		return this.leftExpression;
 	}
 
-	protected void setLeft(ASTNode leftExpression) // TODO take Expression
+	public void setLeft(Expression leftExpression)
 	{
 		this.leftExpression = leftExpression;
 		super.addChild(leftExpression);
 	}
 	
-	public ASTNode getRight() // TODO return Expression
+	public Expression getRight()
 	{
 		return this.rightExpression;
 	}
 
-	protected void setRight(ASTNode rightExpression) // TODO take Expression
+	public void setRight(Expression rightExpression)
 	{
 		this.rightExpression = rightExpression;
 		super.addChild(rightExpression);
@@ -32,12 +32,10 @@ public class BinaryExpression extends Expression
 	@Override
 	public void addChild(ASTNode item)
 	{
-		// TODO cast this to an Expression again
-		//Expression expression = (Expression) item;
 		if (getLeft() == null)
-			setLeft(item);
+			setLeft((Expression)item);
 		else if (getRight() == null)
-			setRight(item);
+			setRight((Expression)item);
 		else
 			throw new RuntimeException(
 					"Error: attempting to add third child to binary expression");

--- a/src/ast/expressions/BinaryOperationExpression.java
+++ b/src/ast/expressions/BinaryOperationExpression.java
@@ -1,20 +1,5 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class BinaryOperationExpression extends BinaryExpression
 {
-	// for binary operation expressions, change visibility of setLeft() and setRight()
-
-	@Override
-	public void setLeft(ASTNode leftExpression) // TODO take Expression
-	{
-		super.setLeft(leftExpression);
-	}
-
-	@Override
-	public void setRight(ASTNode rightExpression) // TODO take Expression
-	{
-		super.setRight(rightExpression);
-	}
 }

--- a/src/ast/expressions/CallExpression.java
+++ b/src/ast/expressions/CallExpression.java
@@ -4,15 +4,15 @@ import ast.ASTNode;
 
 public class CallExpression extends PostfixExpression
 {
-	private ASTNode targetFunc = null; // TODO change type to Expression once the mapping is finished
+	private Expression targetFunc = null;
 	private ArgumentList argumentList = null;
 	
-	public ASTNode getTargetFunc() // TODO change type to Expression
+	public Expression getTargetFunc()
 	{
 		return this.targetFunc;
 	}
 	
-	public void setTargetFunc(ASTNode targetFunc) // TODO change type to Expression
+	public void setTargetFunc(Expression targetFunc)
 	{
 		this.targetFunc = targetFunc;
 		super.addChild(targetFunc);

--- a/src/ast/expressions/CastExpression.java
+++ b/src/ast/expressions/CastExpression.java
@@ -6,7 +6,7 @@ public class CastExpression extends Expression
 {
 
 	Expression castTarget = null;
-	ASTNode castExpression = null; // TODO make this an expression
+	Expression castExpression = null;
 
 	@Override
 	public void addChild(ASTNode expression)
@@ -28,12 +28,12 @@ public class CastExpression extends Expression
 		super.addChild(castTarget);
 	}
 	
-	public ASTNode getCastExpression()  // TODO return an expression
+	public Expression getCastExpression()
 	{
 		return this.castExpression;
 	}
 
-	public void setCastExpression(ASTNode castExpression) // TODO take an expression
+	public void setCastExpression(Expression castExpression)
 	{
 		this.castExpression = castExpression;
 		super.addChild(castExpression);

--- a/src/ast/expressions/ClassConstantExpression.java
+++ b/src/ast/expressions/ClassConstantExpression.java
@@ -1,29 +1,27 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class ClassConstantExpression extends MemberAccess
 {
-	private ASTNode classExpression = null; // TODO make this an Expression
-	private ASTNode constantName = null;
+	private Expression classExpression = null;
+	private StringExpression constantName = null;
 
-	public ASTNode getClassExpression() // TODO return an Expression
+	public Expression getClassExpression()
 	{
 		return this.classExpression;
 	}
 
-	public void setClassExpression(ASTNode classExpression) // TODO take an Expression
+	public void setClassExpression(Expression classExpression)
 	{
 		this.classExpression = classExpression;
 		super.addChild(classExpression);
 	}
 	
-	public ASTNode getConstantName()
+	public StringExpression getConstantName()
 	{
 		return this.constantName;
 	}
 
-	public void setConstantName(ASTNode constantName)
+	public void setConstantName(StringExpression constantName)
 	{
 		this.constantName = constantName;
 		super.addChild(constantName);

--- a/src/ast/expressions/ConditionalExpression.java
+++ b/src/ast/expressions/ConditionalExpression.java
@@ -1,41 +1,39 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class ConditionalExpression extends Expression
 {
-	protected ASTNode condition = null; // TODO change type to Expression once mapping is finished
-	protected ASTNode trueExpression = null; // TODO change type to Expression once mapping is finished
-	protected ASTNode falseExpression = null; // TODO change type to Expression once mapping is finished
+	protected Expression condition = null;
+	protected Expression trueExpression = null;
+	protected Expression falseExpression = null;
 
-	public ASTNode getCondition()
+	public Expression getCondition()
 	{
 		return this.condition;
 	}
 
-	public void setCondition(ASTNode expression)
+	public void setCondition(Expression expression)
 	{
 		this.condition = expression;
 		super.addChild(expression);
 	}
 	
-	public ASTNode getTrueExpression()
+	public Expression getTrueExpression()
 	{
 		return this.trueExpression;
 	}
 
-	public void setTrueExpression(ASTNode trueExpression)
+	public void setTrueExpression(Expression trueExpression)
 	{
 		this.trueExpression = trueExpression;
 		super.addChild(trueExpression);
 	}
 	
-	public ASTNode getFalseExpression()
+	public Expression getFalseExpression()
 	{
 		return this.falseExpression;
 	}
 
-	public void setFalseExpression(ASTNode falseExpression)
+	public void setFalseExpression(Expression falseExpression)
 	{
 		this.falseExpression = falseExpression;
 		super.addChild(falseExpression);

--- a/src/ast/expressions/ExpressionList.java
+++ b/src/ast/expressions/ExpressionList.java
@@ -3,32 +3,27 @@ package ast.expressions;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import ast.ASTNode;
-
-public class ExpressionList extends ASTNode implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
+public class ExpressionList extends Expression implements Iterable<Expression>
 {
-	private LinkedList<ASTNode> expressions = new LinkedList<ASTNode>();
-	// TODO eventually, of course, this has to be a LinkedList<Expression>
-	// However, until we have completed the PHP AST -> Joern mapping, we must
-	// use ASTNode or we will get ClassCastException's
+	private LinkedList<Expression> expressions = new LinkedList<Expression>();
 
 	public int size()
 	{
 		return this.expressions.size();
 	}
 	
-	public ASTNode getExpression(int i) {
+	public Expression getExpression(int i) {
 		return this.expressions.get(i);
 	}
 
-	public void addExpression(ASTNode expression)
+	public void addExpression(Expression expression)
 	{
 		this.expressions.add(expression);
 		super.addChild(expression);
 	}
 
 	@Override
-	public Iterator<ASTNode> iterator() {
+	public Iterator<Expression> iterator() {
 		return this.expressions.iterator();
 	}
 }

--- a/src/ast/expressions/Identifier.java
+++ b/src/ast/expressions/Identifier.java
@@ -1,11 +1,10 @@
 package ast.expressions;
 
-import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
 public class Identifier extends Expression
 {
-	private ASTNode name = null;
+	private StringExpression name = null;
 	
 	public Identifier()
 	{
@@ -16,12 +15,12 @@ public class Identifier extends Expression
 		super(name);
 	}
 
-	public void setNameChild(ASTNode name) {
+	public void setNameChild(StringExpression name) {
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getNameChild() {
+	public StringExpression getNameChild() {
 		return this.name;
 	}
 

--- a/src/ast/expressions/InstanceofExpression.java
+++ b/src/ast/expressions/InstanceofExpression.java
@@ -1,18 +1,16 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class InstanceofExpression extends Expression
 {
-	ASTNode instanceExpression = null; // TODO make this an Expression once PHP mapping is finished
+	Expression instanceExpression = null;
 	Identifier classIdentifier = null;
 
-	public ASTNode getInstanceExpression() // TODO return Expression
+	public Expression getInstanceExpression()
 	{
 		return this.instanceExpression;
 	}
 
-	public void setInstanceExpression(ASTNode instanceExpression) // TODO take Expression
+	public void setInstanceExpression(Expression instanceExpression)
 	{
 		this.instanceExpression = instanceExpression;
 		super.addChild(instanceExpression);

--- a/src/ast/expressions/NewExpression.java
+++ b/src/ast/expressions/NewExpression.java
@@ -1,17 +1,15 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class NewExpression extends CallExpression
 {
-	private ASTNode targetClass = null; // TODO change type to Expression once the mapping is finished
+	private Expression targetClass = null;
 	
-	public ASTNode getTargetClass() // TODO change type to Expression
+	public Expression getTargetClass()
 	{
 		return this.targetClass;
 	}
 	
-	public void setTargetClass(ASTNode targetClass) // TODO change type to Expression
+	public void setTargetClass(Expression targetClass)
 	{
 		this.targetClass = targetClass;
 		super.addChild(targetClass);

--- a/src/ast/expressions/PropertyExpression.java
+++ b/src/ast/expressions/PropertyExpression.java
@@ -1,29 +1,27 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class PropertyExpression extends MemberAccess
 {
-	private ASTNode objectExpression = null; // TODO make this an Expression
-	private ASTNode propertyName = null;
+	private Expression objectExpression = null;
+	private StringExpression propertyName = null;
 
-	public ASTNode getObjectExpression() // TODO return an Expression
+	public Expression getObjectExpression()
 	{
 		return this.objectExpression;
 	}
 
-	public void setObjectExpression(ASTNode objectExpression) // TODO take an Expression
+	public void setObjectExpression(Expression objectExpression)
 	{
 		this.objectExpression = objectExpression;
 		super.addChild(objectExpression);
 	}
 	
-	public ASTNode getPropertyName()
+	public StringExpression getPropertyName()
 	{
 		return this.propertyName;
 	}
 
-	public void setPropertyName(ASTNode propertyName)
+	public void setPropertyName(StringExpression propertyName)
 	{
 		this.propertyName = propertyName;
 		super.addChild(propertyName);

--- a/src/ast/expressions/StaticPropertyExpression.java
+++ b/src/ast/expressions/StaticPropertyExpression.java
@@ -1,29 +1,27 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class StaticPropertyExpression extends MemberAccess
 {
-	private ASTNode classExpression = null; // TODO make this an Expression
-	private ASTNode propertyName = null;
+	private Expression classExpression = null;
+	private StringExpression propertyName = null;
 
-	public ASTNode getClassExpression() // TODO return an Expression
+	public Expression getClassExpression()
 	{
 		return this.classExpression;
 	}
 
-	public void setClassExpression(ASTNode classExpression) // TODO take an Expression
+	public void setClassExpression(Expression classExpression)
 	{
 		this.classExpression = classExpression;
 		super.addChild(classExpression);
 	}
 	
-	public ASTNode getPropertyName()
+	public StringExpression getPropertyName()
 	{
 		return this.propertyName;
 	}
 
-	public void setPropertyName(ASTNode propertyName)
+	public void setPropertyName(StringExpression propertyName)
 	{
 		this.propertyName = propertyName;
 		super.addChild(propertyName);

--- a/src/ast/expressions/UnaryExpression.java
+++ b/src/ast/expressions/UnaryExpression.java
@@ -1,18 +1,17 @@
 package ast.expressions;
 
-import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
 public class UnaryExpression extends Expression
 {
-	ASTNode expression = null; // TODO make this an Expression once PHP mapping is finished
+	Expression expression = null;
 	
-	public ASTNode getExpression() // TODO return Expression
+	public Expression getExpression()
 	{
 		return this.expression;
 	}
 
-	public void setExpression(ASTNode expression) // TODO take Expression
+	public void setExpression(Expression expression)
 	{
 		this.expression = expression;
 		super.addChild(expression);

--- a/src/ast/expressions/Variable.java
+++ b/src/ast/expressions/Variable.java
@@ -1,17 +1,15 @@
 package ast.expressions;
 
-import ast.ASTNode;
-
 public class Variable extends Expression
 {
-	private ASTNode name = null;
+	private StringExpression name = null;
 	
-	public void setNameChild(ASTNode name) {
+	public void setNameChild(StringExpression name) {
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getNameChild() {
+	public StringExpression getNameChild() {
 		return this.name;
 	}
 }

--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -58,10 +58,9 @@ public class FunctionDef extends ASTNode
 		return this.returnType;
 	}
 	
-	public void setReturnType(ASTNode returnType)
+	public void setReturnType(Identifier returnType)
 	{
-		if( returnType instanceof Identifier)
-			this.returnType = (Identifier)returnType;
+		this.returnType = returnType;
 		super.addChild(returnType);
 	}
 

--- a/src/ast/logical/statements/BlockStarter.java
+++ b/src/ast/logical/statements/BlockStarter.java
@@ -1,18 +1,19 @@
 package ast.logical.statements;
 
 import ast.ASTNode;
+import ast.expressions.Expression;
 
 public class BlockStarter extends Statement
 {
-	protected ASTNode condition = null; // TODO change type back to Expression (or Condition)
+	protected Expression condition = null;
 	protected Statement statement = null;
 
-	public ASTNode getCondition()
+	public Expression getCondition()
 	{
 		return this.condition;
 	}
 
-	public void setCondition(ASTNode expression)
+	public void setCondition(Expression expression)
 	{
 		this.condition = expression;
 		super.addChild(expression);

--- a/src/ast/logical/statements/CompoundStatement.java
+++ b/src/ast/logical/statements/CompoundStatement.java
@@ -7,7 +7,7 @@ import java.util.List;
 import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
-public class CompoundStatement extends Statement implements Iterable<ASTNode>
+public class CompoundStatement extends Statement implements Iterable<ASTNode> // TODO make this an Iterable<Statement>
 {
 	protected static final List<ASTNode> emptyList = new LinkedList<ASTNode>();
 
@@ -17,6 +17,21 @@ public class CompoundStatement extends Statement implements Iterable<ASTNode>
 		return null == children ? emptyList : children;
 	}
 
+	public int size()
+	{
+		return getStatements().size();
+	}
+	
+	public ASTNode getStatement(int i) {
+		return getStatements().get(i);
+	}
+
+	public void addStatement(ASTNode statement)
+	{
+		super.addChild(statement);
+	}
+	
+	
 	public String getEscapedCodeStr()
 	{
 		return "";

--- a/src/ast/logical/statements/Label.java
+++ b/src/ast/logical/statements/Label.java
@@ -1,18 +1,18 @@
 package ast.logical.statements;
 
-import ast.ASTNode;
+import ast.expressions.StringExpression;
 import ast.walking.ASTNodeVisitor;
 
 public class Label extends Statement
 {
-	private ASTNode name = null;
+	private StringExpression name = null;
 
-	public void setNameChild(ASTNode name) {
+	public void setNameChild(StringExpression name) {
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getNameChild() {
+	public StringExpression getNameChild() {
 		return this.name;
 	}
 	

--- a/src/ast/php/declarations/PHPClassDef.java
+++ b/src/ast/php/declarations/PHPClassDef.java
@@ -1,6 +1,5 @@
 package ast.php.declarations;
 
-import ast.ASTNode;
 import ast.ASTNodeProperties;
 import ast.declarations.ClassDefStatement;
 import ast.expressions.Identifier;
@@ -35,10 +34,9 @@ public class PHPClassDef extends ClassDefStatement
 		return this.parent;
 	}
 	
-	public void setExtends(ASTNode parent)
+	public void setExtends(Identifier parent)
 	{
-		if( parent instanceof Identifier)
-			this.parent = (Identifier)parent;
+		this.parent = parent;
 		super.addChild(parent);
 	}
 	
@@ -47,10 +45,9 @@ public class PHPClassDef extends ClassDefStatement
 		return this.interfaces;
 	}
 	
-	public void setImplements(ASTNode interfaces)
+	public void setImplements(IdentifierList interfaces)
 	{
-		if( interfaces instanceof IdentifierList)
-			this.interfaces = (IdentifierList)interfaces;
+		this.interfaces = interfaces;
 		super.addChild(interfaces);
 	}
 	

--- a/src/ast/php/expressions/MethodCallExpression.java
+++ b/src/ast/php/expressions/MethodCallExpression.java
@@ -1,18 +1,18 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
 import ast.expressions.CallExpression;
+import ast.expressions.Expression;
 
 public class MethodCallExpression extends CallExpression
 {
-	private ASTNode targetObject = null; // TODO make this an Expression once mapping is finished
+	private Expression targetObject = null;
 	
-	public ASTNode getTargetObject() // TODO return Expression
+	public Expression getTargetObject()
 	{
 		return this.targetObject;
 	}
 	
-	public void setTargetObject(ASTNode targetObject) // TODO take Expression
+	public void setTargetObject(Expression targetObject)
 	{
 		this.targetObject = targetObject;
 		super.addChild(targetObject);

--- a/src/ast/php/expressions/PHPArrayElement.java
+++ b/src/ast/php/expressions/PHPArrayElement.java
@@ -1,30 +1,29 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
 import ast.expressions.Expression;
 
 public class PHPArrayElement extends Expression
 {
-	private ASTNode value = null; // TODO change type to Expression once mapping is finished
-	private ASTNode key = null; // TODO change type to Expression once mapping is finished
+	private Expression value = null;
+	private Expression key = null;
 
-	public ASTNode getValue()
+	public Expression getValue()
 	{
 		return this.value;
 	}
 
-	public void setValue(ASTNode value)
+	public void setValue(Expression value)
 	{
 		this.value = value;
 		super.addChild(value);
 	}
 	
-	public ASTNode getKey()
+	public Expression getKey()
 	{
 		return this.key;
 	}
 	
-	public void setKey(ASTNode key)
+	public void setKey(Expression key)
 	{
 		this.key = key;
 		super.addChild(key);

--- a/src/ast/php/expressions/PHPCoalesceExpression.java
+++ b/src/ast/php/expressions/PHPCoalesceExpression.java
@@ -1,32 +1,7 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
-import ast.expressions.Expression;
+import ast.expressions.BinaryExpression;
 
-public class PHPCoalesceExpression extends Expression
+public class PHPCoalesceExpression extends BinaryExpression
 {
-	protected ASTNode leftExpression = null;
-	protected ASTNode rightExpression = null;
-
-	public ASTNode getLeftExpression()
-	{
-		return this.leftExpression;
-	}
-
-	public void setLeftExpression(ASTNode leftExpression)
-	{
-		this.leftExpression = leftExpression;
-		super.addChild(leftExpression);
-	}
-
-	public ASTNode getRightExpression()
-	{
-		return this.rightExpression;
-	}
-
-	public void setRightExpression(ASTNode rightExpression)
-	{
-		this.rightExpression = rightExpression;
-		super.addChild(rightExpression);
-	}
 }

--- a/src/ast/php/expressions/PHPEncapsListExpression.java
+++ b/src/ast/php/expressions/PHPEncapsListExpression.java
@@ -3,31 +3,30 @@ package ast.php.expressions;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import ast.ASTNode;
 import ast.expressions.Expression;
 
-public class PHPEncapsListExpression extends Expression implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
+public class PHPEncapsListExpression extends Expression implements Iterable<Expression>
 {
 
-	private LinkedList<ASTNode> elements = new LinkedList<ASTNode>(); // TODO LinkedList<Expression>
+	private LinkedList<Expression> elements = new LinkedList<Expression>();
 
 	public int size()
 	{
 		return this.elements.size();
 	}
 	
-	public ASTNode getElement(int i) { // TODO return type: Expression
+	public Expression getElement(int i) {
 		return this.elements.get(i);
 	}
 
-	public void addElement(ASTNode element) // TODO take an Expression
+	public void addElement(Expression element)
 	{
 		this.elements.add(element);
 		super.addChild(element);
 	}
 	
 	@Override
-	public Iterator<ASTNode> iterator() {
+	public Iterator<Expression> iterator() {
 		return this.elements.iterator();
 	}
 }

--- a/src/ast/php/expressions/PHPIncludeOrEvalExpression.java
+++ b/src/ast/php/expressions/PHPIncludeOrEvalExpression.java
@@ -1,15 +1,15 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.expressions.UnaryExpression;
 
 public class PHPIncludeOrEvalExpression extends UnaryExpression
 {
-	public ASTNode getIncludeOrEvalExpression() { // TODO return an expression
+	public Expression getIncludeOrEvalExpression() {
 		return super.getExpression();
 	}
 	
-	public void setIncludeOrEvalExpression(ASTNode variable) { // TODO take an expression
+	public void setIncludeOrEvalExpression(Expression variable) {
 		super.setExpression(variable);
 	}
 }

--- a/src/ast/php/expressions/PHPIssetExpression.java
+++ b/src/ast/php/expressions/PHPIssetExpression.java
@@ -1,15 +1,15 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.expressions.UnaryExpression;
 
 public class PHPIssetExpression extends UnaryExpression
 {
-	public ASTNode getVariableExpression() { // TODO return an expression
+	public Expression getVariableExpression() {
 		return super.getExpression();
 	}
 	
-	public void setVariableExpression(ASTNode variable) { // TODO take an expression
+	public void setVariableExpression(Expression variable) {
 		super.setExpression(variable);
 	}
 }

--- a/src/ast/php/expressions/PHPListExpression.java
+++ b/src/ast/php/expressions/PHPListExpression.java
@@ -4,30 +4,43 @@ import java.util.Iterator;
 import java.util.LinkedList;
 
 import ast.ASTNode;
+import ast.NullNode;
 import ast.expressions.Expression;
 
-public class PHPListExpression extends Expression implements Iterable<ASTNode> // TODO make this an Iterable<Expression> once the mapping is finished
+public class PHPListExpression extends Expression implements Iterable<Expression>
 {
 
-	private LinkedList<ASTNode> elements = new LinkedList<ASTNode>(); // TODO LinkedList<Expression>
+	private LinkedList<Expression> elements = new LinkedList<Expression>();
 
 	public int size()
 	{
 		return this.elements.size();
 	}
 	
-	public ASTNode getElement(int i) { // TODO return type: Expression
+	public Expression getElement(int i) {
 		return this.elements.get(i);
 	}
 
-	public void addElement(ASTNode element) // TODO take an Expression
+	// we expect either a null node or an Expression
+	public void addElement(ASTNode element)
 	{
-		this.elements.add(element);
+		// This is a very special case; on the one hand PHPListExpression is "null-tolerant",
+		// but on the other ASTNode.addChild(ASTNode) is not. So we add null to elements,
+		// but NullNode to the list of children in ASTNode.
+		
+		if( element instanceof NullNode)
+			this.elements.add(null);
+		else if( element instanceof Expression)
+			this.elements.add((Expression)element);
+		else
+			throw new RuntimeException("Trying to add element to PHP list expression that is neither an Expression"
+					+ "nor a null node!");
+		
 		super.addChild(element);
 	}
 	
 	@Override
-	public Iterator<ASTNode> iterator() {
+	public Iterator<Expression> iterator() {
 		return this.elements.iterator();
 	}
 }

--- a/src/ast/php/expressions/PHPShellExecExpression.java
+++ b/src/ast/php/expressions/PHPShellExecExpression.java
@@ -1,15 +1,15 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.expressions.UnaryExpression;
 
 public class PHPShellExecExpression extends UnaryExpression
 {
-	public ASTNode getShellCommand() { // TODO return an expression
+	public Expression getShellCommand() {
 		return super.getExpression();
 	}
 	
-	public void setShellCommand(ASTNode variable) { // TODO take an expression
+	public void setShellCommand(Expression variable) {
 		super.setExpression(variable);
 	}
 }

--- a/src/ast/php/expressions/PHPYieldExpression.java
+++ b/src/ast/php/expressions/PHPYieldExpression.java
@@ -1,30 +1,29 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
 import ast.expressions.Expression;
 
 public class PHPYieldExpression extends Expression
 {
-	private ASTNode value = null; // TODO change type to Expression once mapping is finished
-	private ASTNode key = null; // TODO change type to Expression once mapping is finished
+	private Expression value = null;
+	private Expression key = null;
 
-	public ASTNode getValue()
+	public Expression getValue()
 	{
 		return this.value;
 	}
 
-	public void setValue(ASTNode value)
+	public void setValue(Expression value)
 	{
 		this.value = value;
 		super.addChild(value);
 	}
 	
-	public ASTNode getKey()
+	public Expression getKey()
 	{
 		return this.key;
 	}
 	
-	public void setKey(ASTNode key)
+	public void setKey(Expression key)
 	{
 		this.key = key;
 		super.addChild(key);

--- a/src/ast/php/expressions/PHPYieldFromExpression.java
+++ b/src/ast/php/expressions/PHPYieldFromExpression.java
@@ -1,18 +1,17 @@
 package ast.php.expressions;
 
-import ast.ASTNode;
 import ast.expressions.Expression;
 
 public class PHPYieldFromExpression extends Expression
 {
-	private ASTNode fromExpression = null; // TODO change type to Expression once mapping is finished
+	private Expression fromExpression = null;
 
-	public ASTNode getFromExpression()
+	public Expression getFromExpression()
 	{
 		return this.fromExpression;
 	}
 
-	public void setFromExpression(ASTNode fromExpression)
+	public void setFromExpression(Expression fromExpression)
 	{
 		this.fromExpression = fromExpression;
 		super.addChild(fromExpression);

--- a/src/ast/php/expressions/StaticCallExpression.java
+++ b/src/ast/php/expressions/StaticCallExpression.java
@@ -2,6 +2,7 @@ package ast.php.expressions;
 
 import ast.expressions.CallExpression;
 import ast.expressions.Identifier;
+import ast.expressions.StringExpression;
 
 public class StaticCallExpression extends CallExpression
 {
@@ -16,5 +17,11 @@ public class StaticCallExpression extends CallExpression
 	{
 		this.targetClass = targetClass;
 		super.addChild(targetClass);
+	}
+	
+	@Override
+	public StringExpression getTargetFunc()
+	{
+		return (StringExpression)super.getTargetFunc();
 	}
 }

--- a/src/ast/php/functionDef/Closure.java
+++ b/src/ast/php/functionDef/Closure.java
@@ -1,6 +1,5 @@
 package ast.php.functionDef;
 
-import ast.ASTNode;
 import ast.functionDef.FunctionDef;
 
 public class Closure extends FunctionDef
@@ -12,10 +11,9 @@ public class Closure extends FunctionDef
 		return this.closureUses;
 	}
 
-	public void setClosureUses(ASTNode closureUses)
+	public void setClosureUses(ClosureUses closureUses)
 	{
-		if( closureUses instanceof ClosureUses)
-			this.closureUses = (ClosureUses)closureUses;
+		this.closureUses = closureUses;
 		super.addChild(closureUses);
 	}
 }

--- a/src/ast/php/functionDef/ClosureVar.java
+++ b/src/ast/php/functionDef/ClosureVar.java
@@ -1,17 +1,18 @@
 package ast.php.functionDef;
 
 import ast.ASTNode;
+import ast.expressions.StringExpression;
 
 public class ClosureVar extends ASTNode
 {
-	private ASTNode name = null;
+	private StringExpression name = null;
 	
-	public void setNameChild(ASTNode name) {
+	public void setNameChild(StringExpression name) {
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getNameChild() {
+	public StringExpression getNameChild() {
 		return this.name;
 	}
 }

--- a/src/ast/php/functionDef/Method.java
+++ b/src/ast/php/functionDef/Method.java
@@ -1,15 +1,7 @@
 package ast.php.functionDef;
 
-import ast.ASTNode;
 import ast.functionDef.FunctionDef;
-import ast.logical.statements.CompoundStatement;
 
 public class Method extends FunctionDef
 {
-	public void setContent(ASTNode content)
-	{
-		if( content instanceof CompoundStatement)
-			this.content = (CompoundStatement)content;
-		super.addChild(content);
-	}
 }

--- a/src/ast/php/functionDef/PHPParameter.java
+++ b/src/ast/php/functionDef/PHPParameter.java
@@ -1,14 +1,16 @@
 package ast.php.functionDef;
 
 import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.expressions.Identifier;
+import ast.expressions.StringExpression;
 import ast.functionDef.Parameter;
 
 public class PHPParameter extends Parameter
 {
 	private Identifier type = null;
-	private ASTNode name = null;
-	private ASTNode defaultvalue = null;
+	private StringExpression name = null;
+	private Expression defaultvalue = null;
 
 	@Override
 	public Identifier getType()
@@ -24,23 +26,23 @@ public class PHPParameter extends Parameter
 		super.addChild(type);
 	}
 	
-	public ASTNode getNameChild()
+	public StringExpression getNameChild()
 	{
 		return this.name;
 	}
 	
-	public void setNameChild(ASTNode name)
+	public void setNameChild(StringExpression name)
 	{
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getDefault()
+	public Expression getDefault()
 	{
 		return this.defaultvalue;
 	}
 	
-	public void setDefault(ASTNode defaultvalue)
+	public void setDefault(Expression defaultvalue)
 	{
 		this.defaultvalue = defaultvalue;
 		super.addChild(defaultvalue);

--- a/src/ast/php/functionDef/TopLevelFunctionDef.java
+++ b/src/ast/php/functionDef/TopLevelFunctionDef.java
@@ -1,6 +1,5 @@
 package ast.php.functionDef;
 
-import ast.ASTNode;
 import ast.expressions.Identifier;
 import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
@@ -25,7 +24,7 @@ public class TopLevelFunctionDef extends FunctionDef
 	}
 	
 	@Override
-	public void setReturnType(ASTNode returnType)
+	public void setReturnType(Identifier returnType)
 	{
 	}
 }

--- a/src/ast/php/statements/ConstantElement.java
+++ b/src/ast/php/statements/ConstantElement.java
@@ -1,30 +1,31 @@
 package ast.php.statements;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
+import ast.expressions.StringExpression;
 import ast.logical.statements.Statement;
 
 public class ConstantElement extends Statement
 {
-	private ASTNode name = null;
-	private ASTNode value = null;
+	private StringExpression name = null;
+	private Expression value = null;
 
-	public ASTNode getNameChild()
+	public StringExpression getNameChild()
 	{
 		return this.name;
 	}
 	
-	public void setNameChild(ASTNode name)
+	public void setNameChild(StringExpression name)
 	{
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getValue()
+	public Expression getValue()
 	{
 		return this.value;
 	}
 	
-	public void setValue(ASTNode value)
+	public void setValue(Expression value)
 	{
 		this.value = value;
 		super.addChild(value);

--- a/src/ast/php/statements/PHPEchoStatement.java
+++ b/src/ast/php/statements/PHPEchoStatement.java
@@ -1,18 +1,18 @@
 package ast.php.statements;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.logical.statements.Statement;
 
 public class PHPEchoStatement extends Statement
 {
-	private ASTNode echoExpression = null; // TODO make into Expression once mapping is finished
+	private Expression echoExpression = null;
 
-	public ASTNode getEchoExpression() // TODO return Expression
+	public Expression getEchoExpression()
 	{
 		return this.echoExpression;
 	}
 
-	public void setEchoExpression(ASTNode echoExpression) // TODO take Expression
+	public void setEchoExpression(Expression echoExpression)
 	{
 		this.echoExpression = echoExpression;
 		super.addChild(echoExpression);

--- a/src/ast/php/statements/PHPGroupUseStatement.java
+++ b/src/ast/php/statements/PHPGroupUseStatement.java
@@ -1,20 +1,20 @@
 package ast.php.statements;
 
-import ast.ASTNode;
+import ast.expressions.StringExpression;
 import ast.logical.statements.Statement;
 import ast.statements.UseStatement;
 
 public class PHPGroupUseStatement extends Statement
 {
-	private ASTNode prefix = null;
+	private StringExpression prefix = null;
 	private UseStatement uses = null;
 	
-	public ASTNode getPrefix()
+	public StringExpression getPrefix()
 	{
 		return this.prefix;
 	}
 
-	public void setPrefix(ASTNode prefix)
+	public void setPrefix(StringExpression prefix)
 	{
 		this.prefix = prefix;
 		super.addChild(prefix);

--- a/src/ast/php/statements/PHPHaltCompilerStatement.java
+++ b/src/ast/php/statements/PHPHaltCompilerStatement.java
@@ -1,18 +1,18 @@
 package ast.php.statements;
 
-import ast.ASTNode;
+import ast.expressions.IntegerExpression;
 import ast.logical.statements.Statement;
 
 public class PHPHaltCompilerStatement extends Statement
 {
-	private ASTNode offset = null; // TODO make into PrimaryExpression (or maybe even more specific: IntegerExpression) once mapping is finished
+	private IntegerExpression offset = null;
 
-	public ASTNode getOffset() // TODO return PrimaryExpression
+	public IntegerExpression getOffset()
 	{
 		return this.offset;
 	}
 
-	public void setOffset(ASTNode offset) // TODO take PrimaryExpression
+	public void setOffset(IntegerExpression offset)
 	{
 		this.offset = offset;
 		super.addChild(offset);

--- a/src/ast/php/statements/PropertyElement.java
+++ b/src/ast/php/statements/PropertyElement.java
@@ -1,30 +1,31 @@
 package ast.php.statements;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
+import ast.expressions.StringExpression;
 import ast.logical.statements.Statement;
 
 public class PropertyElement extends Statement
 {
-	private ASTNode name = null;
-	private ASTNode defaultvalue = null;
+	private StringExpression name = null;
+	private Expression defaultvalue = null;
 
-	public ASTNode getNameChild()
+	public StringExpression getNameChild()
 	{
 		return this.name;
 	}
 	
-	public void setNameChild(ASTNode name)
+	public void setNameChild(StringExpression name)
 	{
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getDefault()
+	public Expression getDefault()
 	{
 		return this.defaultvalue;
 	}
 	
-	public void setDefault(ASTNode defaultvalue)
+	public void setDefault(Expression defaultvalue)
 	{
 		this.defaultvalue = defaultvalue;
 		super.addChild(defaultvalue);

--- a/src/ast/php/statements/StaticVariableDeclaration.java
+++ b/src/ast/php/statements/StaticVariableDeclaration.java
@@ -1,30 +1,31 @@
 package ast.php.statements;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
+import ast.expressions.StringExpression;
 import ast.logical.statements.Statement;
 
 public class StaticVariableDeclaration extends Statement
 {
-	private ASTNode name = null;
-	private ASTNode defaultvalue = null; // TODO make this an Expression
+	private StringExpression name = null;
+	private Expression defaultvalue = null;
 
-	public ASTNode getNameChild()
+	public StringExpression getNameChild()
 	{
 		return this.name;
 	}
 	
-	public void setNameChild(ASTNode name)
+	public void setNameChild(StringExpression name)
 	{
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public ASTNode getDefault() // TODO make this an Expression
+	public Expression getDefault()
 	{
 		return this.defaultvalue;
 	}
 	
-	public void setDefault(ASTNode defaultvalue) // TODO make this an Expression
+	public void setDefault(Expression defaultvalue)
 	{
 		this.defaultvalue = defaultvalue;
 		super.addChild(defaultvalue);

--- a/src/ast/php/statements/blockstarters/ForEachStatement.java
+++ b/src/ast/php/statements/blockstarters/ForEachStatement.java
@@ -1,33 +1,33 @@
 package ast.php.statements.blockstarters;
 
-import ast.ASTNode;
 import ast.expressions.Expression;
 import ast.expressions.Variable;
 import ast.logical.statements.BlockStarter;
 
 public class ForEachStatement extends BlockStarter
 {
-	private ASTNode iteratedObject = null; // TODO make this an Expression sometime
+	private Expression iteratedObject = null;
 	private Variable key = null;
 	private Expression value = null;
 
 	@Override
-	public ASTNode getCondition()
+	public Expression getCondition()
 	{
-		return null;
+		throw new RuntimeException("A condition does not exist for a ForEachStatement!");
 	}
 
 	@Override
-	public void setCondition(ASTNode expression)
+	public void setCondition(Expression expression)
 	{
+		throw new RuntimeException("A condition does not exist for a ForEachStatement!");
 	}
 	
-	public ASTNode getIteratedObject()
+	public Expression getIteratedObject()
 	{
 		return this.iteratedObject;
 	}
 
-	public void setIteratedObject(ASTNode expression)
+	public void setIteratedObject(Expression expression)
 	{
 		this.iteratedObject = expression;
 		super.addChild(expression);

--- a/src/ast/php/statements/blockstarters/MethodReference.java
+++ b/src/ast/php/statements/blockstarters/MethodReference.java
@@ -2,11 +2,12 @@ package ast.php.statements.blockstarters;
 
 import ast.ASTNode;
 import ast.expressions.Identifier;
+import ast.expressions.StringExpression;
 
 public class MethodReference extends ASTNode
 {
 	private Identifier classIdentifier = null;
-	private ASTNode methodName = null;
+	private StringExpression methodName = null;
 	
 	public Identifier getClassIdentifier()
 	{
@@ -19,12 +20,12 @@ public class MethodReference extends ASTNode
 		super.addChild(classIdentifier);
 	}
 	
-	public ASTNode getMethodName()
+	public StringExpression getMethodName()
 	{
 		return this.methodName;
 	}
 
-	public void setMethodName(ASTNode methodName)
+	public void setMethodName(StringExpression methodName)
 	{
 		this.methodName = methodName;
 		super.addChild(methodName);

--- a/src/ast/php/statements/blockstarters/PHPSwitchCase.java
+++ b/src/ast/php/statements/blockstarters/PHPSwitchCase.java
@@ -1,18 +1,18 @@
 package ast.php.statements.blockstarters;
 
-import ast.ASTNode;
+import ast.expressions.PrimaryExpression;
 import ast.logical.statements.BlockStarter;
 
 public class PHPSwitchCase extends BlockStarter
 {
-	private ASTNode value = null;
+	private PrimaryExpression value = null;
 	
-	public ASTNode getValue()
+	public PrimaryExpression getValue()
 	{
 		return this.value;
 	}
 
-	public void setValue(ASTNode value)
+	public void setValue(PrimaryExpression value)
 	{
 		this.value = value;
 		super.addChild(value);

--- a/src/ast/php/statements/blockstarters/PHPSwitchStatement.java
+++ b/src/ast/php/statements/blockstarters/PHPSwitchStatement.java
@@ -1,19 +1,19 @@
 package ast.php.statements.blockstarters;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.statements.blockstarters.SwitchStatement;
 
 public class PHPSwitchStatement extends SwitchStatement
 {
-	private ASTNode expression = null; // TODO change type to Expression
+	private Expression expression = null;
 	protected PHPSwitchList switchList = null;
 
-	public ASTNode getExpression()
+	public Expression getExpression()
 	{
 		return this.expression;
 	}
 
-	public void setExpression(ASTNode expression)
+	public void setExpression(Expression expression)
 	{
 		this.expression = expression;
 		super.addChild(expression);

--- a/src/ast/php/statements/blockstarters/PHPTraitAlias.java
+++ b/src/ast/php/statements/blockstarters/PHPTraitAlias.java
@@ -1,17 +1,17 @@
 package ast.php.statements.blockstarters;
 
-import ast.ASTNode;
+import ast.expressions.StringExpression;
 
 public class PHPTraitAlias extends PHPTraitAdaptationElement
 {
-	private ASTNode alias = null;
+	private StringExpression alias = null;
 	
-	public ASTNode getAlias()
+	public StringExpression getAlias()
 	{
 		return this.alias;
 	}
 
-	public void setAlias(ASTNode alias)
+	public void setAlias(StringExpression alias)
 	{
 		this.alias = alias;
 		super.addChild(alias);

--- a/src/ast/php/statements/jump/PHPBreakStatement.java
+++ b/src/ast/php/statements/jump/PHPBreakStatement.java
@@ -1,18 +1,18 @@
 package ast.php.statements.jump;
 
-import ast.ASTNode;
+import ast.expressions.IntegerExpression;
 import ast.statements.jump.BreakStatement;
 
 public class PHPBreakStatement extends BreakStatement
 {
-	private ASTNode depth = null;
+	private IntegerExpression depth = null;
 	
-	public void setDepth(ASTNode depth) {
+	public void setDepth(IntegerExpression depth) {
 		this.depth = depth;
 		super.addChild(depth);
 	}
 	
-	public ASTNode getDepth() {
+	public IntegerExpression getDepth() {
 		return this.depth;
 	}
 }

--- a/src/ast/php/statements/jump/PHPContinueStatement.java
+++ b/src/ast/php/statements/jump/PHPContinueStatement.java
@@ -1,18 +1,18 @@
 package ast.php.statements.jump;
 
-import ast.ASTNode;
+import ast.expressions.IntegerExpression;
 import ast.statements.jump.ContinueStatement;
 
 public class PHPContinueStatement extends ContinueStatement
 {
-	private ASTNode depth = null;
+	private IntegerExpression depth = null;
 	
-	public void setDepth(ASTNode depth) {
+	public void setDepth(IntegerExpression depth) {
 		this.depth = depth;
 		super.addChild(depth);
 	}
 	
-	public ASTNode getDepth() {
+	public IntegerExpression getDepth() {
 		return this.depth;
 	}
 }

--- a/src/ast/statements/UseElement.java
+++ b/src/ast/statements/UseElement.java
@@ -1,30 +1,30 @@
 package ast.statements;
 
-import ast.ASTNode;
+import ast.expressions.StringExpression;
 import ast.logical.statements.Statement;
 
 public class UseElement extends Statement
 {
-	private ASTNode namespace = null;
-	private ASTNode alias = null;
+	private StringExpression namespace = null;
+	private StringExpression alias = null;
 	
-	public ASTNode getNamespace()
+	public StringExpression getNamespace()
 	{
 		return this.namespace;
 	}
 
-	public void setNamespace(ASTNode namespace)
+	public void setNamespace(StringExpression namespace)
 	{
 		this.namespace = namespace;
 		super.addChild(namespace);
 	}
 	
-	public ASTNode getAlias()
+	public StringExpression getAlias()
 	{
 		return this.alias;
 	}
 
-	public void setAlias(ASTNode alias)
+	public void setAlias(StringExpression alias)
 	{
 		this.alias = alias;
 		super.addChild(alias);

--- a/src/ast/statements/blockstarters/CatchStatement.java
+++ b/src/ast/statements/blockstarters/CatchStatement.java
@@ -1,7 +1,7 @@
 package ast.statements.blockstarters;
 
-import ast.ASTNode;
 import ast.expressions.Identifier;
+import ast.expressions.StringExpression;
 import ast.logical.statements.BlockStarter;
 import ast.logical.statements.CompoundStatement;
 import ast.walking.ASTNodeVisitor;
@@ -9,7 +9,7 @@ import ast.walking.ASTNodeVisitor;
 public class CatchStatement extends BlockStarter
 {
 	private Identifier exceptionIdentifier = null;
-	private ASTNode variableName = null;
+	private StringExpression variableName = null;
 	private CompoundStatement content = null;
 
 	public Identifier getExceptionIdentifier()
@@ -23,12 +23,12 @@ public class CatchStatement extends BlockStarter
 		super.addChild(exceptionIdentifier);
 	}
 	
-	public ASTNode getVariableName()
+	public StringExpression getVariableName()
 	{
 		return this.variableName;
 	}
 	
-	public void setVariableName(ASTNode variableName)
+	public void setVariableName(StringExpression variableName)
 	{
 		this.variableName = variableName;
 		super.addChild(variableName);

--- a/src/ast/statements/blockstarters/ForStatement.java
+++ b/src/ast/statements/blockstarters/ForStatement.java
@@ -10,26 +10,26 @@ import ast.walking.ASTNodeVisitor;
 
 public class ForStatement extends BlockStarter
 {
-	private ASTNode forInitExpression = null; // TODO make this an ExpressionList sometime (might need to create a PHPForStatement)
-	private ASTNode forLoopExpression = null; // TODO make this an ExpressionList sometime (might need to create a PHPForStatement)
+	private Expression forInitExpression = null; // TODO make this an ExpressionList sometime (might need to create a PHPForStatement)
+	private Expression forLoopExpression = null; // TODO make this an ExpressionList sometime (might need to create a PHPForStatement)
 
-	public ASTNode getForInitExpression()
+	public Expression getForInitExpression()
 	{
 		return forInitExpression;
 	}
 
-	public void setForInitExpression(ASTNode expression)
+	public void setForInitExpression(Expression expression)
 	{
 		this.forInitExpression = expression;
 		super.addChild(expression);
 	}
 
-	public ASTNode getForLoopExpression()
+	public Expression getForLoopExpression()
 	{
 		return forLoopExpression;
 	}
 
-	public void setForLoopExpression(ASTNode expression)
+	public void setForLoopExpression(Expression expression)
 	{
 		this.forLoopExpression = expression;
 		super.addChild(expression);
@@ -41,9 +41,9 @@ public class ForStatement extends BlockStarter
 		if (node instanceof Condition)
 			setCondition((Condition) node);
 		else if (node instanceof ForInit)
-			setForInitExpression(node);
+			setForInitExpression((Expression)node);
 		else if (node instanceof Expression)
-			setForLoopExpression(node);
+			setForLoopExpression((Expression)node);
 		else if (node instanceof Statement)
 			setStatement((Statement) node);
 		else

--- a/src/ast/statements/blockstarters/NamespaceStatement.java
+++ b/src/ast/statements/blockstarters/NamespaceStatement.java
@@ -1,20 +1,20 @@
 package ast.statements.blockstarters;
 
-import ast.ASTNode;
+import ast.expressions.StringExpression;
 import ast.logical.statements.BlockStarter;
 import ast.logical.statements.CompoundStatement;
 
 public class NamespaceStatement extends BlockStarter
 {
-	private ASTNode name = null;
+	private StringExpression name = null;
 	private CompoundStatement content = null;
 
-	public ASTNode getName()
+	public StringExpression getName()
 	{
 		return this.name;
 	}
 	
-	public void setName(ASTNode name)
+	public void setName(StringExpression name)
 	{
 		this.name = name;
 		super.addChild(name);

--- a/src/ast/statements/jump/GotoStatement.java
+++ b/src/ast/statements/jump/GotoStatement.java
@@ -1,19 +1,19 @@
 package ast.statements.jump;
 
-import ast.ASTNode;
+import ast.expressions.StringExpression;
 import ast.logical.statements.JumpStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class GotoStatement extends JumpStatement
 {
-	private ASTNode label = null;
+	private StringExpression label = null;
 
-	public void setTargetLabel(ASTNode label) {
+	public void setTargetLabel(StringExpression label) {
 		this.label = label;
 		super.addChild(label);
 	}
 	
-	public ASTNode getTargetLabel() {
+	public StringExpression getTargetLabel() {
 		return this.label;
 	}
 	

--- a/src/ast/statements/jump/ReturnStatement.java
+++ b/src/ast/statements/jump/ReturnStatement.java
@@ -1,19 +1,19 @@
 package ast.statements.jump;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.logical.statements.JumpStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class ReturnStatement extends JumpStatement
 {
-	private ASTNode returnExpression = null;
+	private Expression returnExpression = null;
 	
-	public ASTNode getReturnExpression()
+	public Expression getReturnExpression()
 	{
 		return this.returnExpression;
 	}
 
-	public void setReturnExpression(ASTNode expression)
+	public void setReturnExpression(Expression expression)
 	{
 		this.returnExpression = expression;
 		super.addChild(expression);

--- a/src/ast/statements/jump/ThrowStatement.java
+++ b/src/ast/statements/jump/ThrowStatement.java
@@ -1,19 +1,19 @@
 package ast.statements.jump;
 
-import ast.ASTNode;
+import ast.expressions.Expression;
 import ast.logical.statements.JumpStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class ThrowStatement extends JumpStatement
 {
-	private ASTNode throwExpression = null;
+	private Expression throwExpression = null;
 	
-	public ASTNode getThrowExpression()
+	public Expression getThrowExpression()
 	{
 		return this.throwExpression;
 	}
 
-	public void setThrowExpression(ASTNode expression)
+	public void setThrowExpression(Expression expression)
 	{
 		this.throwExpression = expression;
 		super.addChild(expression);

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -25,6 +25,7 @@ import ast.expressions.ClassConstantExpression;
 import ast.expressions.ConditionalExpression;
 import ast.expressions.Constant;
 import ast.expressions.DoubleExpression;
+import ast.expressions.Expression;
 import ast.expressions.ExpressionList;
 import ast.expressions.GreaterExpression;
 import ast.expressions.GreaterOrEqualExpression;
@@ -1358,7 +1359,8 @@ public class TestPHPCSVASTBuilder
 	 * 
 	 * Any AST_EXIT node has exactly exactly one child, representing the expression whose
 	 * evaluation yields either a string to be printed before exiting or an integer which
-	 * will be used as an exit status.
+	 * will be used as an exit status. The child may also be a NULL node, if no exit status
+	 * is passed as argument.
 	 * See http://php.net/manual/en/function.exit.php
 	 * 
 	 * This test checks a few 'exit' expressions' children in the following PHP code:
@@ -2233,7 +2235,8 @@ public class TestPHPCSVASTBuilder
 	 * AST_BREAK nodes are nodes representing a break statement.
 	 * 
 	 * Any AST_BREAK node has exactly one child which is of type "integer", holding
-	 * the number of enclosing structures to be broken out of.
+	 * the number of enclosing structures to be broken out of. It may also be a null
+	 * child, in which case no depth was specified, which is equivalent to depth 1.
 	 * 
 	 * This test checks a few break statements' children in the following PHP code:
 	 * 
@@ -2290,7 +2293,8 @@ public class TestPHPCSVASTBuilder
 	 * AST_CONTINUE nodes are nodes representing a continue statement.
 	 * 
 	 * Any AST_CONTINUE node has exactly one child which is of type "integer", holding
-	 * the number of enclosing loops to be skipped to the end of.
+	 * the number of enclosing loops to be skipped to the end of. It may also be a null
+	 * child, in which case no depth was specified, which is equivalent to depth 1.
 	 * 
 	 * This test checks a few continue statements' children in the following PHP code:
 	 * 
@@ -2434,12 +2438,7 @@ public class TestPHPCSVASTBuilder
 		assertThat( node4, instanceOf(ArrayIndexing.class));
 		assertEquals( 2, node4.getChildCount());
 		assertEquals( ast.getNodeById((long)21), ((ArrayIndexing)node4).getArrayExpression());
-		// TODO ((ArrayIndexing)node4).getIndexExpression() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPArrayElement accepts arbitrary ASTNode's for indices,
-		// when we actually only want to accept Expression's. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((ArrayIndexing)node4).getIndexExpression().getProperty("type"));
+		assertNull( ((ArrayIndexing)node4).getIndexExpression());
 	}
 	
 	/**
@@ -2793,28 +2792,28 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node, instanceOf(AssignmentExpression.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( ast.getNodeById((long)4), ((AssignmentExpression)node).getVariable());
-		assertEquals( ast.getNodeById((long)6), ((AssignmentExpression)node).getAssignExpression());
+		assertEquals( ast.getNodeById((long)4), ((AssignmentExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((AssignmentExpression)node).getRight());
 
 		assertThat( node2, instanceOf(AssignmentExpression.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)8), ((AssignmentExpression)node2).getVariable());
-		assertEquals( ast.getNodeById((long)12), ((AssignmentExpression)node2).getAssignExpression());
+		assertEquals( ast.getNodeById((long)8), ((AssignmentExpression)node2).getLeft());
+		assertEquals( ast.getNodeById((long)12), ((AssignmentExpression)node2).getRight());
 		
 		assertThat( node3, instanceOf(AssignmentExpression.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)14), ((AssignmentExpression)node3).getVariable());
-		assertEquals( ast.getNodeById((long)18), ((AssignmentExpression)node3).getAssignExpression());
+		assertEquals( ast.getNodeById((long)14), ((AssignmentExpression)node3).getLeft());
+		assertEquals( ast.getNodeById((long)18), ((AssignmentExpression)node3).getRight());
 		
 		assertThat( node4, instanceOf(AssignmentExpression.class));
 		assertEquals( 2, node4.getChildCount());
-		assertEquals( ast.getNodeById((long)22), ((AssignmentExpression)node4).getVariable());
-		assertEquals( ast.getNodeById((long)26), ((AssignmentExpression)node4).getAssignExpression());
+		assertEquals( ast.getNodeById((long)22), ((AssignmentExpression)node4).getLeft());
+		assertEquals( ast.getNodeById((long)26), ((AssignmentExpression)node4).getRight());
 		
 		assertThat( node5, instanceOf(AssignmentExpression.class));
 		assertEquals( 2, node5.getChildCount());
-		assertEquals( ast.getNodeById((long)31), ((AssignmentExpression)node5).getVariable());
-		assertEquals( ast.getNodeById((long)34), ((AssignmentExpression)node5).getAssignExpression());
+		assertEquals( ast.getNodeById((long)31), ((AssignmentExpression)node5).getLeft());
+		assertEquals( ast.getNodeById((long)34), ((AssignmentExpression)node5).getRight());
 	}
 	
 	/**
@@ -2915,23 +2914,23 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node, instanceOf(PHPAssignmentByRefExpression.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( ast.getNodeById((long)4), ((PHPAssignmentByRefExpression)node).getVariable());
-		assertEquals( ast.getNodeById((long)6), ((PHPAssignmentByRefExpression)node).getAssignExpression());
+		assertEquals( ast.getNodeById((long)4), ((PHPAssignmentByRefExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((PHPAssignmentByRefExpression)node).getRight());
 
 		assertThat( node2, instanceOf(PHPAssignmentByRefExpression.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)9), ((PHPAssignmentByRefExpression)node2).getVariable());
-		assertEquals( ast.getNodeById((long)13), ((PHPAssignmentByRefExpression)node2).getAssignExpression());
+		assertEquals( ast.getNodeById((long)9), ((PHPAssignmentByRefExpression)node2).getLeft());
+		assertEquals( ast.getNodeById((long)13), ((PHPAssignmentByRefExpression)node2).getRight());
 		
 		assertThat( node3, instanceOf(PHPAssignmentByRefExpression.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)18), ((PHPAssignmentByRefExpression)node3).getVariable());
-		assertEquals( ast.getNodeById((long)22), ((PHPAssignmentByRefExpression)node3).getAssignExpression());
+		assertEquals( ast.getNodeById((long)18), ((PHPAssignmentByRefExpression)node3).getLeft());
+		assertEquals( ast.getNodeById((long)22), ((PHPAssignmentByRefExpression)node3).getRight());
 		
 		assertThat( node4, instanceOf(PHPAssignmentByRefExpression.class));
 		assertEquals( 2, node4.getChildCount());
-		assertEquals( ast.getNodeById((long)28), ((PHPAssignmentByRefExpression)node4).getVariable());
-		assertEquals( ast.getNodeById((long)32), ((PHPAssignmentByRefExpression)node4).getAssignExpression());
+		assertEquals( ast.getNodeById((long)28), ((PHPAssignmentByRefExpression)node4).getLeft());
+		assertEquals( ast.getNodeById((long)32), ((PHPAssignmentByRefExpression)node4).getRight());
 	}
 	
 	/**
@@ -2988,18 +2987,18 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node, instanceOf(AssignmentWithOpExpression.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( ast.getNodeById((long)4), ((AssignmentWithOpExpression)node).getVariable());
-		assertEquals( ast.getNodeById((long)6), ((AssignmentWithOpExpression)node).getAssignExpression());
+		assertEquals( ast.getNodeById((long)4), ((AssignmentWithOpExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)6), ((AssignmentWithOpExpression)node).getRight());
 
 		assertThat( node2, instanceOf(AssignmentWithOpExpression.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)8), ((AssignmentWithOpExpression)node2).getVariable());
-		assertEquals( ast.getNodeById((long)10), ((AssignmentWithOpExpression)node2).getAssignExpression());
+		assertEquals( ast.getNodeById((long)8), ((AssignmentWithOpExpression)node2).getLeft());
+		assertEquals( ast.getNodeById((long)10), ((AssignmentWithOpExpression)node2).getRight());
 		
 		assertThat( node3, instanceOf(AssignmentWithOpExpression.class));
 		assertEquals( 2, node2.getChildCount());
-		assertEquals( ast.getNodeById((long)12), ((AssignmentWithOpExpression)node3).getVariable());
-		assertEquals( ast.getNodeById((long)14), ((AssignmentWithOpExpression)node3).getAssignExpression());
+		assertEquals( ast.getNodeById((long)12), ((AssignmentWithOpExpression)node3).getLeft());
+		assertEquals( ast.getNodeById((long)14), ((AssignmentWithOpExpression)node3).getRight());
 	}
 	
 	/**
@@ -3619,12 +3618,7 @@ public class TestPHPCSVASTBuilder
 		assertThat( node4, instanceOf(PHPArrayElement.class));
 		assertEquals( 2, node4.getChildCount());
 		assertEquals( ast.getNodeById((long)17), ((PHPArrayElement)node4).getValue());
-		// TODO ((PHPArrayElement)node4).getKey() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPArrayElement accepts arbitrary ASTNode's for keys,
-		// when we actually only want to accept Expression's. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPArrayElement)node4).getKey().getProperty("type"));
+		assertNull( ((PHPArrayElement)node4).getKey());
 	}
 	
 	/**
@@ -3811,12 +3805,7 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)8), ((PHPYieldExpression)node).getValue());
 		assertEquals( "42", ((PHPYieldExpression)node).getValue().getEscapedCodeStr());
-		// TODO ((PHPYieldExpression)node).getKey() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPYieldExpression accepts arbitrary ASTNode's for keys,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPYieldExpression)node).getKey().getProperty("type"));
+		assertNull( ((PHPYieldExpression)node).getKey());
 		
 		assertThat( node2, instanceOf(PHPYieldExpression.class));
 		assertEquals( 2, node2.getChildCount());
@@ -3858,8 +3847,8 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node, instanceOf(PHPCoalesceExpression.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( ast.getNodeById((long)4), ((PHPCoalesceExpression)node).getLeftExpression());
-		assertEquals( ast.getNodeById((long)5), ((PHPCoalesceExpression)node).getRightExpression());
+		assertEquals( ast.getNodeById((long)4), ((PHPCoalesceExpression)node).getLeft());
+		assertEquals( ast.getNodeById((long)5), ((PHPCoalesceExpression)node).getRight());
 	}
 	
 	/**
@@ -3929,13 +3918,7 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)9), ((StaticVariableDeclaration)node).getNameChild());
 		assertEquals( "bar", ((StaticVariableDeclaration)node).getNameChild().getEscapedCodeStr());
-		assertEquals( ast.getNodeById((long)10), ((StaticVariableDeclaration)node).getDefault());
-		// TODO ((StaticVariableDeclaration)node).getDefault() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because StaticVariableDeclaration accepts arbitrary ASTNode's for default values,
-		// when we actually only want to accept strings. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((StaticVariableDeclaration)node).getDefault().getProperty("type"));
+		assertNull( ((StaticVariableDeclaration)node).getDefault());
 
 		assertThat( node2, instanceOf(StaticVariableDeclaration.class));
 		assertEquals( 2, node2.getChildCount());
@@ -4214,12 +4197,7 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node4, instanceOf(PHPIfElement.class));
 		assertEquals( 2, node4.getChildCount());
-		// TODO ((PHPIfElement)node4).getCondition() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPIfElement accepts arbitrary ASTNode's for conditions,
-		// when we actually only want to accept Expression's. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPIfElement)node4).getCondition().getProperty("type"));
+		assertNull( ((PHPIfElement)node4).getCondition());
 		assertEquals( ast.getNodeById((long)18), ((PHPIfElement)node4).getStatement());
 	}
 	
@@ -4417,13 +4395,7 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node4, instanceOf(PHPSwitchCase.class));
 		assertEquals( 2, node4.getChildCount());
-		assertEquals( ast.getNodeById((long)21), ((PHPSwitchCase)node4).getValue());
-		// TODO ((PHPSwitchCase)node4).getValue() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPSwitchCase accepts arbitrary ASTNode's for values,
-		// when we actually only want to accept ints/strings/doubles. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPSwitchCase)node4).getValue().getProperty("type"));
+		assertNull( ((PHPSwitchCase)node4).getValue());
 		assertEquals( ast.getNodeById((long)22), ((PHPSwitchCase)node4).getStatement());
 	}
 	
@@ -4560,13 +4532,7 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)10), ((PropertyElement)node).getNameChild());
 		assertEquals( "foo", ((PropertyElement)node).getNameChild().getEscapedCodeStr());
-		assertEquals( ast.getNodeById((long)11), ((PropertyElement)node).getDefault());
-		// TODO ((PropertyElement)node).getDefault() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PropertyElement accepts arbitrary ASTNode's for default values,
-		// when we actually only want to accept strings. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PropertyElement)node).getDefault().getProperty("type"));
+		assertNull( ((PropertyElement)node).getDefault());
 
 		assertThat( node2, instanceOf(PropertyElement.class));
 		assertEquals( 2, node2.getChildCount());
@@ -4872,7 +4838,8 @@ public class TestPHPCSVASTBuilder
 	 * (TODO check if they can appear in other contexts)
 	 * 
 	 * Any AST_METHOD_REFERENCE node has exactly two children:
-	 * 1) AST_NAME, representing the class that the referenced method is declared in
+	 * 1) AST_NAME or NULL, representing the class that the referenced method is declared in
+	 *    (or null if no class name is given)
 	 * 2) string, indicating the method's name
 	 *    
 	 * This test checks a few method references' children in the following PHP code:
@@ -5048,12 +5015,7 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node3, instanceOf(NamespaceStatement.class));
 		assertEquals( 2, node3.getChildCount());
-		// TODO ((NamespaceStatement)node3).getName() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because NamespaceStatement accepts arbitrary ASTNode's for names,
-		// when we actually only want to accept strings. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((NamespaceStatement)node3).getName().getProperty("type"));
+		assertNull( ((NamespaceStatement)node3).getName());
 		assertEquals( ast.getNodeById((long)11), ((NamespaceStatement)node3).getContent());
 	}
 	
@@ -5220,12 +5182,7 @@ public class TestPHPCSVASTBuilder
 		assertThat( node2, instanceOf(PHPTraitAlias.class));
 		assertEquals( 2, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)23), ((PHPTraitAlias)node2).getMethod());
-		// TODO ((PHPTraitAlias)node).getAlias() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPTraitAlias accepts arbitrary ASTNode's for aliases,
-		// when we actually only want to accept strings. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPTraitAlias)node2).getAlias().getProperty("type"));
+		assertNull( ((PHPTraitAlias)node2).getAlias());
 	}
 	
 	/**
@@ -5673,7 +5630,7 @@ public class TestPHPCSVASTBuilder
 	 *    in the loop's guard, used to check whether to continue iterating
 	 * 3) AST_EXPR_LIST or NULL, representing the list of expressions
 	 *    used to increment or otherwise modify variables in each step
-	 * 4) statement types or NULL, representing the code in the loop's body
+	 * 4) statement node or NULL, representing the code in the loop's body
 	 *    (e.g., could be AST_STMT_LIST, AST_CALL, etc...)
 	 * 
 	 * This test checks a for loop's children in the following PHP code:
@@ -5750,7 +5707,7 @@ public class TestPHPCSVASTBuilder
 	 * Any AST_FOREACH node has exactly four children:
 	 * 1) various possible types, representing the array or object to be iterated over
 	 *    (e.g., could be AST_VAR, AST_CALL, AST_CONST, etc...)
-	 * 2) AST_VAR, representing the value of the current element
+	 * 2) AST_VAR or AST_REF, representing the value of the current element
 	 * 3) AST_VAR or NULL, representing the key of the current element
 	 * 4) statement types or NULL, representing the code in the loop's body
 	 *    (e.g., could be AST_STMT_LIST, AST_CALL, etc...)
@@ -5962,10 +5919,10 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 3, node.getChildCount());
 		assertEquals( 3, ((PHPListExpression)node).size());
 		assertEquals( ast.getNodeById((long)5), ((PHPListExpression)node).getElement(0));
-		assertEquals( ast.getNodeById((long)7), ((PHPListExpression)node).getElement(1));
+		assertNull( ((PHPListExpression)node).getElement(1));
 		assertEquals( ast.getNodeById((long)8), ((PHPListExpression)node).getElement(2));
 		for( ASTNode element : (PHPListExpression)node) // TODO iterate over Expression's
-			assertTrue( ast.containsValue(element));
+			assertTrue( null == element || ast.containsValue(element));
 		
 		assertThat( node2, instanceOf(PHPListExpression.class));
 		assertEquals( 2, node2.getChildCount());
@@ -6111,7 +6068,7 @@ public class TestPHPCSVASTBuilder
 		assertEquals( ast.getNodeById((long)12), ((PHPEncapsListExpression)node).getElement(4));
 		assertEquals( ast.getNodeById((long)13), ((PHPEncapsListExpression)node).getElement(5));
 		assertEquals( ast.getNodeById((long)17), ((PHPEncapsListExpression)node).getElement(6));
-		for( ASTNode element : (PHPEncapsListExpression)node) // TODO iterate over Expression's
+		for( Expression element : (PHPEncapsListExpression)node)
 			assertTrue( ast.containsValue(element));
 	}
 	
@@ -6192,14 +6149,14 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, ((ExpressionList)node).size());
 		assertEquals( ast.getNodeById((long)5), ((ExpressionList)node).getExpression(0));
 		assertEquals( ast.getNodeById((long)9), ((ExpressionList)node).getExpression(1));
-		for( ASTNode expression : (ExpressionList)node) // TODO iterate over Expression's
+		for( Expression expression : (ExpressionList)node)
 			assertTrue( ast.containsValue(expression));
 		
 		assertThat( node2, instanceOf(ExpressionList.class));
 		assertEquals( 1, node2.getChildCount());
 		assertEquals( 1, ((ExpressionList)node2).size());
 		assertEquals( ast.getNodeById((long)14), ((ExpressionList)node2).getExpression(0));
-		for( ASTNode expression : (ExpressionList)node2) // TODO iterate over Expression's
+		for( Expression expression : (ExpressionList)node2)
 			assertTrue( ast.containsValue(expression));
 		
 		assertThat( node3, instanceOf(ExpressionList.class));
@@ -6207,7 +6164,7 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, ((ExpressionList)node3).size());
 		assertEquals( ast.getNodeById((long)19), ((ExpressionList)node3).getExpression(0));
 		assertEquals( ast.getNodeById((long)22), ((ExpressionList)node3).getExpression(1));
-		for( ASTNode expression : (ExpressionList)node3) // TODO iterate over Expression's
+		for( Expression expression : (ExpressionList)node3)
 			assertTrue( ast.containsValue(expression));
 	}
 	
@@ -6257,15 +6214,15 @@ public class TestPHPCSVASTBuilder
 		
 		assertThat( node, instanceOf(CompoundStatement.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( 2, ((CompoundStatement)node).getStatements().size());
+		assertEquals( 2, ((CompoundStatement)node).size());
+		assertEquals( ast.getNodeById((long)3), ((CompoundStatement)node).getStatement(0));
+		assertEquals( ast.getNodeById((long)8), ((CompoundStatement)node).getStatement(1));
 		for( ASTNode stmt : (CompoundStatement)node)
 			assertTrue( ast.containsValue(stmt));
-		assertEquals( ast.getNodeById((long)3), node.getChild(0));
-		assertEquals( ast.getNodeById((long)8), node.getChild(1));
 
 		assertThat( node2, instanceOf(CompoundStatement.class));
 		assertEquals( 0, node2.getChildCount());
-		assertEquals( 0, ((CompoundStatement)node2).getStatements().size());
+		assertEquals( 0, ((CompoundStatement)node2).size());
 		for( ASTNode stmt : (CompoundStatement)node2)
 			assertTrue( ast.containsValue(stmt));
 	}

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -234,12 +234,7 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node, instanceOf(PHPExitExpression.class));
 		assertEquals( 1, node.getChildCount());
-		// TODO ((PHPExitExpression)node).getExpression() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPExitExpression accepts arbitrary ASTNode's for exit expressions,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPExitExpression)node).getExpression().getProperty("type"));
+		assertNull( ((PHPExitExpression)node).getExpression());
 	}
 	
 	/**
@@ -273,12 +268,7 @@ public class TestPHPCSVASTBuilderMinimal
 		
 		assertThat( node, instanceOf(ReturnStatement.class));
 		assertEquals( 1, node.getChildCount());
-		// TODO ((ReturnStatement)node).getReturnExpression() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because ReturnStatement accepts arbitrary ASTNode's for return expressions,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((ReturnStatement)node).getReturnExpression().getProperty("type"));
+		assertNull( ((ReturnStatement)node).getReturnExpression());
 	}
 	
 	/**
@@ -305,12 +295,7 @@ public class TestPHPCSVASTBuilderMinimal
 		
 		assertThat( node, instanceOf(PHPBreakStatement.class));
 		assertEquals( 1, node.getChildCount());
-		// TODO ((PHPBreakStatement)node).getDepth() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPBreakStatement accepts arbitrary ASTNode's for depths,
-		// when we actually only want to accept plain nodes. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPBreakStatement)node).getDepth().getProperty("type"));
+		assertNull( ((PHPBreakStatement)node).getDepth());
 	}
 	
 	/**
@@ -337,12 +322,7 @@ public class TestPHPCSVASTBuilderMinimal
 		
 		assertThat( node, instanceOf(PHPContinueStatement.class));
 		assertEquals( 1, node.getChildCount());
-		// TODO ((PHPContinueStatement)node).getDepth() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPContinueStatement accepts arbitrary ASTNode's for depths,
-		// when we actually only want to accept plain nodes. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPContinueStatement)node).getDepth().getProperty("type"));
+		assertNull( ((PHPContinueStatement)node).getDepth());
 	}
 
 
@@ -381,18 +361,8 @@ public class TestPHPCSVASTBuilderMinimal
 		
 		assertThat( node, instanceOf(PHPYieldExpression.class));
 		assertEquals( 2, node.getChildCount());
-		// TODO ((PHPYieldExpression)node).getValue() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPYieldExpression accepts arbitrary ASTNode's for values,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPYieldExpression)node).getValue().getProperty("type"));
-		// TODO ((PHPYieldExpression)node).getKey() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPYieldExpression accepts arbitrary ASTNode's for keys,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPYieldExpression)node).getKey().getProperty("type"));
+		assertNull( ((PHPYieldExpression)node).getValue());
+		assertNull( ((PHPYieldExpression)node).getKey());
 	}
 	
 	/**
@@ -437,6 +407,11 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node2, instanceOf(WhileStatement.class));
 		assertEquals( 2, node2.getChildCount());
+		assertNull( ((WhileStatement)node2).getStatement());
+		// TODO find a way to consolidate setStatement(Statement) with an Expression
+		// the problem is that when a single statement is used in the body, this
+		// may very well be an expression statement, say, a CallExpression; but
+		// this cannot be cast to a Statement!
 		assertThat( ((WhileStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
 	}
 
@@ -482,6 +457,11 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node2, instanceOf(DoStatement.class));
 		assertEquals( 2, node2.getChildCount());
+		assertNull( ((DoStatement)node2).getStatement());
+		// TODO find a way to consolidate setStatement(Statement) with an Expression
+		// The problem is that when a single statement is used in the body, this
+		// may very well be an expression statement, say, a CallExpression; but
+		// this cannot be cast to a Statement!
 		assertThat( ((DoStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
 	}
 	
@@ -524,13 +504,13 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node2, instanceOf(PHPIfElement.class));
 		assertEquals( 2, node2.getChildCount());
-		// TODO ((PHPIfElement)node2).getCondition() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPIfElement accepts arbitrary ASTNode's for conditions,
-		// when we actually only want to accept Expression's. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPIfElement)node2).getCondition().getProperty("type"));
+		assertNull( ((PHPIfElement)node2).getCondition());
 		assertNull( ((PHPIfElement)node2).getStatement());
+		// TODO find a way to consolidate setStatement(Statement) with an Expression
+		// The problem is that when a single statement is used in the body, this
+		// may very well be an expression statement, say, a CallExpression; but
+		// this cannot be cast to a Statement!
+		assertThat( ((PHPIfElement)node).getStatement(), not(instanceOf(CompoundStatement.class)));
 	}
 	
 	/**
@@ -563,13 +543,7 @@ public class TestPHPCSVASTBuilderMinimal
 		
 		assertThat( node, instanceOf(PHPSwitchCase.class));
 		assertEquals( 2, node.getChildCount());
-		assertEquals( ast.getNodeById((long)12), ((PHPSwitchCase)node).getValue());
-		// TODO ((PHPSwitchCase)node).getValue() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPSwitchCase accepts arbitrary ASTNode's for values,
-		// when we actually only want to accept ints/strings/doubles. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPSwitchCase)node).getValue().getProperty("type"));
+		assertNull( ((PHPSwitchCase)node).getValue());
 	}
 	
 	/**
@@ -616,7 +590,7 @@ public class TestPHPCSVASTBuilderMinimal
 	 * use Foo\Bar;
 	 */
 	@Test
-	public void testUseElementCreation() throws IOException, InvalidCSVFile
+	public void testMinimalUseElementCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "3,AST_USE,T_CLASS,3,,0,1,,,\n";
@@ -635,12 +609,7 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node, instanceOf(UseElement.class));
 		assertEquals( 2, node.getChildCount());
-		// TODO ((UseElement)node).getAlias() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because UseElement accepts arbitrary ASTNode's for aliases,
-		// when we actually only want to accept strings. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((UseElement)node).getAlias().getProperty("type"));
+		assertNull( ((UseElement)node).getAlias());
 	}
 
 
@@ -673,12 +642,7 @@ public class TestPHPCSVASTBuilderMinimal
 		
 		assertThat( node, instanceOf(ConditionalExpression.class));
 		assertEquals( 3, node.getChildCount());
-		// TODO ((ConditionalExpression)node).getTrueExpression() should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because ConditionalExpression accepts arbitrary ASTNode's for true expressions,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((ConditionalExpression)node).getTrueExpression().getProperty("type"));
+		assertNull( ((ConditionalExpression)node).getTrueExpression());
 	}
 
 	/**
@@ -747,11 +711,7 @@ public class TestPHPCSVASTBuilderMinimal
 		assertThat( node, instanceOf(PHPParameter.class));
 		assertEquals( 3, node.getChildCount());
 		assertNull( ((PHPParameter)node).getType());
-		// Note that ((PHPParameter)node).getDefault() is always non-null,
-		// even when there is no default type. Technically, this is because
-		// we allow arbitrary node types to designate the default value anyway,
-		// including the null node (more generally, all plain nodes are fine)
-		assertEquals( "NULL", ((PHPParameter)node).getDefault().getProperty("type"));
+		assertNull( ((PHPParameter)node).getDefault());
 	}
 
 	
@@ -782,14 +742,15 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node, instanceOf(ForStatement.class));
 		assertEquals( 4, node.getChildCount());
-		// TODO The three calls to obtain the for-loop's expression list's should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because ForStatement accepts arbitrary ASTNode's for them. Might need to
-		// create a new class PHPForLoop for that, but finish mapping first.
-		assertEquals( "NULL", ((ForStatement)node).getForInitExpression().getProperty("type"));
-		assertEquals( "NULL", ((ForStatement)node).getCondition().getProperty("type"));
-		assertEquals( "NULL", ((ForStatement)node).getForLoopExpression().getProperty("type"));
+		assertNull( ((ForStatement)node).getForInitExpression());
+		assertNull( ((ForStatement)node).getCondition());
+		assertNull( ((ForStatement)node).getForLoopExpression());
 		assertNull( ((ForStatement)node).getStatement());
+		// TODO find a way to consolidate setStatement(Statement) with an Expression
+		// The problem is that when a single statement is used in the body, this
+		// may very well be an expression statement, say, a CallExpression; but
+		// this cannot be cast to a Statement!
+		assertThat( ((ForStatement)node).getStatement(), not(instanceOf(CompoundStatement.class)));
 	}
 	
 	/**
@@ -823,6 +784,11 @@ public class TestPHPCSVASTBuilderMinimal
 		assertEquals( 4, node.getChildCount());
 		assertNull( ((ForEachStatement)node).getKeyVariable());
 		assertNull( ((ForEachStatement)node).getStatement());
+		// TODO find a way to consolidate setStatement(Statement) with an Expression
+		// The problem is that when a single statement is used in the body, this
+		// may very well be an expression statement, say, a CallExpression; but
+		// this cannot be cast to a Statement!
+		assertThat( ((ForEachStatement)node).getStatement(), not(instanceOf(CompoundStatement.class)));
 	}
 
 
@@ -882,12 +848,7 @@ public class TestPHPCSVASTBuilderMinimal
 		assertThat( node, instanceOf(PHPListExpression.class));
 		assertEquals( 1, node.getChildCount());
 		assertEquals( 1, ((PHPListExpression)node).size());
-		// TODO ((PHPListExpression)node).getElement(0) should
-		// actually return null, not a null node. This currently does not work exactly
-		// as expected because PHPListExpression accepts arbitrary ASTNode's as elements,
-		// when we actually only want to accept expressions. Once the mapping is
-		// finished, we can fix that.
-		assertEquals( "NULL", ((PHPListExpression)node).getElement(0).getProperty("type"));
+		assertNull( ((PHPListExpression)node).getElement(0));
 	}
 	
 	/**

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1,6 +1,7 @@
 package tools.phpast2cfg;
 
 import ast.ASTNode;
+import ast.NullNode;
 import ast.expressions.AndExpression;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
@@ -19,14 +20,17 @@ import ast.expressions.GreaterOrEqualExpression;
 import ast.expressions.Identifier;
 import ast.expressions.IdentifierList;
 import ast.expressions.InstanceofExpression;
+import ast.expressions.IntegerExpression;
 import ast.expressions.NewExpression;
 import ast.expressions.OrExpression;
 import ast.expressions.PostDecOperationExpression;
 import ast.expressions.PostIncOperationExpression;
 import ast.expressions.PreDecOperationExpression;
 import ast.expressions.PreIncOperationExpression;
+import ast.expressions.PrimaryExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
+import ast.expressions.StringExpression;
 import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryPlusExpression;
@@ -129,7 +133,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		String type = startNode.getProperty(PHPCSVNodeTypes.TYPE.getName());
 		switch (type)
 		{
-			// primary expressions (leafs)
+			// - null nodes (leafs)
+			// - primary expressions (leafs)
+			case PHPCSVNodeTypes.TYPE_NULL:
 			case PHPCSVNodeTypes.TYPE_INTEGER:
 			case PHPCSVNodeTypes.TYPE_DOUBLE:
 			case PHPCSVNodeTypes.TYPE_STRING:
@@ -491,7 +497,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // name child
-				startNode.setNameChild(endNode);
+				startNode.setNameChild((StringExpression)endNode);
 				break;
 				
 			default:
@@ -508,7 +514,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // name child
-				startNode.setNameChild(endNode);
+				startNode.setNameChild((StringExpression)endNode);
 				break;
 				
 			default:
@@ -548,13 +554,16 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setParameterList((ParameterList)endNode);
 				break;
 			case 1: // NULL child
-				startNode.addChild(endNode);
+				startNode.addChild((NullNode)endNode);
 				break;
 			case 2: // stmts child
 				startNode.setContent((CompoundStatement)endNode);
 				break;
 			case 3: // returnType child: either Identifier or NULL node
-				startNode.setReturnType(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setReturnType((Identifier)endNode);
 				break;
 				
 			default:
@@ -574,13 +583,19 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setParameterList((ParameterList)endNode);
 				break;
 			case 1: // uses child: either ClosureUses or NULL node
-				startNode.setClosureUses(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setClosureUses((ClosureUses)endNode);
 				break;
 			case 2: // stmts child
 				startNode.setContent((CompoundStatement)endNode);
 				break;
 			case 3: // returnType child: either Identifier or NULL node
-				startNode.setReturnType(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setReturnType((Identifier)endNode);
 				break;
 				
 			default:
@@ -600,13 +615,19 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setParameterList((ParameterList)endNode);
 				break;
 			case 1: // NULL child
-				startNode.addChild(endNode);
+				startNode.addChild((NullNode)endNode);
 				break;
 			case 2: // stmts child: either CompoundStatement or NULL
-				startNode.setContent(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setContent((CompoundStatement)endNode);
 				break;
 			case 3: // returnType child: either Identifier or NULL node
-				startNode.setReturnType(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setReturnType((Identifier)endNode);
 				break;
 				
 			default:
@@ -623,10 +644,16 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // extends child: either Identifier or NULL node
-				startNode.setExtends(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setExtends((Identifier)endNode);
 				break;
 			case 1: // implements child: either IdentifierList or NULL node
-				startNode.setImplements(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setImplements((IdentifierList)endNode);
 				break;
 			case 2: // toplevel child
 				startNode.setTopLevelFunc((TopLevelFunctionDef)endNode);
@@ -649,9 +676,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // name child
-				// TODO cast to PrimaryType once mapping is finished, and change
-				// Variable.name and getters and setters accordingly
-				startNode.setNameChild(endNode);
+				startNode.setNameChild((StringExpression)endNode);
 				break;
 				
 			default:
@@ -685,9 +710,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// PHPUnpackExpression.unpackExpression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -704,9 +727,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryOperationExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -723,9 +744,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryOperationExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -742,9 +761,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// CastExpression.castExpression and getters and setters accordingly
-				startNode.setCastExpression(endNode);
+				startNode.setCastExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -761,9 +778,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -779,10 +794,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setVariableExpression(endNode);
+			case 0: // var child
+				startNode.setVariableExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -799,9 +812,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryOperationExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -818,9 +829,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setShellCommand(endNode);
+				startNode.setShellCommand((Expression)endNode);
 				break;
 				
 			default:
@@ -837,9 +846,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -855,10 +862,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+			case 0: // expr child: Expression or NULL node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -875,9 +883,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -894,9 +900,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryExpression.expression and getters and setters accordingly
-				startNode.setIncludeOrEvalExpression(endNode);
+				startNode.setIncludeOrEvalExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -913,9 +917,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// UnaryOperationExpression.expression and getters and setters accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -1000,9 +1002,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				// TODO cast to Exression once mapping is finished, and change
-				// PHPYieldFromExpression.fromExpression and getters and setters accordingly
-				startNode.setFromExpression(endNode);
+				startNode.setFromExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -1052,8 +1052,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // expr child
-				startNode.setReturnExpression(endNode);
+			case 0: // expr child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setReturnExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -1070,7 +1073,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // name child
-				startNode.setNameChild(endNode);
+				startNode.setNameChild((StringExpression)endNode);
 				break;
 				
 			default:
@@ -1104,10 +1107,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // offset child
-				startNode.setOffset(endNode);
-				// TODO in time, we should be able to cast endNode to PrimaryExpression (or IntegerExpression);
-				// then, change PHPHaltCompilerStatement.offset to be a PrimaryExpression instead
-				// of a generic ASTNode, and getOffset() and setOffset() accordingly
+				startNode.setOffset((IntegerExpression)endNode);
 				break;
 				
 			default:
@@ -1124,10 +1124,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				startNode.setEchoExpression(endNode);
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change PHPEchoStatement.echoExpression to be an Expression instead
-				// of a generic ASTNode, and getEchoExpression() and setEchoExpression() accordingly
+				startNode.setEchoExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -1144,10 +1141,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child
-				startNode.setThrowExpression(endNode);
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change ThrowStatement.throwExpression to be an Expression instead
-				// of a generic ASTNode, and getThrowExpression() and setThrowExpression() accordingly
+				startNode.setThrowExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -1164,7 +1158,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // label child
-				startNode.setTargetLabel(endNode);
+				startNode.setTargetLabel((StringExpression)endNode);
 				break;
 				
 			default:
@@ -1180,8 +1174,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // depth child
-				startNode.setDepth(endNode);
+			case 0: // depth child: IntegerExpression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setDepth((IntegerExpression)endNode);
 				break;
 				
 			default:
@@ -1197,8 +1194,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // depth child
-				startNode.setDepth(endNode);
+			case 0: // depth child: IntegerExpression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setDepth((IntegerExpression)endNode);
 				break;
 				
 			default:
@@ -1218,17 +1218,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change ArrayIndexing.arrayExpression to be an Expression instead
-				// of a generic ASTNode, and getArrayExpression() and setArrayExpression() accordingly
-				startNode.setArrayExpression(endNode);
+				startNode.setArrayExpression((Expression)endNode);
 				break;
 			case 1: // dim child: Expression or NULL node
-				// TODO in time, we should be able to cast endNode to Expression,
-				// unless it's a null node; then, use case distinction here,
-				// change ArrayIndexing.indexExpression to be an Expression instead
-				// of a generic ASTNode, and getIndexExpression() and setIndexExpression() accordingly
-				startNode.setIndexExpression(endNode);
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setIndexExpression((Expression)endNode);
 				break;
 
 			default:
@@ -1245,13 +1241,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change PropertyExpression.objectExpression to be an Expression instead
-				// of a generic ASTNode, and getObjectExpression() and setObjectExpression() accordingly
-				startNode.setObjectExpression(endNode);
+				startNode.setObjectExpression((Expression)endNode);
 				break;
-			case 1: // prop child: string node
-				startNode.setPropertyName(endNode);
+			case 1: // prop child: StringExpression node
+				startNode.setPropertyName((StringExpression)endNode);
 				break;
 
 			default:
@@ -1268,13 +1261,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // class child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change StaticPropertyExpression.classExpression to be an Expression instead
-				// of a generic ASTNode, and getClassExpression() and setClassExpression() accordingly
-				startNode.setClassExpression(endNode);
+				startNode.setClassExpression((Expression)endNode);
 				break;
-			case 1: // prop child: string node
-				startNode.setPropertyName(endNode);
+			case 1: // prop child: StringExpression node
+				startNode.setPropertyName((StringExpression)endNode);
 				break;
 
 			default:
@@ -1291,10 +1281,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change CallExpression.targetFunc to be an Expression instead
-				// of a generic ASTNode, and getTargetFunc() and setTargetFunc() accordingly
-				startNode.setTargetFunc(endNode);
+				startNode.setTargetFunc((Expression)endNode);
 				break;
 			case 1: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
@@ -1314,13 +1301,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // class child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change ClassConstantExpression.classExpression to be an Expression instead
-				// of a generic ASTNode, and getClassExpression() and setClassExpression() accordingly
-				startNode.setClassExpression(endNode);
+				startNode.setClassExpression((Expression)endNode);
 				break;
-			case 1: // const child: string node
-				startNode.setConstantName(endNode);
+			case 1: // const child: StringExpression node
+				startNode.setConstantName((StringExpression)endNode);
 				break;
 
 			default:
@@ -1337,16 +1321,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // var child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getVariable() and setVariable() accordingly
-				startNode.setVariable(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
-				startNode.setAssignExpression(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1363,16 +1341,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // var child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getVariable() and setVariable() accordingly
-				startNode.setVariable(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
-				startNode.setAssignExpression(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1389,16 +1361,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // var child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getVariable() and setVariable() accordingly
-				startNode.setVariable(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getAssignExpression() and setAssignExpression() accordingly
-				startNode.setAssignExpression(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1415,16 +1381,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // left child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getLeft() and setLeft() accordingly
-				startNode.setLeft(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // right child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getRight() and setRight() accordingly
-				startNode.setRight(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1441,16 +1401,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // left child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getLeft() and setLeft() accordingly
-				startNode.setLeft(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // right child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getRight() and setRight() accordingly
-				startNode.setRight(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1467,16 +1421,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // left child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getLeft() and setLeft() accordingly
-				startNode.setLeft(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // right child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getRight() and setRight() accordingly
-				startNode.setRight(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1493,16 +1441,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // left child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getLeft() and setLeft() accordingly
-				startNode.setLeft(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // right child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getRight() and setRight() accordingly
-				startNode.setRight(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1519,16 +1461,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // left child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.left to be an Expression instead
-				// of a generic ASTNode, and getLeft() and setLeft() accordingly
-				startNode.setLeft(endNode);
+				startNode.setLeft((Expression)endNode);
 				break;
 			case 1: // right child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BinaryExpression.right to be an Expression instead
-				// of a generic ASTNode, and getRight() and setRight() accordingly
-				startNode.setRight(endNode);
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1545,15 +1481,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // value child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change PHPArrayElement.value to be an Expression instead
-				// of a generic ASTNode, and getValue() and setValue() accordingly
-				startNode.setValue(endNode);
+				startNode.setValue((Expression)endNode);
 				break;
-			case 1: // key child: Expression or NULL node
-				// TODO in time, we should be able to ALWAYS cast endNode to Expression,
-				// unless it is a NULL node: test that!
-				startNode.setKey(endNode);
+			case 1: // key child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setKey((Expression)endNode);
 				break;
 
 			default:
@@ -1570,10 +1504,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // class child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change NewExpression.targetClass to be an Expression instead
-				// of a generic ASTNode, and getTargetClass() and setTargetClass() accordingly
-				startNode.setTargetClass(endNode);
+				startNode.setTargetClass((Expression)endNode);
 				break;
 			case 1: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
@@ -1593,10 +1524,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change InstanceofExpression.instanceExpression to be an Expression instead
-				// of a generic ASTNode, and getInstanceExpression() and setInstanceExpression() accordingly
-				startNode.setInstanceExpression(endNode);
+				startNode.setInstanceExpression((Expression)endNode);
 				break;
 			case 1: // class child: Identifier node
 				startNode.setClassIdentifier((Identifier)endNode);
@@ -1615,15 +1543,17 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // value child: Expression or plain or NULL node
-				// TODO in time, we should be able to ALWAYS cast endNode to Expression,
-				// unless it is a NULL node: test that!
-				startNode.setValue(endNode);
+			case 0: // value child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setValue((Expression)endNode);
 				break;
-			case 1: // key child: Expression or plain or NULL node
-				// TODO in time, we should be able to ALWAYS cast endNode to Expression,
-				// unless it is a NULL node: test that!
-				startNode.setKey(endNode);
+			case 1: // key child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setKey((Expression)endNode);
 				break;
 
 			default:
@@ -1639,11 +1569,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // left child: Expression or plain node
-				startNode.setLeftExpression(endNode);
+			case 0: // left child: Expression node
+				startNode.setLeft((Expression)endNode);
 				break;
-			case 1: // right child: Expression or plain node
-				startNode.setRightExpression(endNode);
+			case 1: // right child: Expression node
+				startNode.setRight((Expression)endNode);
 				break;
 
 			default:
@@ -1659,14 +1589,14 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // name child: plain node
-				startNode.setNameChild(endNode);
+			case 0: // name child: StringExpression node
+				startNode.setNameChild((StringExpression)endNode);
 				break;
-			case 1: // default child: either Expression or NULL node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change StaticVariableDeclaration.defaultvalue to be an Expression instead
-				// of a generic ASTNode, and getDefault() and setDefault() accordingly
-				startNode.setDefault(endNode);
+			case 1: // default child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setDefault((Expression)endNode);
 				break;
 				
 			default:
@@ -1683,18 +1613,19 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // cond child
-				startNode.setCondition(endNode);
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BlockStarter.condition to be an Expression instead
-				// of a generic ASTNode, and getCondition() and setCondition() accordingly
+				startNode.setCondition((Expression)endNode);
 				break;
-			case 1: // stmts child: statement node (e.g., AST_STMT_LIST) or NULL node
-				if( endNode instanceof Statement)
-					startNode.setStatement((Statement)endNode);
+			case 1: // stmts child: Statement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				// TODO find a way to consolidate setStatement(Statement) with an Expression
+				// The problem is that when a single statement is used in the body, this
+				// may very well be an expression statement, say, a CallExpression; but
+				// this cannot be cast to a Statement!
+				else if( endNode instanceof Expression)
+					startNode.addChild(endNode); // TODO do something more sensible
 				else
-					startNode.addChild(endNode);
-				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
-				// unless it is a NULL node: test that!
+					startNode.setStatement((Statement)endNode);
 				break;
 
 			default:
@@ -1710,19 +1641,20 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // stmts child: statement node (e.g., AST_STMT_LIST) or NULL node
-				if( endNode instanceof Statement)
-					startNode.setStatement((Statement)endNode);
+			case 0: // stmts child: Statement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				// TODO find a way to consolidate setStatement(Statement) with an Expression
+				// The problem is that when a single statement is used in the body, this
+				// may very well be an expression statement, say, a CallExpression; but
+				// this cannot be cast to a Statement!
+				else if( endNode instanceof Expression)
+					startNode.addChild(endNode); // TODO do something more sensible
 				else
-					startNode.addChild(endNode);
-				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
-				// unless it is a NULL node: test that!
+					startNode.setStatement((Statement)endNode);
 				break;
 			case 1: // cond child
-				startNode.setCondition(endNode);
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BlockStarter.condition to be an Expression instead
-				// of a generic ASTNode, and getCondition() and setCondition() accordingly
+				startNode.setCondition((Expression)endNode);
 				break;
 
 			default:
@@ -1738,19 +1670,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // cond child
-				startNode.setCondition(endNode);
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change BlockStarter.condition to be an Expression instead
-				// of a generic ASTNode, and getCondition() and setCondition() accordingly
-				break;
-			case 1: // stmts child: statement node (e.g., AST_STMT_LIST) or NULL node
-				if( endNode instanceof Statement)
-					startNode.setStatement((Statement)endNode);
+			case 0: // cond child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
-				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
-				// unless it is a NULL node: test that!
+					startNode.setCondition((Expression)endNode);
+				break;
+			case 1: // stmts child: Statement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				// TODO find a way to consolidate setStatement(Statement) with an Expression
+				// The problem is that when a single statement is used in the body, this
+				// may very well be an expression statement, say, a CallExpression; but
+				// this cannot be cast to a Statement!
+				else if( endNode instanceof Expression)
+					startNode.addChild(endNode); // TODO do something more sensible
+				else
+					startNode.setStatement((Statement)endNode);
 				break;
 
 			default:
@@ -1767,12 +1703,9 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change PHPSwitchStatement.expression to be an Expression instead
-				// of a generic ASTNode, and getExpression() and setExpression() accordingly
-				startNode.setExpression(endNode);
+				startNode.setExpression((Expression)endNode);
 				break;
-			case 1: // list child: AST_SWITCH_LIST
+			case 1: // list child: PHPSwitchList node
 				startNode.setSwitchList((PHPSwitchList)endNode);
 				break;
 
@@ -1789,10 +1722,13 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // value child: plain node or NULL
-				startNode.setValue(endNode);
+			case 0: // value child: PrimaryExpression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setValue((PrimaryExpression)endNode);
 				break;
-			case 1: // stmts child: AST_STMT_LIST
+			case 1: // stmts child: CompoundStatement node
 				startNode.setStatement((CompoundStatement)endNode);
 				break;
 
@@ -1809,14 +1745,14 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // declares child: AST_CONST_DECL node
+			case 0: // declares child: ConstantDeclaration node
 				startNode.setDeclares((ConstantDeclaration)endNode);
 				break;
-			case 1: // stmts child: AST_STMT_LIST or NULL node
-				if( endNode instanceof CompoundStatement)
-					startNode.setContent((CompoundStatement)endNode);
+			case 1: // stmts child: CompoundStatement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
+					startNode.setContent((CompoundStatement)endNode);
 				break;
 
 			default:
@@ -1832,14 +1768,14 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // name child: plain node
-				startNode.setNameChild(endNode);
+			case 0: // name child: StringExpression node
+				startNode.setNameChild((StringExpression)endNode);
 				break;
-			case 1: // default child: either Expression or NULL node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change PropertyElement.defaultvalue to be an Expression instead
-				// of a generic ASTNode, and getDefault() and setDefault() accordingly
-				startNode.setDefault(endNode);
+			case 1: // default child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setDefault((Expression)endNode);
 				break;
 				
 			default:
@@ -1855,11 +1791,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // name child: plain node
-				startNode.setNameChild(endNode);
+			case 0: // name child: StringExpression node
+				startNode.setNameChild((StringExpression)endNode);
 				break;
-			case 1: // default child: Expression node
-				startNode.setValue(endNode);
+			case 1: // value child: Expression node
+				startNode.setValue((Expression)endNode);
 				break;
 				
 			default:
@@ -1878,11 +1814,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // traits child: IdentifierList node
 				startNode.setTraits((IdentifierList)endNode);
 				break;
-			case 1: // adaptations child: PHPTraitAdaptations or NULL node
-				if( endNode instanceof PHPTraitAdaptations)
-					startNode.setTraitAdaptations((PHPTraitAdaptations)endNode);
+			case 1: // adaptations child: PHPTraitAdaptations or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
+					startNode.setTraitAdaptations((PHPTraitAdaptations)endNode);
 				break;
 	
 			default:
@@ -1918,14 +1854,14 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // class child: Identifier or NULL node
-				if( endNode instanceof Identifier)
-					startNode.setClassIdentifier((Identifier)endNode);
+			case 0: // class child: Identifier or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
+					startNode.setClassIdentifier((Identifier)endNode);
 				break;
-			case 1: // method child: string node
-				startNode.setMethodName(endNode);
+			case 1: // method child: StringExpression node
+				startNode.setMethodName((StringExpression)endNode);
 				break;
 				
 			default:
@@ -1941,14 +1877,17 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // name child: string or NULL node
-				startNode.setName(endNode);
-				break;
-			case 1: // stmts child: AST_STMT_LIST or NULL node
-				if( endNode instanceof CompoundStatement)
-					startNode.setContent((CompoundStatement)endNode);
+			case 0: // name child: StringExpression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
+					startNode.setName((StringExpression)endNode);
+				break;
+			case 1: // stmts child: CompoundStatement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setContent((CompoundStatement)endNode);
 				break;
 
 			default:
@@ -1964,15 +1903,14 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // name child: string node
-				startNode.setNamespace(endNode);
+			case 0: // name child: StringExpression node
+				startNode.setNamespace((StringExpression)endNode);
 				break;
-			case 1: // alias child: string or NULL node
-				// TODO in time, we should be able to cast endNode to a plain
-				// node type that extends Expression, unless endNode is a null
-				// node; then, adapt UseElement to use a string node and
-				// make a case distinction here to use setAlias() or addChild()
-				startNode.setAlias(endNode);
+			case 1: // alias child: StringExpression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setAlias((StringExpression)endNode);
 				break;
 
 			default:
@@ -1991,12 +1929,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // method child: MethodReference node
 				startNode.setMethod((MethodReference)endNode);
 				break;
-			case 1: // alias child: string or NULL node
-				// TODO in time, we should be able to cast endNode to a plain
-				// node type that extends Expression, unless endNode is a null
-				// node; then, adapt PHPTraitAlias to use a string node and
-				// make a case distinction here to use setAlias() or addChild()
-				startNode.setAlias(endNode);
+			case 1: // alias child: StringExpression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setAlias((StringExpression)endNode);
 				break;
 
 			default:
@@ -2012,10 +1949,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // prefix child: string node
-				startNode.setPrefix(endNode);
+			case 0: // prefix child: StringExpression node
+				startNode.setPrefix((StringExpression)endNode);
 				break;
-			case 1: // uses child: AST_USE node
+			case 1: // uses child: UseStatement node
 				startNode.setUses((UseStatement)endNode);
 				break;
 
@@ -2036,16 +1973,10 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change MethodCallExpression.targetObject to be an Expression instead
-				// of a generic ASTNode, and getTargetObject() and setTargetObject() accordingly
-				startNode.setTargetObject(endNode);
+				startNode.setTargetObject((Expression)endNode);
 				break;
-			case 1: // method child: "string" node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change CallExpression.targetFunc to be an Expression instead
-				// of a generic ASTNode, and getTargetFunc() and setTargetFunc() accordingly
-				startNode.setTargetFunc(endNode);
+			case 1: // method child: Expression node
+				startNode.setTargetFunc((Expression)endNode);
 				break;
 			case 2: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
@@ -2067,10 +1998,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // class child: Identifier node
 				startNode.setTargetClass((Identifier)endNode);
 				break;
-			case 1: // method child: "string" node
-				// TODO in time, we should be able to cast endNode to a plain
-				// node type that extends Expression.
-				startNode.setTargetFunc(endNode);
+			case 1: // method child: StringExpression node
+				startNode.setTargetFunc((StringExpression)endNode);
 				break;
 			case 2: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);
@@ -2090,23 +2019,16 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // cond child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change ConditionalExpression.condition to be an Expression instead
-				// of a generic ASTNode, and getCondition() and setCondition() accordingly
-				startNode.setCondition(endNode);
+				startNode.setCondition((Expression)endNode);
 				break;
-			case 1: // trueExpr child: Expression node or NULL
-				// TODO in time, we should be able to cast endNode to Expression, unless it is NULL;
-				// then, use an appropriate case distinction here,
-				// and change ConditionalExpression.trueExpression to be an Expression instead
-				// of a generic ASTNode, and getTrueExpression() and getTrueExpression() accordingly
-				startNode.setTrueExpression(endNode);
+			case 1: // trueExpr child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setTrueExpression((Expression)endNode);
 				break;
 			case 2: // falseExpr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change ConditionalExpression.falseExpression to be an Expression instead
-				// of a generic ASTNode, and getFalseExpression() and getFalseExpression() accordingly
-				startNode.setFalseExpression(endNode);
+				startNode.setFalseExpression((Expression)endNode);
 				break;
 				
 			default:
@@ -2128,11 +2050,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 1: // catches child: CatchList node
 				startNode.setCatchList((CatchList)endNode);
 				break;
-			case 2: // finallyStmts child: CompoundStatement or NULL node
-				if( endNode instanceof CompoundStatement)
-					startNode.setFinallyContent((CompoundStatement)endNode);
+			case 2: // finallyStmts child: CompoundStatement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
+					startNode.setFinallyContent((CompoundStatement)endNode);
 				break;
 				
 			default:
@@ -2151,8 +2073,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // exception child: Identifier node
 				startNode.setExceptionIdentifier((Identifier)endNode);
 				break;
-			case 1: // varName child: plain node
-				startNode.setVariableName(endNode);
+			case 1: // varName child: StringExpression node
+				startNode.setVariableName((StringExpression)endNode);
 				break;
 			case 2: // stmts child: CompoundStatement node
 				startNode.setContent((CompoundStatement)endNode);
@@ -2171,14 +2093,20 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // type child: either Identifier or NULL node
-				startNode.setType(endNode);
+			case 0: // type child: Identifier or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setType((Identifier)endNode);
 				break;
-			case 1: // name child: plain node
-				startNode.setNameChild(endNode);
+			case 1: // name child: StringExpression node
+				startNode.setNameChild((StringExpression)endNode);
 				break;
-			case 2: // default child: either plain or NULL node
-				startNode.setDefault(endNode);
+			case 2: // default child: Expression or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setDefault((Expression)endNode);
 				break;
 				
 			default:
@@ -2197,23 +2125,41 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // init child: either Expression or NULL node
-				startNode.setForInitExpression(endNode);
-				break;
-			case 1: // cond child: either Expression or NULL node
-				// note that the cond child may be NULL, as opposed to while and do-while loops
-				startNode.setCondition(endNode);
-				break;
-			case 2: // loop child: either Expression or NULL node
-				startNode.setForLoopExpression(endNode);
-				break;
-			case 3: // stmts child: statement node (e.g., AST_STMT_LIST) or NULL node
-				if( endNode instanceof Statement)
-					startNode.setStatement((Statement)endNode);
+			case 0: // init child: ExpressionList or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
 				else
-					startNode.addChild(endNode);
-				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
-				// unless it is a NULL node: test that!
+					// Note: can only cast to Expression instead of the more specific ExpressionList
+					// because in C world, a ForInit node is used instead (also an Expression)
+					startNode.setForInitExpression((Expression)endNode);
+				break;
+			case 1: // cond child: ExpressionList or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					// Note: can only cast to Expression instead of the more specific ExpressionList
+					// because in C world, a Condition node is used instead (also an Expression)
+					startNode.setCondition((Expression)endNode);
+				break;
+			case 2: // loop child: ExpressionList or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					// Note: can only cast to Expression instead of the more specific ExpressionList
+					// because in C world, an Expression node is used instead
+					startNode.setForLoopExpression((Expression)endNode);
+				break;
+			case 3: // stmts child: Statement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				// TODO find a way to consolidate setStatement(Statement) with an Expression
+				// The problem is that when a single statement is used in the body, this
+				// may very well be an expression statement, say, a CallExpression; but
+				// this cannot be cast to a Statement!
+				else if( endNode instanceof Expression)
+					startNode.addChild(endNode); // TODO do something more sensible
+				else
+					startNode.setStatement((Statement)endNode);
 				break;
 
 			default:
@@ -2230,27 +2176,28 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // expr child: Expression node
-				// TODO in time, we should be able to cast endNode to Expression;
-				// then, change ForEach.iteratedObject to be an Expression instead
-				// of a generic ASTNode, and getIteratedObject() and setIteratedObject() accordingly
-				startNode.setIteratedObject(endNode);
+				startNode.setIteratedObject((Expression)endNode);
 				break;
 			case 1: // value child: Variable or PHPReferenceExpression node
 				startNode.setValueExpression((Expression)endNode);
 				break;
-			case 2: // key child: either Variable or NULL node
-				if( endNode instanceof Variable)
+			case 2: // key child: Variable or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
 					startNode.setKeyVariable((Variable)endNode);
-				else
-					startNode.addChild(endNode);
 				break;
-			case 3: // stmts child: statement node (e.g., AST_STMT_LIST) or NULL node
-				if( endNode instanceof Statement)
-					startNode.setStatement((Statement)endNode);
+			case 3: // stmts child: Statement or null node
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				// TODO find a way to consolidate setStatement(Statement) with an Expression
+				// The problem is that when a single statement is used in the body, this
+				// may very well be an expression statement, say, a CallExpression; but
+				// this cannot be cast to a Statement!
+				else if( endNode instanceof Expression)
+					startNode.addChild(endNode); // TODO do something more sensible
 				else
-					startNode.addChild(endNode);
-				// TODO in time, we should be able to ALWAYS cast endNode to Statement,
-				// unless it is a NULL node: test that!
+					startNode.setStatement((Statement)endNode);
 				break;
 
 			default:
@@ -2265,14 +2212,17 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	
 	private int handleArgumentList( ArgumentList startNode, ASTNode endNode, int childnum)
 	{
-		startNode.addArgument(endNode); // TODO cast to Expression
+		startNode.addArgument((Expression)endNode);
 
 		return 0;
 	}
 	
 	private int handleList( PHPListExpression startNode, ASTNode endNode, int childnum)
 	{
-		startNode.addElement(endNode); // TODO cast to Expression
+		// This should be either a null node or an Expression:
+		// There is no closer ancestor than ASTNode itself, so we do not cast endNode
+		// to anything more specific here.
+		startNode.addElement(endNode);
 
 		return 0;
 	}
@@ -2286,21 +2236,23 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	
 	private int handleEncapsList( PHPEncapsListExpression startNode, ASTNode endNode, int childnum)
 	{
-		startNode.addElement(endNode); // TODO cast to Expression
+		startNode.addElement((Expression)endNode);
 
 		return 0;
 	}
 	
 	private int handleExpressionList( ExpressionList startNode, ASTNode endNode, int childnum)
 	{
-		startNode.addExpression(endNode); // TODO cast to Expression
+		startNode.addExpression((Expression)endNode);
 
 		return 0;
 	}
 	
 	private int handleCompound( CompoundStatement startNode, ASTNode endNode, int childnum)
 	{
-		startNode.addChild(endNode); // TODO introduce addStatement in CompoundStatement (and cast to Statement)
+		// TODO cast to Statement once CompoundStatement implements Iterable<Statement>
+		// and takes only Statements.
+		startNode.addStatement(endNode);
 
 		return 0;
 	}

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -6,6 +6,7 @@ import inputModules.csv.csv2ast.ASTUnderConstruction;
 import inputModules.csv.csv2ast.CSVRowInterpreter;
 import ast.ASTNode;
 import ast.CodeLocation;
+import ast.NullNode;
 import ast.expressions.AndExpression;
 import ast.expressions.ArgumentList;
 import ast.expressions.ArrayIndexing;
@@ -120,6 +121,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		switch (type)
 		{
+			// null nodes (leafs)
+			case PHPCSVNodeTypes.TYPE_NULL:
+				retval = handleNull(row, ast);
+				break;
+
 			// primary expressions (leafs)
 			case PHPCSVNodeTypes.TYPE_INTEGER:
 				retval = handleInteger(row, ast);
@@ -487,6 +493,29 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 	}
 
 	
+	/* null nodes (leafs) */
+
+	private long handleNull(KeyedCSVRow row, ASTUnderConstruction ast)
+	{
+		NullNode newNode = new NullNode();
+
+		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
+		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
+		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
+
+		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
+		CodeLocation codeloc = new CodeLocation();
+		codeloc.startLine = Integer.parseInt(lineno);
+		newNode.setLocation(codeloc);
+		newNode.setProperty(PHPCSVNodeTypes.CHILDNUM.getName(), childnum);
+
+		long id = Long.parseLong(row.getFieldForKey(PHPCSVNodeTypes.NODE_ID));
+		ast.addNodeWithId(newNode, id);
+
+		return id;
+	}
+	
+	
 	/* primary expressions (leafs) */
 
 	private long handleInteger(KeyedCSVRow row, ASTUnderConstruction ast)
@@ -494,13 +523,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		IntegerExpression newNode = new IntegerExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
-		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
 		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
-		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
@@ -518,13 +545,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		DoubleExpression newNode = new DoubleExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
-		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
 		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
-		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);
@@ -542,13 +567,11 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 		StringExpression newNode = new StringExpression();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
-		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);
 		String lineno = row.getFieldForKey(PHPCSVNodeTypes.LINENO);
 		String code = row.getFieldForKey(PHPCSVNodeTypes.CODE);
 		String childnum = row.getFieldForKey(PHPCSVNodeTypes.CHILDNUM);
 
 		newNode.setProperty(PHPCSVNodeTypes.TYPE.getName(), type);
-		newNode.setFlags(flags);
 		CodeLocation codeloc = new CodeLocation();
 		codeloc.startLine = Integer.parseInt(lineno);
 		newNode.setLocation(codeloc);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -29,6 +29,14 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_FILE = "File";
 	public static final String TYPE_DIRECTORY = "Directory";
 
+	// null nodes (leafs)
+	// used as dummy child for nodes with a fixed number of children
+	// that do not need a certain child in a given context, to keep
+	// the number of their children constant
+	// (e.g., a function node that does not specify its return type in
+	// its declaration; see TestPHPCSVASTBuilderMinimal for more examples.)
+	public static final String TYPE_NULL = "NULL";
+	
 	// primary expressions (leafs)
 	public static final String TYPE_INTEGER = "integer";
 	public static final String TYPE_DOUBLE = "double";


### PR DESCRIPTION
Killed tons of small TODOs scattered everywhere. :blush: 

**Nodes now use more precise child types**

Now that the mapping is finished, we can make the fields corresponding to a node's children much more precise (and accordingly, the getter and setter methods as well). Instead of a generic `ASTNode`, these fields can now have specific other node types (e.g., `Expression`).

This was not possible before the mapping was finished, often simply because a given node type that appeared as a child of another node did not exist yet; or, e.g., because some node had a child of which we know that is always of type `Expression`, but since we had not yet mapped all nodes, not all nodes could actually be cast to `Expression`. In such a situation, to avoid `ClassCastException`'s, we therefore had to use a generic `ASTNode` as the type of the field corresponding to the given child. At times, when I mapped a PHP AST node to a Joern AST node that already existed, I even had to make the already-existing fields *less* precise, e.g., change them from an `Expression` to a generic `ASTNode` (e.g., `BinaryExpression` with its `left` and `right` fields of type `Expression`.)

Now, all nodes have fields (and getters and setters for them) that are as precise as possible, as it should be. The edge interpreter casts the children nodes to the appropriate types. This was a big TODO that I had to push off until after the mapping was finished, and it is now done. :smile: 

**The null node**

I also introduced a new dummy `ast.NullNode` node.

* `NULL` -> `ast.NullNode`

Thereby, we can better deal with `null` nodes in PHP ASTs. Indeed, like primary expressions, there are nodes in PHP ASTs that are literally not instances of `ast\Node` nor plain values such as `integer`, `string` or `double` (see PR #90), but simply `null`.

Having a dedicated `NullNode` makes sense to keep the number of children of nodes supposed to have a fixed number of children constant (this is the same reason why `null` nodes exist in the PHP ASTs in PHP userland). For instance, when a function node has no return type specified in its declaration, then it will still have a "return type" child which will be a `NullNode`. Thus, a function node *always* has 4 children, even when some of its children are unspecified in the parsed PHP code. Null nodes are also leafs, of course, additionally to those leafs mentioned in PR #90.

Moreover, we often have to distinguish the cases where we are dealing with a null node or with a non-null node: e.g., the edge interpreter can only cast a non-null child to its appropriate type (as explained in the previous section) if it is *not* a null node, and we therefore have to ensure that this child is *not* an instance of `NullNode`.

**A problem: What about expression statements?**

While doing all this, I encountered the following problem. Some nodes (namely, blockstarter nodes) are supposed to have a `Statement` child that can be retrieved via `getStatement()`. These are:
* `PHPIfElement`
* `WhileStatement`
* `DoStatement`
* `ForStatement`
* `ForEachStatement`

The problem is that this statement child is not always a compound statement, but may be a single statement. We had already discussed this earlier in PR #77. The thing is that when it is a single statement, this statement is most often an *expression statement*, i.e., an expression used as a statement. For instance, when there is only a single call in the body of an if/while/do/for/foreach statement (`while(true) foo();`), the "statement" child is a `CallExpression`. In particular, from Joern's point of view, this node is an expression, not a statement. So we cannot use `setStatement(Statement)` or `getStatement()` here, because they access the global field `Statement statement`, which cannot hold a node of type `Expression`.

This is a problem, because the appropriate child can thus not be retrieved via `getStatement()`.

It is for the same reason that `CompoundStatement` implements `Iterable<ASTNode>` instead of `Iterable<Statement>`, which would be more intuitive: In a compound statement, there will often be statements that are expression statements, and thus instances of `Expression` instead of `Statement`.

How do we deal with this? How to cope with expression statements?
* We could make the class `Expression` extend `Statement`. It would make sense since each and every single expression, without exception, can also be used as a standalone statement. So in a sense, expressions are statements too. However, I do not know how such a fundamental hierarchy change would affect the rest of Joern. There may be dire consequences that are difficult to foresee. :wink: 
* Or we could create a new node `ExpressionStatement` that extends `Statement` and holds an `Expression`. Additionally to `setStatement(Statement)`, we now add a new method `setStatement(Expression)` to the blockstarter nodes. What this new method does is instantiate a new `ExpressionStatement` with the expression given as argument, and then call `setStatement(Statement)`, passing the newly created `ExpressionStatement` as statement. Same thing goes for a new method `CompoundStatement.addStatement(Expression)` (complementing `CompoundStatement.addStatement(Statement)`), and then `CompoundStatement` could finally maintain a `LinkedList<Statement>`, which would be so much nicer.

Hmm, actually, I think I like the second idea... I will think about it a bit more until tomorrow, but I'm tired right now. What do you think? :blush:

Have a nice evening!
