### PR TITLE
Expression statements and other goodies

### DIFF
--- a/src/ast/functionDef/FunctionDef.java
+++ b/src/ast/functionDef/FunctionDef.java
@@ -1,19 +1,71 @@
 package ast.functionDef;
 
 import ast.ASTNode;
-import ast.ASTNodeProperties;
 import ast.expressions.Identifier;
 import ast.logical.statements.CompoundStatement;
 import ast.walking.ASTNodeVisitor;
 
 public class FunctionDef extends ASTNode
 {
-
-	protected Identifier identifier = null;
 	protected ParameterList parameterList = null;
 	protected CompoundStatement content = null;
-	protected Identifier returnType = null;
 
+	public ParameterList getParameterList()
+	{
+		return this.parameterList;
+	}
+
+	public void setParameterList(ParameterList parameterList)
+	{
+		this.parameterList = parameterList;
+		super.addChild(parameterList);
+	}
+	
+	public CompoundStatement getContent()
+	{
+		return this.content;
+	}
+	
+	public void setContent(CompoundStatement content)
+	{
+		this.content = content;
+		super.addChild(content);
+	}
+
+	
+	/* C world stuff */
+
+	protected Identifier identifier = null; // TODO only used in C world, refactor and create a CFunctionDef
+	
+	public Identifier getIdentifier()
+	{
+		return this.identifier;
+	}
+
+	private void setIdentifier(Identifier identifier)
+	{
+		this.identifier = identifier;
+		super.addChild(identifier);
+	}
+	
+	public String getFunctionSignature()
+	{
+		String retval = getIdentifier().getEscapedCodeStr();
+		if (getParameterList() != null)
+			retval += " (" + getParameterList().getEscapedCodeStr() + ")";
+		else
+			retval += " ()";
+		return retval;
+	}
+	
+	@Override
+	public String getEscapedCodeStr()
+	{
+		setCodeStr(getFunctionSignature());
+		return getCodeStr();
+	}
+
+	@Override
 	public void addChild(ASTNode node)
 	{
 		if (node instanceof CompoundStatement)
@@ -26,86 +78,9 @@ public class FunctionDef extends ASTNode
 			super.addChild(node);
 	}
 	
-	public String getName() {
-		return getProperty(ASTNodeProperties.NAME);
-	}
-	
-	public void setName(String name) {
-		setProperty(ASTNodeProperties.NAME, name);
-	}
-	
-	public String getDocComment() {
-		return getProperty(ASTNodeProperties.DOCCOMMENT);
-	}
-	
-	public void setDocComment(String doccomment) {
-		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
-	}
-
-	public CompoundStatement getContent()
-	{
-		return this.content;
-	}
-	
-	public void setContent(CompoundStatement content)
-	{
-		this.content = content;
-		super.addChild(content);
-	}
-	
-	public Identifier getReturnType()
-	{
-		return this.returnType;
-	}
-	
-	public void setReturnType(Identifier returnType)
-	{
-		this.returnType = returnType;
-		super.addChild(returnType);
-	}
-
 	@Override
-	public String getEscapedCodeStr()
-	{
-		setCodeStr(getFunctionSignature());
-		return getCodeStr();
-	}
-
-	public String getFunctionSignature()
-	{
-		String retval = getIdentifier().getEscapedCodeStr();
-		if (getParameterList() != null)
-			retval += " (" + getParameterList().getEscapedCodeStr() + ")";
-		else
-			retval += " ()";
-		return retval;
-	}
-
 	public void accept(ASTNodeVisitor visitor)
 	{
 		visitor.visit(this);
 	}
-
-	public ParameterList getParameterList()
-	{
-		return this.parameterList;
-	}
-
-	public void setParameterList(ParameterList parameterList)
-	{
-		this.parameterList = parameterList;
-		super.addChild(parameterList);
-	}
-
-	public Identifier getIdentifier()
-	{
-		return this.identifier;
-	}
-
-	private void setIdentifier(Identifier identifier)
-	{
-		this.identifier = identifier;
-		super.addChild(identifier);
-	}
-
 }

--- a/src/ast/logical/statements/BlockStarter.java
+++ b/src/ast/logical/statements/BlockStarter.java
@@ -2,6 +2,7 @@ package ast.logical.statements;
 
 import ast.ASTNode;
 import ast.expressions.Expression;
+import ast.statements.ExpressionStatement;
 
 public class BlockStarter extends Statement
 {
@@ -18,7 +19,7 @@ public class BlockStarter extends Statement
 		this.condition = expression;
 		super.addChild(expression);
 	}
-	
+
 	public Statement getStatement()
 	{
 		return this.statement;
@@ -28,6 +29,18 @@ public class BlockStarter extends Statement
 	{
 		this.statement = statement;
 		super.addChild(statement);
+	}
+	
+	// Expressions can be used as statements. For instance, in the code 'if(true) foo();',
+	// - foo() is an expression
+	// - foo(); is an expression statement
+	// In this case, we need to create an ExpressionStatement that holds the given Expression.
+	public void setStatement(Expression expression)
+	{
+		ExpressionStatement expressionStatement = new ExpressionStatement();
+		expressionStatement.setExpression(expression);
+		
+		setStatement(expressionStatement);
 	}
 
 	@Override

--- a/src/ast/logical/statements/CompoundStatement.java
+++ b/src/ast/logical/statements/CompoundStatement.java
@@ -7,7 +7,7 @@ import java.util.List;
 import ast.ASTNode;
 import ast.walking.ASTNodeVisitor;
 
-public class CompoundStatement extends Statement implements Iterable<ASTNode> // TODO make this an Iterable<Statement>
+public class CompoundStatement extends Statement implements Iterable<ASTNode>
 {
 	protected static final List<ASTNode> emptyList = new LinkedList<ASTNode>();
 
@@ -26,6 +26,8 @@ public class CompoundStatement extends Statement implements Iterable<ASTNode> //
 		return getStatements().get(i);
 	}
 
+	// Note: These may be all kinds of AST nodes: instances of Statement, but also
+	// instances of Expression, FunctionDef, or even null nodes.
 	public void addStatement(ASTNode statement)
 	{
 		super.addChild(statement);

--- a/src/ast/php/functionDef/Closure.java
+++ b/src/ast/php/functionDef/Closure.java
@@ -1,8 +1,6 @@
 package ast.php.functionDef;
 
-import ast.functionDef.FunctionDef;
-
-public class Closure extends FunctionDef
+public class Closure extends PHPFunctionDef
 {
 	private ClosureUses closureUses = null;
 

--- a/src/ast/php/functionDef/Method.java
+++ b/src/ast/php/functionDef/Method.java
@@ -1,7 +1,5 @@
 package ast.php.functionDef;
 
-import ast.functionDef.FunctionDef;
-
-public class Method extends FunctionDef
+public class Method extends PHPFunctionDef
 {
 }

--- a/src/ast/php/functionDef/PHPFunctionDef.java
+++ b/src/ast/php/functionDef/PHPFunctionDef.java
@@ -1,0 +1,43 @@
+package ast.php.functionDef;
+
+import ast.ASTNodeProperties;
+import ast.expressions.Identifier;
+import ast.functionDef.FunctionDef;
+
+public class PHPFunctionDef extends FunctionDef
+{
+	protected Identifier returnType = null;
+
+	public String getName() {
+		return getProperty(ASTNodeProperties.NAME);
+	}
+	
+	public void setName(String name) {
+		setProperty(ASTNodeProperties.NAME, name);
+	}
+	
+	public String getDocComment() {
+		return getProperty(ASTNodeProperties.DOCCOMMENT);
+	}
+	
+	public void setDocComment(String doccomment) {
+		setProperty(ASTNodeProperties.DOCCOMMENT, doccomment);
+	}
+
+	public Identifier getReturnType()
+	{
+		return this.returnType;
+	}
+	
+	public void setReturnType(Identifier returnType)
+	{
+		this.returnType = returnType;
+		super.addChild(returnType);
+	}
+	
+	@Override
+	public Identifier getIdentifier()
+	{
+		throw new RuntimeException("An Identifier is not used for PHP function names, use getName() instead!");
+	}
+}

--- a/src/ast/php/functionDef/TopLevelFunctionDef.java
+++ b/src/ast/php/functionDef/TopLevelFunctionDef.java
@@ -1,10 +1,9 @@
 package ast.php.functionDef;
 
 import ast.expressions.Identifier;
-import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 
-public class TopLevelFunctionDef extends FunctionDef
+public class TopLevelFunctionDef extends PHPFunctionDef
 {
 	@Override
 	public ParameterList getParameterList()

--- a/src/ast/statements/ExpressionHolderStatement.java
+++ b/src/ast/statements/ExpressionHolderStatement.java
@@ -1,10 +1,24 @@
 package ast.statements;
 
+import ast.ASTNode;
 import ast.expressions.Expression;
 import ast.logical.statements.Statement;
 
 public class ExpressionHolderStatement extends Statement
 {
+	private Expression expression = null;
+
+	public Expression getExpression()
+	{
+		return this.expression;
+	}
+	
+	public void setExpression(Expression expression)
+	{	
+		this.expression = expression;
+		super.addChild(expression);
+	}
+	
 	@Override
 	public String getEscapedCodeStr()
 	{
@@ -16,12 +30,13 @@ public class ExpressionHolderStatement extends Statement
 		setCodeStr(expr.getEscapedCodeStr());
 		return getCodeStr();
 	}
-
-	public Expression getExpression()
+	
+	@Override
+	public void addChild(ASTNode node)
 	{
-		if (children == null)
-			return null;
-		return (Expression) children.get(0);
+		if (node instanceof Expression)
+			setExpression((Expression)node);
+		else
+			super.addChild(node);
 	}
-
 }

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -8,8 +8,8 @@ import java.io.StringReader;
 
 import org.junit.Test;
 
-import ast.functionDef.FunctionDef;
 import ast.logical.statements.CompoundStatement;
+import ast.php.functionDef.PHPFunctionDef;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.CSV2AST;
 
@@ -20,14 +20,14 @@ public class TestCSV2AST
 	String nodeHeader = "id:ID,type,flags:string[],lineno:int,code,childnum:int,funcid:int,endlineno:int,name,doccomment\n";
 	String edgeHeader = ":START_ID,:END_ID,:TYPE\n";
 
-	private FunctionDef createASTFromStrings(String nodeStr, String edgeStr)
+	private PHPFunctionDef createASTFromStrings(String nodeStr, String edgeStr)
 			throws IOException, InvalidCSVFile
 	{
 		CSV2AST csv2AST = new CSV2AST();
 		StringReader nodeReader = new StringReader(nodeStr);
 		StringReader edgeReader = new StringReader(edgeStr);
 		csv2AST.setLanguage("PHP");
-		return csv2AST.convert(nodeReader, edgeReader);
+		return (PHPFunctionDef)csv2AST.convert(nodeReader, edgeReader);
 	}
 	
 	@Test
@@ -35,7 +35,7 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertTrue(func != null);
 	}
@@ -45,7 +45,7 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,foo,\n";
-		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertEquals("foo", func.getName());
 	}
@@ -55,7 +55,7 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "2,AST_FUNC_DECL,,3,,0,,3,,\n";
-		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertEquals("", func.getName());
 	}
@@ -65,7 +65,7 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,6,bar,\n";
-		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertEquals("bar", func.getName());
 		assertEquals("MODIFIER_PUBLIC", func.getFlags());
@@ -76,7 +76,7 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "13,AST_METHOD,MODIFIER_PUBLIC,6,,0,11,36,bar,\n";
-		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertEquals("bar", func.getName());
 		assertEquals(6, func.getLocation().startLine);
@@ -88,7 +88,7 @@ public class TestCSV2AST
 	{
 		String nodeStr = nodeHeader;
 		nodeStr += "3,AST_FUNC_DECL,,4,,0,1,4,foo,\"/** This is a doccomment */\"\n";
-		FunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeHeader);
 		
 		assertEquals("foo", func.getName());
 		assertEquals("/** This is a doccomment */", func.getDocComment());
@@ -123,7 +123,7 @@ public class TestCSV2AST
 		edgeStr += "2,5,PARENT_OF\n";
 		edgeStr += "2,10,PARENT_OF\n";
 
-		FunctionDef func = createASTFromStrings(nodeStr, edgeStr);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeStr);
 		CompoundStatement content = func.getContent();
 
 		// TODO: well this is gonna look a lot nicer once we mapped all PHP AST constructs
@@ -161,7 +161,7 @@ public class TestCSV2AST
 		edgeStr += "2,5,PARENT_OF\n";
 		edgeStr += "2,10,PARENT_OF\n";
 
-		FunctionDef func = createASTFromStrings(nodeStr, edgeStr);
+		PHPFunctionDef func = createASTFromStrings(nodeStr, edgeStr);
 		CompoundStatement content = func.getContent();
 
 		assertEquals(1, content.getChildCount());

--- a/src/tests/inputModules/TestCSVFunctionExtractor.java
+++ b/src/tests/inputModules/TestCSVFunctionExtractor.java
@@ -1,6 +1,7 @@
 package tests.inputModules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -8,7 +9,7 @@ import java.io.StringReader;
 import org.junit.Before;
 import org.junit.Test;
 
-import ast.functionDef.FunctionDef;
+import ast.php.functionDef.PHPFunctionDef;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csvFuncExtractor.CSVFunctionExtractor;
 
@@ -40,9 +41,9 @@ public class TestCSVFunctionExtractor
 	public void testHeaderOnly() throws IOException, InvalidCSVFile
 	{
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
 
-		assertEquals(null, function);
+		assertNull(function);
 	}
 
 	
@@ -71,13 +72,13 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("foo", function.getName());
 		assertEquals("<foo.php>", function2.getName());
-		assertEquals(null, function3);
+		assertNull(function3);
 	}
 
 	/**
@@ -103,13 +104,13 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
 		
 		assertEquals("foo", function.getName());
 		assertEquals("<foo.php>", function2.getName());
-		assertEquals(null, function3);
+		assertNull(function3);
 	}
 
 	/**
@@ -139,13 +140,13 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("foo", function.getName());
 		assertEquals("<foo.php>", function2.getName());
-		assertEquals(null, function3);
+		assertNull(function3);
 	}
 
 	/**
@@ -173,15 +174,15 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("foo", function.getName());
 		assertEquals("bar", function2.getName());
 		assertEquals("<foo.php>", function3.getName());
-		assertEquals(null, function4);
+		assertNull(function4);
 	}
 	
 	/**
@@ -210,15 +211,15 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("bar", function.getName());
 		assertEquals("foo", function2.getName());
 		assertEquals("<foo.php>", function3.getName());
-		assertEquals(null, function4);
+		assertNull(function4);
 	}
 	
 	/**
@@ -253,17 +254,17 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
-		FunctionDef function5 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function5 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("bar", function.getName());
 		assertEquals("foo", function2.getName());
 		assertEquals("buz", function3.getName());
 		assertEquals("<foo.php>", function4.getName());
-		assertEquals(null, function5);
+		assertNull(function5);
 	}
 
 	/**
@@ -292,15 +293,15 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("{closure}", function.getName());
 		assertEquals("foo", function2.getName());
 		assertEquals("<foo.php>", function3.getName());
-		assertEquals(null, function4);
+		assertNull(function4);
 	}
 
 	/**
@@ -337,17 +338,17 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
-		FunctionDef function5 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function5 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("foo", function.getName());
 		assertEquals("<foobar/foo.php>", function2.getName());
 		assertEquals("bar", function3.getName());
 		assertEquals("<foobar/bar.php>", function4.getName());
-		assertEquals(null, function5);
+		assertNull(function5);
 	}
 	
 	/**
@@ -369,13 +370,13 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("[foo]", function.getName());
 		assertEquals("<foo.php>", function2.getName());
-		assertEquals(null, function3);
+		assertNull(function3);
 	}
 	
 	/**
@@ -416,19 +417,19 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
-		FunctionDef function5 = extractor.getNextFunction();
-		FunctionDef function6 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function5 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function6 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("foo", function.getName());
 		assertEquals("bar", function2.getName());
 		assertEquals("[foo]", function3.getName());
 		assertEquals("[buz]", function4.getName());
 		assertEquals("<foo.php>", function5.getName());
-		assertEquals(null, function6);
+		assertNull(function6);
 	}
 	
 	/**
@@ -479,12 +480,12 @@ public class TestCSVFunctionExtractor
 		nodeReader = new StringReader(nodeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
-		FunctionDef function5 = extractor.getNextFunction();
-		FunctionDef function6 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function5 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function6 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals("foo", function.getName());
 		assertEquals("[foo]", function2.getName());
@@ -602,8 +603,8 @@ public class TestCSVFunctionExtractor
 		edgeReader = new StringReader(edgeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals(4, function.getChildCount());
 		assertEquals(1, function2.getChildCount());
@@ -663,10 +664,10 @@ public class TestCSVFunctionExtractor
 		edgeReader = new StringReader(edgeStr);
 
 		extractor.initialize(nodeReader, edgeReader);
-		FunctionDef function = extractor.getNextFunction();
-		FunctionDef function2 = extractor.getNextFunction();
-		FunctionDef function3 = extractor.getNextFunction();
-		FunctionDef function4 = extractor.getNextFunction();
+		PHPFunctionDef function = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function2 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function3 = (PHPFunctionDef)extractor.getNextFunction();
+		PHPFunctionDef function4 = (PHPFunctionDef)extractor.getNextFunction();
 
 		assertEquals(4, function.getChildCount());
 		assertEquals(1, function2.getChildCount());

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -46,7 +46,6 @@ import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryPlusExpression;
 import ast.expressions.Variable;
-import ast.functionDef.FunctionDef;
 import ast.functionDef.Parameter;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
@@ -78,6 +77,7 @@ import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPFunctionDef;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
@@ -398,14 +398,14 @@ public class TestPHPCSVASTBuilder
 
 		ASTNode node = ast.getNodeById((long)3);
 		
-		assertThat( node, instanceOf(FunctionDef.class));
-		assertEquals( "foo", ((FunctionDef)node).getName());
+		assertThat( node, instanceOf(PHPFunctionDef.class));
+		assertEquals( "foo", ((PHPFunctionDef)node).getName());
 		assertEquals( 4, node.getChildCount());
-		assertEquals( ast.getNodeById((long)4), ((FunctionDef)node).getParameterList());
-		assertEquals( ast.getNodeById((long)6), ((FunctionDef)node).getContent());
-		assertEquals( ast.getNodeById((long)7), ((FunctionDef)node).getReturnType());
-		assertEquals( ast.getNodeById((long)8), ((FunctionDef)node).getReturnType().getNameChild());
-		assertEquals( "int", ((FunctionDef)node).getReturnType().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)4), ((PHPFunctionDef)node).getParameterList());
+		assertEquals( ast.getNodeById((long)6), ((PHPFunctionDef)node).getContent());
+		assertEquals( ast.getNodeById((long)7), ((PHPFunctionDef)node).getReturnType());
+		assertEquals( ast.getNodeById((long)8), ((PHPFunctionDef)node).getReturnType().getNameChild());
+		assertEquals( "int", ((PHPFunctionDef)node).getReturnType().getNameChild().getEscapedCodeStr());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -33,6 +33,7 @@ import ast.php.statements.blockstarters.PHPSwitchList;
 import ast.php.statements.blockstarters.PHPUseTrait;
 import ast.php.statements.jump.PHPBreakStatement;
 import ast.php.statements.jump.PHPContinueStatement;
+import ast.statements.ExpressionStatement;
 import ast.statements.UseElement;
 import ast.statements.blockstarters.CatchList;
 import ast.statements.blockstarters.DoStatement;
@@ -407,12 +408,9 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node2, instanceOf(WhileStatement.class));
 		assertEquals( 2, node2.getChildCount());
-		assertNull( ((WhileStatement)node2).getStatement());
-		// TODO find a way to consolidate setStatement(Statement) with an Expression
-		// the problem is that when a single statement is used in the body, this
-		// may very well be an expression statement, say, a CallExpression; but
-		// this cannot be cast to a Statement!
 		assertThat( ((WhileStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
+		assertThat( ((WhileStatement)node2).getStatement(), instanceOf(ExpressionStatement.class));
+		assertEquals( ast.getNodeById((long)10), ((ExpressionStatement)((WhileStatement)node2).getStatement()).getExpression());
 	}
 
 	/**
@@ -457,22 +455,22 @@ public class TestPHPCSVASTBuilderMinimal
 
 		assertThat( node2, instanceOf(DoStatement.class));
 		assertEquals( 2, node2.getChildCount());
-		assertNull( ((DoStatement)node2).getStatement());
-		// TODO find a way to consolidate setStatement(Statement) with an Expression
-		// The problem is that when a single statement is used in the body, this
-		// may very well be an expression statement, say, a CallExpression; but
-		// this cannot be cast to a Statement!
 		assertThat( ((DoStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
+		assertThat( ((DoStatement)node2).getStatement(), instanceOf(ExpressionStatement.class));
+		assertEquals( ast.getNodeById((long)8), ((ExpressionStatement)((DoStatement)node2).getStatement()).getExpression());
 	}
 	
 	/**
 	 * if(true) ;
 	 * else ;
+	 * if(true) foo();
+	 * else bar();
 	 */
 	@Test
 	public void testMinimalIfElementCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_IF,,3,,0,1,,,\n";
 		nodeStr += "4,AST_IF_ELEM,,3,,0,1,,,\n";
 		nodeStr += "5,AST_CONST,,3,,0,1,,,\n";
@@ -482,6 +480,21 @@ public class TestPHPCSVASTBuilderMinimal
 		nodeStr += "9,AST_IF_ELEM,,4,,1,1,,,\n";
 		nodeStr += "10,NULL,,4,,0,1,,,\n";
 		nodeStr += "11,NULL,,4,,1,1,,,\n";
+		nodeStr += "12,AST_IF,,5,,1,1,,,\n";
+		nodeStr += "13,AST_IF_ELEM,,5,,0,1,,,\n";
+		nodeStr += "14,AST_CONST,,5,,0,1,,,\n";
+		nodeStr += "15,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "16,string,,5,\"true\",0,1,,,\n";
+		nodeStr += "17,AST_CALL,,5,,1,1,,,\n";
+		nodeStr += "18,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
+		nodeStr += "19,string,,5,\"foo\",0,1,,,\n";
+		nodeStr += "20,AST_ARG_LIST,,5,,1,1,,,\n";
+		nodeStr += "21,AST_IF_ELEM,,6,,1,1,,,\n";
+		nodeStr += "22,NULL,,6,,0,1,,,\n";
+		nodeStr += "23,AST_CALL,,6,,1,1,,,\n";
+		nodeStr += "24,AST_NAME,NAME_NOT_FQ,6,,0,1,,,\n";
+		nodeStr += "25,string,,6,\"bar\",0,1,,,\n";
+		nodeStr += "26,AST_ARG_LIST,,6,,1,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "6,7,PARENT_OF\n";
@@ -492,11 +505,29 @@ public class TestPHPCSVASTBuilderMinimal
 		edgeStr += "9,10,PARENT_OF\n";
 		edgeStr += "9,11,PARENT_OF\n";
 		edgeStr += "3,9,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "15,16,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "18,19,PARENT_OF\n";
+		edgeStr += "17,18,PARENT_OF\n";
+		edgeStr += "17,20,PARENT_OF\n";
+		edgeStr += "13,17,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "21,22,PARENT_OF\n";
+		edgeStr += "24,25,PARENT_OF\n";
+		edgeStr += "23,24,PARENT_OF\n";
+		edgeStr += "23,26,PARENT_OF\n";
+		edgeStr += "21,23,PARENT_OF\n";
+		edgeStr += "12,21,PARENT_OF\n";
+		edgeStr += "2,12,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
 
 		ASTNode node = ast.getNodeById((long)4);
 		ASTNode node2 = ast.getNodeById((long)9);
+		ASTNode node3 = ast.getNodeById((long)13);
+		ASTNode node4 = ast.getNodeById((long)21);
 		
 		assertThat( node, instanceOf(PHPIfElement.class));
 		assertEquals( 2, node.getChildCount());
@@ -506,11 +537,19 @@ public class TestPHPCSVASTBuilderMinimal
 		assertEquals( 2, node2.getChildCount());
 		assertNull( ((PHPIfElement)node2).getCondition());
 		assertNull( ((PHPIfElement)node2).getStatement());
-		// TODO find a way to consolidate setStatement(Statement) with an Expression
-		// The problem is that when a single statement is used in the body, this
-		// may very well be an expression statement, say, a CallExpression; but
-		// this cannot be cast to a Statement!
-		assertThat( ((PHPIfElement)node).getStatement(), not(instanceOf(CompoundStatement.class)));
+		
+		assertThat( node3, instanceOf(PHPIfElement.class));
+		assertEquals( 2, node3.getChildCount());
+		assertThat( ((PHPIfElement)node3).getStatement(), not(instanceOf(CompoundStatement.class)));
+		assertThat( ((PHPIfElement)node3).getStatement(), instanceOf(ExpressionStatement.class));
+		assertEquals( ast.getNodeById((long)17), ((ExpressionStatement)((PHPIfElement)node3).getStatement()).getExpression());
+		
+		assertThat( node4, instanceOf(PHPIfElement.class));
+		assertEquals( 2, node4.getChildCount());
+		assertNull( ((PHPIfElement)node4).getCondition());
+		assertThat( ((PHPIfElement)node4).getStatement(), not(instanceOf(CompoundStatement.class)));
+		assertThat( ((PHPIfElement)node4).getStatement(), instanceOf(ExpressionStatement.class));
+		assertEquals( ast.getNodeById((long)23), ((ExpressionStatement)((PHPIfElement)node4).getStatement()).getExpression());
 	}
 	
 	/**
@@ -719,26 +758,46 @@ public class TestPHPCSVASTBuilderMinimal
 
 	/**
 	 * for (;;);
+	 * for (;;) foo();
 	 */
 	@Test
 	public void testMinimalForCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FOR,,3,,0,1,,,\n";
 		nodeStr += "4,NULL,,3,,0,1,,,\n";
 		nodeStr += "5,NULL,,3,,1,1,,,\n";
 		nodeStr += "6,NULL,,3,,2,1,,,\n";
 		nodeStr += "7,NULL,,3,,3,1,,,\n";
+		nodeStr += "8,AST_FOR,,4,,1,1,,,\n";
+		nodeStr += "9,NULL,,4,,0,1,,,\n";
+		nodeStr += "10,NULL,,4,,1,1,,,\n";
+		nodeStr += "11,NULL,,4,,2,1,,,\n";
+		nodeStr += "12,AST_CALL,,4,,3,1,,,\n";
+		nodeStr += "13,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "14,string,,4,\"foo\",0,1,,,\n";
+		nodeStr += "15,AST_ARG_LIST,,4,,1,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "3,4,PARENT_OF\n";
 		edgeStr += "3,5,PARENT_OF\n";
 		edgeStr += "3,6,PARENT_OF\n";
 		edgeStr += "3,7,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "8,9,PARENT_OF\n";
+		edgeStr += "8,10,PARENT_OF\n";
+		edgeStr += "8,11,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
+		edgeStr += "12,15,PARENT_OF\n";
+		edgeStr += "8,12,PARENT_OF\n";
+		edgeStr += "2,8,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
 
 		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)8);
 
 		assertThat( node, instanceOf(ForStatement.class));
 		assertEquals( 4, node.getChildCount());
@@ -746,20 +805,26 @@ public class TestPHPCSVASTBuilderMinimal
 		assertNull( ((ForStatement)node).getCondition());
 		assertNull( ((ForStatement)node).getForLoopExpression());
 		assertNull( ((ForStatement)node).getStatement());
-		// TODO find a way to consolidate setStatement(Statement) with an Expression
-		// The problem is that when a single statement is used in the body, this
-		// may very well be an expression statement, say, a CallExpression; but
-		// this cannot be cast to a Statement!
-		assertThat( ((ForStatement)node).getStatement(), not(instanceOf(CompoundStatement.class)));
+
+		assertThat( node2, instanceOf(ForStatement.class));
+		assertEquals( 4, node2.getChildCount());
+		assertNull( ((ForStatement)node2).getForInitExpression());
+		assertNull( ((ForStatement)node2).getCondition());
+		assertNull( ((ForStatement)node2).getForLoopExpression());
+		assertThat( ((ForStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
+		assertThat( ((ForStatement)node2).getStatement(), instanceOf(ExpressionStatement.class));
+		assertEquals( ast.getNodeById((long)12), ((ExpressionStatement)((ForStatement)node2).getStatement()).getExpression());
 	}
 	
 	/**
 	 * foreach ($somearray as $foo);
+	 * foreach ($somearray as $foo) bar();
 	 */
 	@Test
 	public void testMinimalForEachCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_FOREACH,,3,,0,1,,,\n";
 		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
 		nodeStr += "5,string,,3,\"somearray\",0,1,,,\n";
@@ -767,6 +832,16 @@ public class TestPHPCSVASTBuilderMinimal
 		nodeStr += "7,string,,3,\"foo\",0,1,,,\n";
 		nodeStr += "8,NULL,,3,,2,1,,,\n";
 		nodeStr += "9,NULL,,3,,3,1,,,\n";
+		nodeStr += "10,AST_FOREACH,,4,,1,1,,,\n";
+		nodeStr += "11,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "12,string,,4,\"somearray\",0,1,,,\n";
+		nodeStr += "13,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "14,string,,4,\"foo\",0,1,,,\n";
+		nodeStr += "15,NULL,,4,,2,1,,,\n";
+		nodeStr += "16,AST_CALL,,4,,3,1,,,\n";
+		nodeStr += "17,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
+		nodeStr += "18,string,,4,\"bar\",0,1,,,\n";
+		nodeStr += "19,AST_ARG_LIST,,4,,1,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "4,5,PARENT_OF\n";
@@ -775,20 +850,34 @@ public class TestPHPCSVASTBuilderMinimal
 		edgeStr += "3,6,PARENT_OF\n";
 		edgeStr += "3,8,PARENT_OF\n";
 		edgeStr += "3,9,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
+		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "10,13,PARENT_OF\n";
+		edgeStr += "10,15,PARENT_OF\n";
+		edgeStr += "17,18,PARENT_OF\n";
+		edgeStr += "16,17,PARENT_OF\n";
+		edgeStr += "16,19,PARENT_OF\n";
+		edgeStr += "10,16,PARENT_OF\n";
+		edgeStr += "2,10,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
 
 		ASTNode node = ast.getNodeById((long)3);
+		ASTNode node2 = ast.getNodeById((long)10);
 
 		assertThat( node, instanceOf(ForEachStatement.class));
 		assertEquals( 4, node.getChildCount());
 		assertNull( ((ForEachStatement)node).getKeyVariable());
 		assertNull( ((ForEachStatement)node).getStatement());
-		// TODO find a way to consolidate setStatement(Statement) with an Expression
-		// The problem is that when a single statement is used in the body, this
-		// may very well be an expression statement, say, a CallExpression; but
-		// this cannot be cast to a Statement!
-		assertThat( ((ForEachStatement)node).getStatement(), not(instanceOf(CompoundStatement.class)));
+		
+		assertThat( node2, instanceOf(ForEachStatement.class));
+		assertEquals( 4, node2.getChildCount());
+		assertNull( ((ForEachStatement)node2).getKeyVariable());
+		assertThat( ((ForEachStatement)node2).getStatement(), not(instanceOf(CompoundStatement.class)));
+		assertThat( ((ForEachStatement)node2).getStatement(), instanceOf(ExpressionStatement.class));
+		assertEquals( ast.getNodeById((long)16), ((ExpressionStatement)((ForEachStatement)node2).getStatement()).getExpression());
 	}
 
 

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import ast.ASTNode;
 import ast.expressions.ArgumentList;
 import ast.expressions.ConditionalExpression;
-import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.php.declarations.PHPClassDef;
@@ -25,6 +24,7 @@ import ast.php.expressions.PHPListExpression;
 import ast.php.expressions.PHPYieldExpression;
 import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPFunctionDef;
 import ast.php.functionDef.PHPParameter;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
@@ -117,9 +117,9 @@ public class TestPHPCSVASTBuilderMinimal
 
 		ASTNode node = ast.getNodeById((long)3);
 		
-		assertThat( node, instanceOf(FunctionDef.class));
+		assertThat( node, instanceOf(PHPFunctionDef.class));
 		assertEquals( 4, node.getChildCount());
-		assertNull( ((FunctionDef)node).getReturnType());
+		assertNull( ((PHPFunctionDef)node).getReturnType());
 	}
 
 	/**

--- a/src/tools/phpast2cfg/Main.java
+++ b/src/tools/phpast2cfg/Main.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 
 import org.apache.commons.cli.ParseException;
 
-import ast.functionDef.FunctionDef;
+import ast.php.functionDef.PHPFunctionDef;
 import cfg.CFG;
 import inputModules.csv.KeyedCSV.exceptions.InvalidCSVFile;
 import inputModules.csv.csv2ast.CSV2AST;
@@ -35,8 +35,8 @@ public class Main
 		extractor.setLanguage("PHP");
 		extractor.initialize(nodeFileReader, edgeFileReader);
 
-		FunctionDef funcAST;
-		while ((funcAST = extractor.getNextFunction()) != null)
+		PHPFunctionDef funcAST;
+		while ((funcAST = (PHPFunctionDef)extractor.getNextFunction()) != null)
 		{
 			CFG cfg = cfgFactory.newInstance(funcAST);
 		}

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -35,7 +35,6 @@ import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryPlusExpression;
 import ast.expressions.Variable;
-import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
@@ -65,6 +64,7 @@ import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPFunctionDef;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
@@ -155,7 +155,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				errno = handleTopLevelFunction((TopLevelFunctionDef)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_FUNC_DECL:
-				errno = handleFunction((FunctionDef)startNode, endNode, childnum);
+				errno = handleFunction((PHPFunctionDef)startNode, endNode, childnum);
 				break;
 			case PHPCSVNodeTypes.TYPE_CLOSURE:
 				errno = handleClosure((Closure)startNode, endNode, childnum);
@@ -544,7 +544,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		return errno;		
 	}
 
-	private int handleFunction( FunctionDef startNode, ASTNode endNode, int childnum)
+	private int handleFunction( PHPFunctionDef startNode, ASTNode endNode, int childnum)
 	{
 		int errno = 0;
 

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1615,15 +1615,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // cond child
 				startNode.setCondition((Expression)endNode);
 				break;
-			case 1: // stmts child: Statement or null node
+			case 1: // stmts child: Statement or Expression or null node
 				if( endNode instanceof NullNode)
 					startNode.addChild((NullNode)endNode);
-				// TODO find a way to consolidate setStatement(Statement) with an Expression
-				// The problem is that when a single statement is used in the body, this
-				// may very well be an expression statement, say, a CallExpression; but
-				// this cannot be cast to a Statement!
-				else if( endNode instanceof Expression)
-					startNode.addChild(endNode); // TODO do something more sensible
+				else if( endNode instanceof Expression) // the child is an expression used as a statement
+					startNode.setStatement((Expression)endNode);
 				else
 					startNode.setStatement((Statement)endNode);
 				break;
@@ -1641,15 +1637,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // stmts child: Statement or null node
+			case 0: // stmts child: Statement or Expression or null node
 				if( endNode instanceof NullNode)
 					startNode.addChild((NullNode)endNode);
-				// TODO find a way to consolidate setStatement(Statement) with an Expression
-				// The problem is that when a single statement is used in the body, this
-				// may very well be an expression statement, say, a CallExpression; but
-				// this cannot be cast to a Statement!
-				else if( endNode instanceof Expression)
-					startNode.addChild(endNode); // TODO do something more sensible
+				else if( endNode instanceof Expression) // the child is an expression used as a statement
+					startNode.setStatement((Expression)endNode);
 				else
 					startNode.setStatement((Statement)endNode);
 				break;
@@ -1676,15 +1668,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				else
 					startNode.setCondition((Expression)endNode);
 				break;
-			case 1: // stmts child: Statement or null node
+			case 1: // stmts child: Statement or Expression or null node
 				if( endNode instanceof NullNode)
 					startNode.addChild((NullNode)endNode);
-				// TODO find a way to consolidate setStatement(Statement) with an Expression
-				// The problem is that when a single statement is used in the body, this
-				// may very well be an expression statement, say, a CallExpression; but
-				// this cannot be cast to a Statement!
-				else if( endNode instanceof Expression)
-					startNode.addChild(endNode); // TODO do something more sensible
+				else if( endNode instanceof Expression) // the child is an expression used as a statement
+					startNode.setStatement((Expression)endNode);
 				else
 					startNode.setStatement((Statement)endNode);
 				break;
@@ -2149,15 +2137,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 					// because in C world, an Expression node is used instead
 					startNode.setForLoopExpression((Expression)endNode);
 				break;
-			case 3: // stmts child: Statement or null node
+			case 3: // stmts child: Statement or Expression or null node
 				if( endNode instanceof NullNode)
 					startNode.addChild((NullNode)endNode);
-				// TODO find a way to consolidate setStatement(Statement) with an Expression
-				// The problem is that when a single statement is used in the body, this
-				// may very well be an expression statement, say, a CallExpression; but
-				// this cannot be cast to a Statement!
-				else if( endNode instanceof Expression)
-					startNode.addChild(endNode); // TODO do something more sensible
+				else if( endNode instanceof Expression) // the child is an expression used as a statement
+					startNode.setStatement((Expression)endNode);
 				else
 					startNode.setStatement((Statement)endNode);
 				break;
@@ -2187,15 +2171,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				else
 					startNode.setKeyVariable((Variable)endNode);
 				break;
-			case 3: // stmts child: Statement or null node
+			case 3: // stmts child: Statement or Expression or null node
 				if( endNode instanceof NullNode)
 					startNode.addChild((NullNode)endNode);
-				// TODO find a way to consolidate setStatement(Statement) with an Expression
-				// The problem is that when a single statement is used in the body, this
-				// may very well be an expression statement, say, a CallExpression; but
-				// this cannot be cast to a Statement!
-				else if( endNode instanceof Expression)
-					startNode.addChild(endNode); // TODO do something more sensible
+				else if( endNode instanceof Expression) // the child is an expression used as a statement
+					startNode.setStatement((Expression)endNode);
 				else
 					startNode.setStatement((Statement)endNode);
 				break;
@@ -2250,8 +2230,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 	
 	private int handleCompound( CompoundStatement startNode, ASTNode endNode, int childnum)
 	{
-		// TODO cast to Statement once CompoundStatement implements Iterable<Statement>
-		// and takes only Statements.
+		// Note: These may be all kinds of AST nodes: instances of Statement, but also
+		// instances of Expression, PHPFunctionDef, or even null nodes.
 		startNode.addStatement(endNode);
 
 		return 0;

--- a/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeInterpreter.java
@@ -39,7 +39,6 @@ import ast.expressions.UnaryMinusExpression;
 import ast.expressions.UnaryOperationExpression;
 import ast.expressions.UnaryPlusExpression;
 import ast.expressions.Variable;
-import ast.functionDef.FunctionDef;
 import ast.functionDef.ParameterList;
 import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
@@ -70,6 +69,7 @@ import ast.php.functionDef.Closure;
 import ast.php.functionDef.ClosureUses;
 import ast.php.functionDef.ClosureVar;
 import ast.php.functionDef.Method;
+import ast.php.functionDef.PHPFunctionDef;
 import ast.php.functionDef.PHPParameter;
 import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.ClassConstantDeclaration;
@@ -670,7 +670,7 @@ public class PHPCSVNodeInterpreter implements CSVRowInterpreter
 
 	private static long handleFunction(KeyedCSVRow row, ASTUnderConstruction ast)
 	{
-		FunctionDef newNode = new FunctionDef();
+		PHPFunctionDef newNode = new PHPFunctionDef();
 
 		String type = row.getFieldForKey(PHPCSVNodeTypes.TYPE);
 		String flags = row.getFieldForKey(PHPCSVNodeTypes.FLAGS);

--- a/src/tools/phpast2cfg/PHPCSVNodeTypes.java
+++ b/src/tools/phpast2cfg/PHPCSVNodeTypes.java
@@ -8,6 +8,7 @@ import inputModules.csv.KeyedCSV.CSVKey;
 public class PHPCSVNodeTypes
 {
 	/* node row keys */
+	
 	public static final CSVKey NODE_ID = new CSVKey("id","ID");
 	// node properties shared by all nodes (cf. ast\Node specification
 	// in {@link https://github.com/nikic/php-ast})
@@ -24,7 +25,9 @@ public class PHPCSVNodeTypes
 	public static final CSVKey CHILDNUM = new CSVKey("childnum","int");
 	public static final CSVKey FUNCID = new CSVKey("funcid","int");
 
+	
 	/* node types */
+	
 	// directory/file types
 	public static final String TYPE_FILE = "File";
 	public static final String TYPE_DIRECTORY = "Directory";
@@ -172,11 +175,46 @@ public class PHPCSVNodeTypes
 	public static final String TYPE_TRAIT_ADAPTATIONS = "AST_TRAIT_ADAPTATIONS";
 	public static final String TYPE_USE = "AST_USE";
 
+	
 	/* node flags */
+	
+	// flags for TYPE_ARRAY_ELEM and TYPE_CLOSURE_VAR (exclusive)
+	public static final String FLAG_BY_REFERENCE = "BY_REFERENCE"; // custom, see phpjoern commit 95cdc6b6de1c4b973775a97b90e8bf41c90f629b
+
+	// flags for TYPE_NAME nodes (exclusive)
+	public static final String FLAG_NAME_FQ = "NAME_FQ";
+	public static final String FLAG_NAME_NOT_FQ = "NAME_NOT_FQ";
+	public static final String FLAG_NAME_RELATIVE = "NAME_RELATIVE";
+
 	// flags for TYPE_TOPLEVEL nodes (exclusive)
 	public static final String FLAG_TOPLEVEL_FILE = "TOPLEVEL_FILE"; // artificial
 	public static final String FLAG_TOPLEVEL_CLASS = "TOPLEVEL_CLASS"; // artificial
 	
+	// flags for TYPE_METHOD, TYPE_PROP_DECL and TYPE_TRAIT_ALIAS nodes (combinable)
+	public static final String FLAG_MODIFIER_PUBLIC = "MODIFIER_PUBLIC";
+	public static final String FLAG_MODIFIER_PROTECTED = "MODIFIER_PROTECTED";
+	public static final String FLAG_MODIFIER_PRIVATE = "MODIFIER_PRIVATE";
+	public static final String FLAG_MODIFIER_STATIC = "MODIFIER_STATIC";
+	public static final String FLAG_MODIFIER_ABSTRACT = "MODIFIER_ABSTRACT";
+	public static final String FLAG_MODIFIER_FINAL = "MODIFIER_FINAL";
+	
+	// flags for TYPE_CLOSURE nodes (combinable)
+	//public static final String FLAG_MODIFIER_STATIC = "MODIFIER_STATIC"; // already defined above
+
+	// flags for TYPE_FUNC_DECL, TYPE_METHOD, TYPE_CLOSURE nodes (combinable)
+	public static final String FLAG_RETURNS_REF = "RETURNS_REF";
+	
+	// flags for TYPE_CLASS nodes (exclusive)
+	public static final String FLAG_CLASS_ABSTRACT = "CLASS_ABSTRACT";
+	public static final String FLAG_CLASS_FINAL = "CLASS_FINAL";
+	public static final String FLAG_CLASS_TRAIT = "CLASS_TRAIT";
+	public static final String FLAG_CLASS_INTERFACE = "CLASS_INTERFACE";
+	public static final String FLAG_CLASS_ANONYMOUS = "CLASS_ANONYMOUS";
+	
+	// flags for TYPE_PARAM nodes (exclusive)
+	public static final String FLAG_PARAM_REF = "PARAM_REF";
+	public static final String FLAG_PARAM_VARIADIC = "PARAM_VARIADIC";
+
 	// flags for TYPE_TYPE nodes (exclusive)
 	public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY";
 	public static final String FLAG_TYPE_CALLABLE = "TYPE_CALLABLE";
@@ -187,8 +225,57 @@ public class PHPCSVNodeTypes
 	public static final String FLAG_TYPE_LONG = "TYPE_LONG";
 	public static final String FLAG_TYPE_DOUBLE = "TYPE_DOUBLE";
 	public static final String FLAG_TYPE_STRING = "TYPE_STRING";
-	//public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY"; // *also* used (and thus already defined) by TYPE_TYPE
+	//public static final String FLAG_TYPE_ARRAY = "TYPE_ARRAY"; // already defined above
 	public static final String FLAG_TYPE_OBJECT = "TYPE_OBJECT";
+	
+	// flags for TYPE_UNARY_OP nodes (exclusive)
+	public static final String FLAG_UNARY_BOOL_NOT = "UNARY_BOOL_NOT";
+	public static final String FLAG_UNARY_BITWISE_NOT = "UNARY_BITWISE_NOT";
+	public static final String FLAG_UNARY_MINUS = "UNARY_MINUS"; // since version 20 of php-ast
+	public static final String FLAG_UNARY_PLUS = "UNARY_PLUS"; // since version 20 of php-ast
+	public static final String FLAG_UNARY_SILENCE = "UNARY_SILENCE"; // since version 20 of php-ast
+	
+	// flags for TYPE_BINARY_OP and TYPE_ASSIGN_OP nodes in version >= 20 of php-ast (exclusive)
+	public static final String FLAG_BINARY_BITWISE_OR = "BINARY_BITWISE_OR";
+	public static final String FLAG_BINARY_BITWISE_AND = "BINARY_BITWISE_AND";
+	public static final String FLAG_BINARY_BITWISE_XOR = "BINARY_BITWISE_XOR";
+	public static final String FLAG_BINARY_CONCAT = "BINARY_CONCAT";
+	public static final String FLAG_BINARY_ADD = "BINARY_ADD";
+	public static final String FLAG_BINARY_SUB = "BINARY_SUB";
+	public static final String FLAG_BINARY_MUL = "BINARY_MUL";
+	public static final String FLAG_BINARY_DIV = "BINARY_DIV";
+	public static final String FLAG_BINARY_MOD = "BINARY_MOD";
+	public static final String FLAG_BINARY_POW = "BINARY_POW";
+	public static final String FLAG_BINARY_SHIFT_LEFT = "BINARY_SHIFT_LEFT";
+	public static final String FLAG_BINARY_SHIFT_RIGHT = "BINARY_SHIFT_RIGHT";
+
+	// flags for TYPE_BINARY_OP (exclusive)
+	public static final String FLAG_BINARY_BOOL_AND = "BINARY_BOOL_AND"; // since version 20 of php-ast
+	public static final String FLAG_BINARY_BOOL_OR = "BINARY_BOOL_OR"; // since version 20 of php-ast
+	public static final String FLAG_BINARY_BOOL_XOR = "BINARY_BOOL_XOR";
+	public static final String FLAG_BINARY_IS_IDENTICAL = "BINARY_IS_IDENTICAL";
+	public static final String FLAG_BINARY_IS_NOT_IDENTICAL = "BINARY_IS_NOT_IDENTICAL";
+	public static final String FLAG_BINARY_IS_EQUAL = "BINARY_IS_EQUAL";
+	public static final String FLAG_BINARY_IS_NOT_EQUAL = "BINARY_IS_NOT_EQUAL";
+	public static final String FLAG_BINARY_IS_SMALLER = "BINARY_IS_SMALLER";
+	public static final String FLAG_BINARY_IS_SMALLER_OR_EQUAL = "BINARY_IS_SMALLER_OR_EQUAL";
+	public static final String FLAG_BINARY_IS_GREATER = "BINARY_IS_GREATER"; // since version 20 of php-ast
+	public static final String FLAG_BINARY_IS_GREATER_OR_EQUAL = "BINARY_IS_GREATER_OR_EQUAL"; // since version 20 of php-ast
+	public static final String FLAG_BINARY_SPACESHIP = "BINARY_SPACESHIP";
+
+	// flags for TYPE_ASSIGN_OP in versions before 20 (exclusive)
+	public static final String FLAG_ASSIGN_BITWISE_OR = "ASSIGN_BITWISE_OR";
+	public static final String FLAG_ASSIGN_BITWISE_AND = "ASSIGN_BITWISE_AND";
+	public static final String FLAG_ASSIGN_BITWISE_XOR = "ASSIGN_BITWISE_XOR";
+	public static final String FLAG_ASSIGN_CONCAT = "ASSIGN_CONCAT";
+	public static final String FLAG_ASSIGN_ADD = "ASSIGN_ADD";
+	public static final String FLAG_ASSIGN_SUB = "ASSIGN_SUB";
+	public static final String FLAG_ASSIGN_MUL = "ASSIGN_MUL";
+	public static final String FLAG_ASSIGN_DIV = "ASSIGN_DIV";
+	public static final String FLAG_ASSIGN_MOD = "ASSIGN_MOD";
+	public static final String FLAG_ASSIGN_POW = "ASSIGN_POW";
+	public static final String FLAG_ASSIGN_SHIFT_LEFT = "ASSIGN_SHIFT_LEFT";
+	public static final String FLAG_ASSIGN_SHIFT_RIGHT = "ASSIGN_SHIFT_RIGHT";
 	
 	// flags for TYPE_MAGIC_CONST nodes (exclusive)
 	public static final String FLAG_MAGIC_LINE = "T_LINE";
@@ -199,6 +286,11 @@ public class PHPCSVNodeTypes
 	public static final String FLAG_MAGIC_METHOD = "T_METHOD_C";
 	public static final String FLAG_MAGIC_CLASS = "T_CLASS_C";
 	public static final String FLAG_MAGIC_TRAIT = "T_TRAIT_C";
+
+	// flags for TYPE_USE, TYPE_GROUP_USE and TYPE_USE_ELEM nodes (exclusive)
+	public static final String FLAG_USE_NORMAL = "T_CLASS";
+	public static final String FLAG_USE_FUNCTION = "T_FUNCTION";
+	public static final String FLAG_USE_CONST = "T_CONST";
 
 	// flags for TYPE_INCLUDE_OR_EVAL nodes (exclusive)
 	public static final String FLAG_EXEC_EVAL = "EXEC_EVAL";


### PR DESCRIPTION
**Expression statements**

As explained yesterday in PR #91, in addition to the already existing method `setStatement(Statement)`, I have now introduced a method `setStatement(Expression)` to `BlockStarter`, which creates an `ExpressionStatement` that holds the given `Expression`, and adds this `ExpressionStatement` as the statement child of the blockstarter.

I refactored `ExpressionHolderStatement` a little bit, adding a field `expression`, a public setter for it, and modified the getter to return that field instead of `getChild(0)`. For this to work in C world too, I had to override method `addChild(ASTNode)` and call the new setter from there.

The edge interpreter was changed accordingly, and a few tests improved to test this new functionality.

**PHP function nodes**

I introduced a new class `PHPFunctionDef` which extends `FunctionDef` and mapped `AST_FUNC_DECL` to `PHPFunctionDef` (instead of `FunctionDef`). This is to better separate functionality for PHP function nodes from the C world and I had already added an appropriate comment to remember to do that to issue #80 a few weeks ago. This is now done.

All other PHP function nodes (`Closure`, `Method` and `TopLevelFunctionDef`) now extend `PHPFunctionDef` instead of `FunctionDef`, therefore any kind of PHP function is always an instance of `PHPFunctionDef`.

In general, when dealing with PHP functions in Joern, one should now *always* work with a `PHPFunctionDef` instead of a `FunctionDef`, even when doing very "general" work and the exact type of function is not important. In particular:
- Note that the *name* of a PHP function is retrieved via `getName()` and not `getIdentifier()`, and `getName()` is now only defined by `PHPFunctionDef`;
- the return type of a PHP function declaration can be retrieved via `getReturnType()`, which is only defined by `PHPFunctionDef`;
- finally, `getDocComment()` is also only defined by `PHPFunctionDef`, although this is probably not very important for static analysis. :wink:

**Miscellaneous**

I also added all remaining flag constants to `PHPCSVNodeTypes` for the purpose of completeness and clarity. Thereby all kinds of nodes and flags are now documented in this file, and we have a fully working API for PHP ASTs in Joern. :smile:

I'm done with refactoring and cleanup for now, and will conduct some more intensive testing on some real-world code tomorrow. Next week, I'll start with the DEF/USE annotations!

