### PR TITLE
Hunting bugs

### DIFF
--- a/src/ast/expressions/InstanceofExpression.java
+++ b/src/ast/expressions/InstanceofExpression.java
@@ -3,7 +3,7 @@ package ast.expressions;
 public class InstanceofExpression extends Expression
 {
 	Expression instanceExpression = null;
-	Identifier classIdentifier = null;
+	Expression classExpression = null;
 
 	public Expression getInstanceExpression()
 	{
@@ -16,14 +16,14 @@ public class InstanceofExpression extends Expression
 		super.addChild(instanceExpression);
 	}
 	
-	public Identifier getClassIdentifier()
+	public Expression getClassExpression()
 	{
-		return this.classIdentifier;
+		return this.classExpression;
 	}
 
-	public void setClassIdentifier(Identifier classIdentifier)
+	public void setClassExpression(Expression classExpression)
 	{
-		this.classIdentifier = classIdentifier;
-		super.addChild(classIdentifier);
+		this.classExpression = classExpression;
+		super.addChild(classExpression);
 	}
 }

--- a/src/ast/expressions/PropertyExpression.java
+++ b/src/ast/expressions/PropertyExpression.java
@@ -3,7 +3,7 @@ package ast.expressions;
 public class PropertyExpression extends MemberAccess
 {
 	private Expression objectExpression = null;
-	private StringExpression propertyName = null;
+	private Expression propertyName = null;
 
 	public Expression getObjectExpression()
 	{
@@ -16,12 +16,12 @@ public class PropertyExpression extends MemberAccess
 		super.addChild(objectExpression);
 	}
 	
-	public StringExpression getPropertyName()
+	public Expression getPropertyName()
 	{
 		return this.propertyName;
 	}
 
-	public void setPropertyName(StringExpression propertyName)
+	public void setPropertyName(Expression propertyName)
 	{
 		this.propertyName = propertyName;
 		super.addChild(propertyName);

--- a/src/ast/expressions/PropertyExpression.java
+++ b/src/ast/expressions/PropertyExpression.java
@@ -3,7 +3,7 @@ package ast.expressions;
 public class PropertyExpression extends MemberAccess
 {
 	private Expression objectExpression = null;
-	private Expression propertyName = null;
+	private Expression propertyExpression = null;
 
 	public Expression getObjectExpression()
 	{
@@ -16,14 +16,14 @@ public class PropertyExpression extends MemberAccess
 		super.addChild(objectExpression);
 	}
 	
-	public Expression getPropertyName()
+	public Expression getPropertyExpression()
 	{
-		return this.propertyName;
+		return this.propertyExpression;
 	}
 
-	public void setPropertyName(Expression propertyName)
+	public void setPropertyExpression(Expression propertyExpression)
 	{
-		this.propertyName = propertyName;
-		super.addChild(propertyName);
+		this.propertyExpression = propertyExpression;
+		super.addChild(propertyExpression);
 	}
 }

--- a/src/ast/expressions/StaticPropertyExpression.java
+++ b/src/ast/expressions/StaticPropertyExpression.java
@@ -3,7 +3,7 @@ package ast.expressions;
 public class StaticPropertyExpression extends MemberAccess
 {
 	private Expression classExpression = null;
-	private StringExpression propertyName = null;
+	private Expression propertyExpression = null;
 
 	public Expression getClassExpression()
 	{
@@ -16,14 +16,14 @@ public class StaticPropertyExpression extends MemberAccess
 		super.addChild(classExpression);
 	}
 	
-	public StringExpression getPropertyName()
+	public Expression getPropertyExpression()
 	{
-		return this.propertyName;
+		return this.propertyExpression;
 	}
 
-	public void setPropertyName(StringExpression propertyName)
+	public void setPropertyExpression(Expression propertyExpression)
 	{
-		this.propertyName = propertyName;
-		super.addChild(propertyName);
+		this.propertyExpression = propertyExpression;
+		super.addChild(propertyExpression);
 	}
 }

--- a/src/ast/expressions/Variable.java
+++ b/src/ast/expressions/Variable.java
@@ -2,14 +2,14 @@ package ast.expressions;
 
 public class Variable extends Expression
 {
-	private StringExpression name = null;
+	private Expression name = null;
 	
-	public void setNameChild(StringExpression name) {
+	public void setNameExpression(Expression name) {
 		this.name = name;
 		super.addChild(name);
 	}
 	
-	public StringExpression getNameChild() {
+	public Expression getNameExpression() {
 		return this.name;
 	}
 }

--- a/src/ast/php/expressions/ClosureExpression.java
+++ b/src/ast/php/expressions/ClosureExpression.java
@@ -1,0 +1,20 @@
+package ast.php.expressions;
+
+import ast.expressions.Expression;
+import ast.php.functionDef.Closure;
+
+public class ClosureExpression extends Expression
+{
+	private Closure closure = null;
+
+	public Closure getClosure()
+	{
+		return this.closure;
+	}
+	
+	public void setClosure(Closure closure)
+	{	
+		this.closure = closure;
+		super.addChild(closure);
+	}
+}

--- a/src/ast/php/expressions/StaticCallExpression.java
+++ b/src/ast/php/expressions/StaticCallExpression.java
@@ -1,19 +1,19 @@
 package ast.php.expressions;
 
 import ast.expressions.CallExpression;
-import ast.expressions.Identifier;
+import ast.expressions.Expression;
 import ast.expressions.StringExpression;
 
 public class StaticCallExpression extends CallExpression
 {
-	private Identifier targetClass = null;
+	private Expression targetClass = null;
 	
-	public Identifier getTargetClass()
+	public Expression getTargetClass()
 	{
 		return this.targetClass;
 	}
 	
-	public void setTargetClass(Identifier targetClass)
+	public void setTargetClass(Expression targetClass)
 	{
 		this.targetClass = targetClass;
 		super.addChild(targetClass);

--- a/src/ast/php/expressions/StaticCallExpression.java
+++ b/src/ast/php/expressions/StaticCallExpression.java
@@ -2,7 +2,6 @@ package ast.php.expressions;
 
 import ast.expressions.CallExpression;
 import ast.expressions.Expression;
-import ast.expressions.StringExpression;
 
 public class StaticCallExpression extends CallExpression
 {
@@ -17,11 +16,5 @@ public class StaticCallExpression extends CallExpression
 	{
 		this.targetClass = targetClass;
 		super.addChild(targetClass);
-	}
-	
-	@Override
-	public StringExpression getTargetFunc()
-	{
-		return (StringExpression)super.getTargetFunc();
 	}
 }

--- a/src/ast/php/statements/blockstarters/PHPSwitchCase.java
+++ b/src/ast/php/statements/blockstarters/PHPSwitchCase.java
@@ -1,18 +1,18 @@
 package ast.php.statements.blockstarters;
 
-import ast.expressions.PrimaryExpression;
+import ast.expressions.Expression;
 import ast.logical.statements.BlockStarter;
 
 public class PHPSwitchCase extends BlockStarter
 {
-	private PrimaryExpression value = null;
+	private Expression value = null;
 	
-	public PrimaryExpression getValue()
+	public Expression getValue()
 	{
 		return this.value;
 	}
 
-	public void setValue(PrimaryExpression value)
+	public void setValue(Expression value)
 	{
 		this.value = value;
 		super.addChild(value);

--- a/src/inputModules/csv/KeyedCSV/CSVKey.java
+++ b/src/inputModules/csv/KeyedCSV/CSVKey.java
@@ -51,4 +51,9 @@ public class CSVKey
 	public int hashCode() {
 		return Objects.hash(this.name, this.type);
 	}
+	
+	@Override
+	public String toString() {
+		return this.name + ":" + this.type;
+	}
 }

--- a/src/inputModules/csv/KeyedCSV/KeyedCSVReader.java
+++ b/src/inputModules/csv/KeyedCSV/KeyedCSVReader.java
@@ -15,7 +15,6 @@ public class KeyedCSVReader
 	private CSVParser parser;
 	private Iterator<CSVRecord> iterator;
 	private int currentLineNumber;
-	private String keyRow;
 
 	public void init(Reader reader) throws IOException
 	{
@@ -29,18 +28,13 @@ public class KeyedCSVReader
 		iterator = parser.iterator();
 		CSVRecord header = iterator.next();
 
-		keyRow = "";
 		keys = new CSVKey[header.size()];
 
 		for (int i = 0; i < header.size(); i++)
 		{
 			String field = header.get(i);
 			keys[i] = createKeyFromFields(field);
-			keyRow += field;
-			if( i < header.size() - 1)
-				keyRow += ",";
 		}
-
 	}
 
 	private CSVKey createKeyFromFields(String field)
@@ -64,7 +58,7 @@ public class KeyedCSVReader
 		{
 			return null;
 		}
-
+		
 		currentLineNumber++;
 		KeyedCSVRow keyedRow = new KeyedCSVRow(keys);
 		keyedRow.initFromCSVRecord(record);
@@ -91,10 +85,4 @@ public class KeyedCSVReader
 	{
 		return keys;
 	}
-
-	public String getKeyRow()
-	{
-		return keyRow;
-	}
-
 }

--- a/src/inputModules/csv/KeyedCSV/KeyedCSVRow.java
+++ b/src/inputModules/csv/KeyedCSV/KeyedCSVRow.java
@@ -1,7 +1,7 @@
 package inputModules.csv.KeyedCSV;
 
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.commons.csv.CSVRecord;
@@ -9,8 +9,7 @@ import org.apache.commons.csv.CSVRecord;
 public class KeyedCSVRow
 {
 	private CSVKey[] keys;
-	private Map<CSVKey,String> values = new HashMap<CSVKey,String>();
-	private String stringRepr;
+	private Map<CSVKey,String> values = new LinkedHashMap<CSVKey,String>();
 
 	public KeyedCSVRow(CSVKey[] keys)
 	{
@@ -19,16 +18,12 @@ public class KeyedCSVRow
 
 	public void initFromCSVRecord(CSVRecord record)
 	{
-		stringRepr = "";
 		int i = 0;
 		Iterator<String> recIt = record.iterator();
 		while (recIt.hasNext())
 		{
 			String r = recIt.next();
 			values.put(keys[i], r);
-			stringRepr += r;
-			if (recIt.hasNext())
-				stringRepr += ",";
 			i++;
 		}
 	}
@@ -42,7 +37,6 @@ public class KeyedCSVRow
 	@Override
 	public String toString()
 	{
-		return stringRepr;
+		return this.values.toString();
 	}
-
 }

--- a/src/inputModules/csv/csv2ast/CSV2AST.java
+++ b/src/inputModules/csv/csv2ast/CSV2AST.java
@@ -3,7 +3,8 @@ package inputModules.csv.csv2ast;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.io.StringReader;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import ast.functionDef.FunctionDef;
 import inputModules.csv.KeyedCSV.KeyedCSVReader;
@@ -16,71 +17,81 @@ import tools.phpast2cfg.PHPCSVNodeTypes;
 
 public class CSV2AST
 {
-	KeyedCSVReader reader;
 	CSVRowInterpreter nodeInterpreter;
 	CSVRowInterpreter edgeInterpreter;
-	ASTUnderConstruction ast;
 
 	public FunctionDef convert(String nodeFilename, String edgeFilename)
 			throws IOException, InvalidCSVFile
 	{
-		FileReader nodeReader = new FileReader(nodeFilename);
-		FileReader edgeReader = new FileReader(edgeFilename);
-		return convert(nodeReader, edgeReader);
+		FileReader nodeStrReader = new FileReader(nodeFilename);
+		FileReader edgeStrReader = new FileReader(edgeFilename);
+
+		return convert(nodeStrReader, edgeStrReader);
+	}
+
+	public FunctionDef convert(Reader nodeStrReader, Reader edgeStrReader)
+			throws IOException, InvalidCSVFile
+	{
+		KeyedCSVReader nodeReader = new KeyedCSVReader();
+		KeyedCSVReader edgeReader = new KeyedCSVReader();
+		nodeReader.init(nodeStrReader);
+		edgeReader.init(edgeStrReader);
+	
+		CSVAST csvAST = new CSVAST();
+		while( nodeReader.hasNextRow())
+			csvAST.addNodeRow(nodeReader.getNextRow());
+		while( edgeReader.hasNextRow())
+			csvAST.addEdgeRow(edgeReader.getNextRow());
+		
+		return convert(csvAST);
 	}
 
 	public FunctionDef convert(CSVAST csvAST)
 			throws IOException, InvalidCSVFile
 	{
-		StringReader nodeReader = new StringReader(csvAST.getNodesAsString());
-		StringReader edgeReader = new StringReader(csvAST.getEdgesAsString());
-		return convert(nodeReader, edgeReader);
-	}
-	
-	public FunctionDef convert(Reader nodeReader, Reader edgeReader)
-			throws IOException, InvalidCSVFile
-	{
-		ast = new ASTUnderConstruction();
+		ASTUnderConstruction ast = new ASTUnderConstruction();
 
-		initReader(nodeReader);
-		createASTNodes();
-
-		initReader(edgeReader);
-		createASTEdges();
+		createASTNodes(csvAST, ast);
+		createASTEdges(csvAST, ast);
 		
 		return ast.getRootNode();
 	}
 
-	private void initReader(Reader in) throws IOException
+	private void createASTNodes(CSVAST csvAST, ASTUnderConstruction ast) throws InvalidCSVFile
 	{
-		reader = new KeyedCSVReader();
-		reader.init(in);
-	}
-
-	private void createASTNodes() throws InvalidCSVFile
-	{
+		Iterator<KeyedCSVRow> nodeRows = csvAST.nodeIterator();
 		KeyedCSVRow keyedRow;
+		
+		try {
+			keyedRow = nodeRows.next();
+		}
+		catch( NoSuchElementException ex) {
+			throw new InvalidCSVFile( "Empty CSV files are not permissible.");
+		}
 
 		// first row must be a function type;
 		// otherwise we cannot create a function node
-		keyedRow = reader.getNextRow();
-		if( null == keyedRow || !PHPCSVNodeTypes.funcTypes.contains(keyedRow.getFieldForKey(PHPCSVNodeTypes.TYPE)))
+		if( !PHPCSVNodeTypes.funcTypes.contains(keyedRow.getFieldForKey(PHPCSVNodeTypes.TYPE)))
 			throw new InvalidCSVFile( "Type of first row is not a function declaration.");
 		
 		FunctionDef root = (FunctionDef) ast.getNodeById( nodeInterpreter.handle(keyedRow, ast));
 		ast.setRootNode(root);
 
-		while ((keyedRow = reader.getNextRow()) != null)
+		while (nodeRows.hasNext())
 		{
+			keyedRow = nodeRows.next();
 			nodeInterpreter.handle(keyedRow, ast);
 		}
 	}
 
-	private void createASTEdges() throws InvalidCSVFile
+	private void createASTEdges(CSVAST csvAST, ASTUnderConstruction ast) throws InvalidCSVFile
 	{
+		Iterator<KeyedCSVRow> edgeRows = csvAST.edgeIterator();
 		KeyedCSVRow keyedRow;
-		while ((keyedRow = reader.getNextRow()) != null)
+		
+		while (edgeRows.hasNext())
 		{
+			keyedRow = edgeRows.next();
 			edgeInterpreter.handle(keyedRow, ast);
 		}
 	}

--- a/src/inputModules/csv/csvFuncExtractor/CSVAST.java
+++ b/src/inputModules/csv/csvFuncExtractor/CSVAST.java
@@ -1,39 +1,43 @@
 package inputModules.csv.csvFuncExtractor;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+import inputModules.csv.KeyedCSV.KeyedCSVRow;
 
 public class CSVAST
 {
 
-	List<String> nodeRows = new LinkedList<String>();
-	List<String> edgeRows = new LinkedList<String>();
+	List<KeyedCSVRow> nodeRows = new LinkedList<KeyedCSVRow>();
+	List<KeyedCSVRow> edgeRows = new LinkedList<KeyedCSVRow>();
 
-	public void addNodeRow(String str)
+	public void addNodeRow(KeyedCSVRow row)
 	{
-		nodeRows.add(str);
+		this.nodeRows.add(row);
 	}
 
-	public void addEdgeRow(String str)
+	public void addEdgeRow(KeyedCSVRow row)
 	{
-		edgeRows.add(str);
+		this.edgeRows.add(row);
 	}
-
-	public String getNodesAsString()
-	{
-		return StringUtils.join(nodeRows, "\n");
+	
+	public Iterator<KeyedCSVRow> nodeIterator() {
+		return this.nodeRows.iterator();
 	}
-
-	public String getEdgesAsString()
-	{
-		return StringUtils.join(edgeRows, "\n");
+	
+	public Iterator<KeyedCSVRow> edgeIterator() {
+		return this.edgeRows.iterator();
 	}
 
 	public int getNumberOfNodes()
 	{
-		return nodeRows.size() - 1;
+		return this.nodeRows.size();
+	}
+	
+	public int getNumberOfEdges()
+	{
+		return this.edgeRows.size();
 	}
 
 }

--- a/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
+++ b/src/inputModules/csv/csvFuncExtractor/CSVFunctionExtractor.java
@@ -208,7 +208,7 @@ public class CSVFunctionExtractor
 			for( CSVAST csvAST : csvNodeIds.keySet()) {
 				Set<String> nodeSet = csvNodeIds.get(csvAST);
 				if( nodeSet.contains(startId) && nodeSet.contains(endId))
-					csvAST.addEdgeRow(currEdgeRow.toString());
+					csvAST.addEdgeRow(currEdgeRow);
 			}
 		}
 		
@@ -248,8 +248,6 @@ public class CSVFunctionExtractor
 	private void initCSVAST(String functionNodeId)
 	{
 		CSVAST csvAST = new CSVAST();
-		csvAST.addNodeRow(nodeReader.getKeyRow());
-		csvAST.addEdgeRow(edgeReader.getKeyRow());
 		csvStack.push(csvAST);
 		funcIdStack.push(functionNodeId);
 	}
@@ -265,7 +263,7 @@ public class CSVFunctionExtractor
 
 		// add row to CSVAST on top of stack
 		CSVAST csvAST = csvStack.peek();
-		csvAST.addNodeRow( currNodeRow.toString());
+		csvAST.addNodeRow( currNodeRow);
 
 		// add id to list of ids of the CSVAST on top of stack
 		String currId = currNodeRow.getFieldForKey(PHPCSVNodeTypes.NODE_ID);

--- a/src/tests/inputModules/TestCSV2AST.java
+++ b/src/tests/inputModules/TestCSV2AST.java
@@ -168,6 +168,15 @@ public class TestCSV2AST
 	}
 
 	/**
+	 * An invalid CSV file that is empty.
+	 */
+	@Test(expected=InvalidCSVFile.class)
+	public void testInvalidCSVEmpty() throws IOException, InvalidCSVFile
+	{
+		createASTFromStrings(nodeHeader, edgeHeader);
+	}
+	
+	/**
 	 * An invalid CSV file that does not start with a function declaration.
 	 */
 	@Test(expected=InvalidCSVFile.class)

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -2465,12 +2465,13 @@ public class TestPHPCSVASTBuilder
 	 * Any AST_PROP node has exactly two children:
 	 * 1) an expression, whose evaluation returns the object to be accessed
 	 *    (e.g., could be AST_VAR, AST_CALL, etc...)
-	 * 2) a string, representing the property name
+	 * 2) an expression, whose evaluation holds the property name
+	 *    (e.g., could be string, AST_VAR, etc...)
 	 * 
 	 * This test checks a few property access expressions' children in the following PHP code:
 	 * 
 	 * $foo->bar;
-	 * buz()->qux;
+	 * buz()->$qux;
 	 */
 	@Test
 	public void testPropertyCreation() throws IOException, InvalidCSVFile
@@ -2485,7 +2486,8 @@ public class TestPHPCSVASTBuilder
 		nodeStr += "9,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
 		nodeStr += "10,string,,4,\"buz\",0,1,,,\n";
 		nodeStr += "11,AST_ARG_LIST,,4,,1,1,,,\n";
-		nodeStr += "12,string,,4,\"qux\",1,1,,,\n";
+		nodeStr += "12,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "13,string,,4,\"qux\",0,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "4,5,PARENT_OF\n";
@@ -2495,6 +2497,7 @@ public class TestPHPCSVASTBuilder
 		edgeStr += "8,9,PARENT_OF\n";
 		edgeStr += "8,11,PARENT_OF\n";
 		edgeStr += "7,8,PARENT_OF\n";
+		edgeStr += "12,13,PARENT_OF\n";
 		edgeStr += "7,12,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -4313,8 +4313,9 @@ public class TestPHPCSVASTBuilder
 	 * a statement list; see description of AST_SWITCH_LIST and AST_SWITCH for the bigger picture.
 	 * 
 	 * Any AST_SWITCH_CASE node has exactly two children:
-	 * 1) a plain node or NULL, representing the value in the switch element's guard,
+	 * 1) an Expression or NULL, representing the value in the switch element's guard,
 	 *    NULL is used when there is no such value, i.e., in "default" switch-elements.
+	 *    (e.g., could be integer, double, string, AST_CONST, AST_CLASS_CONST, ...)
 	 * 2) AST_STMT_LIST, representing the code in the switch element's body
 	 * 
 	 * This test checks a few switch-elements' children in the following PHP code:

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -3712,42 +3712,46 @@ public class TestPHPCSVASTBuilder
 	 * Any AST_INSTANCEOF node has exactly 2 children:
 	 * 1) an expression, whose evaluation holds the object to be checked
 	 *    (e.g., could be AST_VAR, AST_CALL, ...)
-	 * 2) AST_NAME, representing the name of the class that the object
-	 *    may or may not be an instance of.
+	 * 2) an expression, whose evaluation holds the name of the class that the object
+	 *    may or may not be an instance of
+	 *    (e.g., could be AST_NAME, AST_VAR, ...)
 	 * 
 	 * This test checks a few instanceof expressions' children in the following PHP code:
 	 * 
-	 * $foo instanceof Foo;
-	 * buz() instanceof Bar\Buz;
+	 * $foo instanceof Bar;
+	 * buz() instanceof $qux;
 	 */
 	@Test
 	public void testInstanceofCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_INSTANCEOF,,3,,0,1,,,\n";
 		nodeStr += "4,AST_VAR,,3,,0,1,,,\n";
 		nodeStr += "5,string,,3,\"foo\",0,1,,,\n";
 		nodeStr += "6,AST_NAME,NAME_NOT_FQ,3,,1,1,,,\n";
-		nodeStr += "7,string,,3,\"Foo\",0,1,,,\n";
+		nodeStr += "7,string,,3,\"Bar\",0,1,,,\n";
 		nodeStr += "8,AST_INSTANCEOF,,4,,1,1,,,\n";
 		nodeStr += "9,AST_CALL,,4,,0,1,,,\n";
 		nodeStr += "10,AST_NAME,NAME_NOT_FQ,4,,0,1,,,\n";
 		nodeStr += "11,string,,4,\"buz\",0,1,,,\n";
 		nodeStr += "12,AST_ARG_LIST,,4,,1,1,,,\n";
-		nodeStr += "13,AST_NAME,NAME_NOT_FQ,4,,1,1,,,\n";
-		nodeStr += "14,string,,4,\"Bar\\Buz\",0,1,,,\n";
+		nodeStr += "13,AST_VAR,,4,,1,1,,,\n";
+		nodeStr += "14,string,,4,\"qux\",0,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "4,5,PARENT_OF\n";
 		edgeStr += "3,4,PARENT_OF\n";
 		edgeStr += "6,7,PARENT_OF\n";
 		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
 		edgeStr += "10,11,PARENT_OF\n";
 		edgeStr += "9,10,PARENT_OF\n";
 		edgeStr += "9,12,PARENT_OF\n";
 		edgeStr += "8,9,PARENT_OF\n";
 		edgeStr += "13,14,PARENT_OF\n";
 		edgeStr += "8,13,PARENT_OF\n";
+		edgeStr += "2,8,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
 
@@ -3758,15 +3762,15 @@ public class TestPHPCSVASTBuilder
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)4), ((InstanceofExpression)node).getInstanceExpression());
 		assertEquals( "foo", ((Variable)((InstanceofExpression)node).getInstanceExpression()).getNameExpression().getEscapedCodeStr());
-		assertEquals( ast.getNodeById((long)6), ((InstanceofExpression)node).getClassIdentifier());
-		assertEquals( "Foo", ((InstanceofExpression)node).getClassIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)6), ((InstanceofExpression)node).getClassExpression());
+		assertEquals( "Bar", ((Identifier)((InstanceofExpression)node).getClassExpression()).getNameChild().getEscapedCodeStr());
 		
 		assertThat( node2, instanceOf(InstanceofExpression.class));
 		assertEquals( 2, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)9), ((InstanceofExpression)node2).getInstanceExpression());
 		assertEquals( "buz", ((Identifier)((CallExpression)((InstanceofExpression)node2).getInstanceExpression()).getTargetFunc()).getNameChild().getEscapedCodeStr());
-		assertEquals( ast.getNodeById((long)13), ((InstanceofExpression)node2).getClassIdentifier());
-		assertEquals( "Bar\\Buz", ((InstanceofExpression)node2).getClassIdentifier().getNameChild().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)13), ((InstanceofExpression)node2).getClassExpression());
+		assertEquals( "qux", ((Variable)((InstanceofExpression)node2).getClassExpression()).getNameExpression().getEscapedCodeStr());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -5375,7 +5375,7 @@ public class TestPHPCSVASTBuilder
 	 * This test checks a few static call expressions' children in the following PHP code:
 	 * 
 	 * Foo::bar($buz);
-	 * $qux::norf();
+	 * $qux::{norf[42]}();
 	 */
 	@Test
 	public void testStaticCallCreation() throws IOException, InvalidCSVFile
@@ -5392,8 +5392,11 @@ public class TestPHPCSVASTBuilder
 		nodeStr += "10,AST_STATIC_CALL,,4,,1,1,,,\n";
 		nodeStr += "11,AST_VAR,,4,,0,1,,,\n";
 		nodeStr += "12,string,,4,\"qux\",0,1,,,\n";
-		nodeStr += "13,string,,4,\"norf\",1,1,,,\n";
-		nodeStr += "14,AST_ARG_LIST,,4,,2,1,,,\n";
+		nodeStr += "13,AST_DIM,,4,,1,1,,,\n";
+		nodeStr += "14,AST_VAR,,4,,0,1,,,\n";
+		nodeStr += "15,string,,4,\"norf\",0,1,,,\n";
+		nodeStr += "16,integer,,4,42,1,1,,,\n";
+		nodeStr += "17,AST_ARG_LIST,,4,,2,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "4,5,PARENT_OF\n";
@@ -5405,8 +5408,11 @@ public class TestPHPCSVASTBuilder
 		edgeStr += "2,3,PARENT_OF\n";
 		edgeStr += "11,12,PARENT_OF\n";
 		edgeStr += "10,11,PARENT_OF\n";
+		edgeStr += "14,15,PARENT_OF\n";
+		edgeStr += "13,14,PARENT_OF\n";
+		edgeStr += "13,16,PARENT_OF\n";
 		edgeStr += "10,13,PARENT_OF\n";
-		edgeStr += "10,14,PARENT_OF\n";
+		edgeStr += "10,17,PARENT_OF\n";
 		edgeStr += "2,10,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
@@ -5427,8 +5433,8 @@ public class TestPHPCSVASTBuilder
 		assertEquals( ast.getNodeById((long)11), ((StaticCallExpression)node2).getTargetClass());
 		assertEquals( "qux", ((StringExpression)((Variable)((StaticCallExpression)node2).getTargetClass()).getNameExpression()).getEscapedCodeStr());
 		assertEquals( ast.getNodeById((long)13), ((StaticCallExpression)node2).getTargetFunc());
-		assertEquals( "norf", ((StaticCallExpression)node2).getTargetFunc().getEscapedCodeStr());
-		assertEquals( ast.getNodeById((long)14), ((StaticCallExpression)node2).getArgumentList());
+		assertEquals( "norf", ((Variable)((ArrayIndexing)((StaticCallExpression)node2).getTargetFunc()).getArrayExpression()).getNameExpression().getEscapedCodeStr());
+		assertEquals( ast.getNodeById((long)17), ((StaticCallExpression)node2).getArgumentList());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilder.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilder.java
@@ -2512,12 +2512,12 @@ public class TestPHPCSVASTBuilder
 		assertThat( node, instanceOf(PropertyExpression.class));
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)4), ((PropertyExpression)node).getObjectExpression());
-		assertEquals( ast.getNodeById((long)6), ((PropertyExpression)node).getPropertyName());
+		assertEquals( ast.getNodeById((long)6), ((PropertyExpression)node).getPropertyExpression());
 
 		assertThat( node2, instanceOf(PropertyExpression.class));
 		assertEquals( 2, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)8), ((PropertyExpression)node2).getObjectExpression());
-		assertEquals( ast.getNodeById((long)12), ((PropertyExpression)node2).getPropertyName());
+		assertEquals( ast.getNodeById((long)12), ((PropertyExpression)node2).getPropertyExpression());
 	}
 	
 	/**
@@ -2526,18 +2526,20 @@ public class TestPHPCSVASTBuilder
 	 * Any AST_STATIC_PROP node has exactly two children:
 	 * 1) an expression, whose evaluation returns the class to be accessed
 	 *    (e.g., could be AST_NAME, AST_VAR, AST_CALL, etc...)
-	 * 2) a string, representing the property name
+	 * 2) an expression, whose evaluation holds the property name
+	 * 	  (e.g., could be AST_NAME, AST_VAR, etc...)
 	 * 
 	 * This test checks a few static property access expressions' children in the following PHP code:
 	 * 
 	 * Foo::$bar;
 	 * $foo::$bar;
-	 * buz()::$qux;
+	 * buz()::$$qux;
 	 */
 	@Test
 	public void testStaticPropertyCreation() throws IOException, InvalidCSVFile
 	{
 		String nodeStr = nodeHeader;
+		nodeStr += "2,AST_STMT_LIST,,1,,0,1,,,\n";
 		nodeStr += "3,AST_STATIC_PROP,,3,,0,1,,,\n";
 		nodeStr += "4,AST_NAME,NAME_NOT_FQ,3,,0,1,,,\n";
 		nodeStr += "5,string,,3,\"Foo\",0,1,,,\n";
@@ -2551,20 +2553,25 @@ public class TestPHPCSVASTBuilder
 		nodeStr += "13,AST_NAME,NAME_NOT_FQ,5,,0,1,,,\n";
 		nodeStr += "14,string,,5,\"buz\",0,1,,,\n";
 		nodeStr += "15,AST_ARG_LIST,,5,,1,1,,,\n";
-		nodeStr += "16,string,,5,\"qux\",1,1,,,\n";
+		nodeStr += "16,AST_VAR,,5,,1,1,,,\n";
+		nodeStr += "17,string,,5,\"qux\",0,1,,,\n";
 
 		String edgeStr = edgeHeader;
 		edgeStr += "4,5,PARENT_OF\n";
 		edgeStr += "3,4,PARENT_OF\n";
 		edgeStr += "3,6,PARENT_OF\n";
+		edgeStr += "2,3,PARENT_OF\n";
 		edgeStr += "8,9,PARENT_OF\n";
 		edgeStr += "7,8,PARENT_OF\n";
 		edgeStr += "7,10,PARENT_OF\n";
+		edgeStr += "2,7,PARENT_OF\n";
 		edgeStr += "13,14,PARENT_OF\n";
 		edgeStr += "12,13,PARENT_OF\n";
 		edgeStr += "12,15,PARENT_OF\n";
 		edgeStr += "11,12,PARENT_OF\n";
+		edgeStr += "16,17,PARENT_OF\n";
 		edgeStr += "11,16,PARENT_OF\n";
+		edgeStr += "2,11,PARENT_OF\n";
 
 		handle(nodeStr, edgeStr);
 
@@ -2575,17 +2582,17 @@ public class TestPHPCSVASTBuilder
 		assertThat( node, instanceOf(StaticPropertyExpression.class));
 		assertEquals( 2, node.getChildCount());
 		assertEquals( ast.getNodeById((long)4), ((StaticPropertyExpression)node).getClassExpression());
-		assertEquals( ast.getNodeById((long)6), ((StaticPropertyExpression)node).getPropertyName());
+		assertEquals( ast.getNodeById((long)6), ((StaticPropertyExpression)node).getPropertyExpression());
 
 		assertThat( node2, instanceOf(StaticPropertyExpression.class));
 		assertEquals( 2, node2.getChildCount());
 		assertEquals( ast.getNodeById((long)8), ((StaticPropertyExpression)node2).getClassExpression());
-		assertEquals( ast.getNodeById((long)10), ((StaticPropertyExpression)node2).getPropertyName());
+		assertEquals( ast.getNodeById((long)10), ((StaticPropertyExpression)node2).getPropertyExpression());
 		
 		assertThat( node3, instanceOf(StaticPropertyExpression.class));
 		assertEquals( 2, node3.getChildCount());
 		assertEquals( ast.getNodeById((long)12), ((StaticPropertyExpression)node3).getClassExpression());
-		assertEquals( ast.getNodeById((long)16), ((StaticPropertyExpression)node3).getPropertyName());
+		assertEquals( ast.getNodeById((long)16), ((StaticPropertyExpression)node3).getPropertyExpression());
 	}
 	
 	/**

--- a/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
+++ b/src/tests/inputModules/TestPHPCSVASTBuilderMinimal.java
@@ -26,6 +26,7 @@ import ast.php.functionDef.Closure;
 import ast.php.functionDef.Method;
 import ast.php.functionDef.PHPFunctionDef;
 import ast.php.functionDef.PHPParameter;
+import ast.php.functionDef.TopLevelFunctionDef;
 import ast.php.statements.blockstarters.ForEachStatement;
 import ast.php.statements.blockstarters.PHPIfElement;
 import ast.php.statements.blockstarters.PHPSwitchCase;
@@ -95,6 +96,28 @@ public class TestPHPCSVASTBuilderMinimal
 
 	/* declaration nodes */	
 
+	/**
+	 * <empty file>
+	 */
+	@Test
+	public void testMinimalTopLevelFunctionDefCreation() throws IOException, InvalidCSVFile
+	{
+		String nodeStr = nodeHeader;
+		nodeStr += "1,AST_TOPLEVEL,TOPLEVEL_FILE,1,,,,0,\"foo.php\",\n";
+		nodeStr += "2,NULL,,0,,0,1,,,\n";
+
+		String edgeStr = edgeHeader;
+		edgeStr += "1,2,PARENT_OF\n";
+		
+		handle(nodeStr, edgeStr);
+
+		ASTNode node = ast.getNodeById((long)1);
+		
+		assertThat( node, instanceOf(TopLevelFunctionDef.class));
+		assertEquals( 1, node.getChildCount());
+		assertNull( ((TopLevelFunctionDef)node).getContent());
+	}
+	
 	/**
 	 * function foo() {}
 	 */
@@ -961,7 +984,7 @@ public class TestPHPCSVASTBuilderMinimal
 	}
 	
 	/**
-	 * <empty file>
+	 * <?php
 	 */
 	@Test
 	public void testMinimalCompoundStatementCreation() throws IOException, InvalidCSVFile

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -543,8 +543,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // stmts child
-				startNode.setContent((CompoundStatement)endNode);
+			case 0: // stmts child: either CompoundStatement or NULL
+				if( endNode instanceof NullNode)
+					startNode.addChild((NullNode)endNode);
+				else
+					startNode.setContent((CompoundStatement)endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1539,8 +1539,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // expr child: Expression node
 				startNode.setInstanceExpression((Expression)endNode);
 				break;
-			case 1: // class child: Identifier node
-				startNode.setClassIdentifier((Identifier)endNode);
+			case 1: // class child: Expression node
+				startNode.setClassExpression((Expression)endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1999,8 +1999,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // class child: Expression node
 				startNode.setTargetClass((Expression)endNode);
 				break;
-			case 1: // method child: StringExpression node
-				startNode.setTargetFunc((StringExpression)endNode);
+			case 1: // method child: Expression node
+				startNode.setTargetFunc((Expression)endNode);
 				break;
 			case 2: // args child: ArgumentList node
 				startNode.setArgumentList((ArgumentList)endNode);

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -40,6 +40,7 @@ import ast.logical.statements.CompoundStatement;
 import ast.logical.statements.Label;
 import ast.logical.statements.Statement;
 import ast.php.declarations.PHPClassDef;
+import ast.php.expressions.ClosureExpression;
 import ast.php.expressions.MethodCallExpression;
 import ast.php.expressions.PHPArrayElement;
 import ast.php.expressions.PHPArrayExpression;
@@ -129,6 +130,16 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		//int childnum = Integer.parseInt(row.getFieldForKey(PHPCSVEdgeTypes.CHILDNUM));
 		int childnum = Integer.parseInt(endNode.getProperty(PHPCSVNodeTypes.CHILDNUM.getName()));
 
+		// Special treatment for closures: they are expressions, so we create a ClosureExpression to hold them
+		// We cannot do this in the PHPCSVNodeInterpreter, since CSV2AST expects an instance of PHPFunctionDef
+		// for the first row of the CSVAST that it converts. (Closure is an instance of PHPFunctionDef and thus
+		// cannot be an instance of Expression.)
+		if( endNode instanceof Closure) {
+			ClosureExpression closureExpression = new ClosureExpression();
+			closureExpression.setClosure((Closure)endNode);
+			endNode = closureExpression;
+		}
+		
 		int errno = 0;
 		String type = startNode.getProperty(PHPCSVNodeTypes.TYPE.getName());
 		switch (type)

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -686,7 +686,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 		switch (childnum)
 		{
 			case 0: // name child
-				startNode.setNameChild((StringExpression)endNode);
+				startNode.setNameExpression((Expression)endNode);
 				break;
 				
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1993,8 +1993,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // class child: Identifier node
-				startNode.setTargetClass((Identifier)endNode);
+			case 0: // class child: Expression node
+				startNode.setTargetClass((Expression)endNode);
 				break;
 			case 1: // method child: StringExpression node
 				startNode.setTargetFunc((StringExpression)endNode);

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -27,7 +27,6 @@ import ast.expressions.PostDecOperationExpression;
 import ast.expressions.PostIncOperationExpression;
 import ast.expressions.PreDecOperationExpression;
 import ast.expressions.PreIncOperationExpression;
-import ast.expressions.PrimaryExpression;
 import ast.expressions.PropertyExpression;
 import ast.expressions.StaticPropertyExpression;
 import ast.expressions.StringExpression;
@@ -1721,11 +1720,11 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 
 		switch (childnum)
 		{
-			case 0: // value child: PrimaryExpression or null node
+			case 0: // value child: Expression or null node
 				if( endNode instanceof NullNode)
 					startNode.addChild((NullNode)endNode);
 				else
-					startNode.setValue((PrimaryExpression)endNode);
+					startNode.setValue((Expression)endNode);
 				break;
 			case 1: // stmts child: CompoundStatement node
 				startNode.setStatement((CompoundStatement)endNode);

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1257,7 +1257,7 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 				startNode.setObjectExpression((Expression)endNode);
 				break;
 			case 1: // prop child: Expression node
-				startNode.setPropertyName((Expression)endNode);
+				startNode.setPropertyExpression((Expression)endNode);
 				break;
 
 			default:
@@ -1276,8 +1276,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // class child: Expression node
 				startNode.setClassExpression((Expression)endNode);
 				break;
-			case 1: // prop child: StringExpression node
-				startNode.setPropertyName((StringExpression)endNode);
+			case 1: // prop child: Expression node
+				startNode.setPropertyExpression((Expression)endNode);
 				break;
 
 			default:

--- a/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
+++ b/src/tools/phpast2cfg/PHPCSVEdgeInterpreter.java
@@ -1253,8 +1253,8 @@ public class PHPCSVEdgeInterpreter implements CSVRowInterpreter
 			case 0: // expr child: Expression node
 				startNode.setObjectExpression((Expression)endNode);
 				break;
-			case 1: // prop child: StringExpression node
-				startNode.setPropertyName((StringExpression)endNode);
+			case 1: // prop child: Expression node
+				startNode.setPropertyName((Expression)endNode);
 				break;
 
 			default:


### PR DESCRIPTION
Well, I threw Joern on some real-world PHP code today and hunted down bugs. There were 2 medium ones, and 8 small ones. After fixing them, I can successfully parse and generate ASTs in Joern for major frameworks with several million AST nodes such as Drupal, Wordpress, TYPO3, Joomla or CakePHP, so I have some confidence that this now works in a reasonably reliable way. :blush:

**Medium bug: CSV escaping problems**

Earlier, when parsing a CSV file with many files and functions, things were such that
1. The `CSVFunctionExtractor` would use a `KeyedCSVReader` to transform each CSV row of the CSV node file it was reading into a `KeyedCSVRow` object;
2. For each such `KeyedCSVRow`, it would determine which function it belongs to, create a new `CSVAST` object for this function (if it did not exist yet), and add the node row to this `CSVAST` *as a string*, that is, transforming the readily parsed `KeyedCSVRow` *back* to a string!
3. Later, the `CSV2AST` converter would *again* initiate a `KeyedCSVReader`, ask the `CSVAST` object it wants to convert to join all its node rows (which are now strings again) with `\n` so as to return a single string, then *again* parse this string anew with the `KeyedCSVReader`, creating `KeyedCSVRow`'s to pass to the node handler.

(And all of this, analgously for the edge file.)

Beside being extremely inefficient (why parse every row twice?), this approach brought other problems with it. Namely, it was error-prone, as the conversion of a `KeyedCSVRow` to a string did *not* guarantee that the resulting string was identical with the original, carefully escaped and quoted string (from which the `KeyedCSVRow` was created in the first place).

I had already taken care of a part of this problem some time ago (see commit a36968b52e4684af0db3c859e934b59d635748c5, the bullet point about the superfuous commas), but this was not enough. The transformation of a `KeyedCSVRow` back to a string had other problems as well:
- In CSV entries with the literal character sequence `\n`, this sequence was replaced with actual newline characters;
- Entries that were enclosed in quotes before were not enclosed in quotes any longer after the conversion back to a string. This is in particular a problem if the original quoted entry contained commas: Without the enclosing quotes, these commas would now be interpreted as CSV separators, and in consequence entries were mapped to the wrong keys and `ArrayIndexOutOfBoundException`'s occurred.

We could have tried to solve these problems by doing appropriate replacements when converting from `KeyedCSVRow` back to `String` (e.g., replacing newlines with literal `\n` character sequences, inserting quotes around entries etc.), but this is also error-prone and even then there is no guarantee that we thought of every possible problem and it would still be inefficient, at any rate.

Thus I chose the "clean" approach to have `CSVAST` maintain two `LinkedList<KeyedCSVRow>` (one for the nodes and one for the edges) instead of two `LinkedList<String>`. It now has functions to return iterators over these `KeyedCSVRow`'s instead of functions that join a `LinkedList<String>` together with newline characters. All other files that deal with `CSVAST`'s were changed accordingly: Most notably, `CSV2AST`'s main `convert()` function now operates on a `CSVAST` object, though I implemented convenience `convert()` methods that take filenames or `StringReader`'s, converting them to `CSVAST` objects and calling the main `convert()` on that. (Before, it was the other way around: `CSV2AST`'s main `convert()` function operated on `StringReader`'s, and there was a convenience `convert()` function that took a `CSVAST` and extracted `StringReader`'s from it. This was the source, by the way, of the problem entailed by replacing the character sequence `\n` with newline characters.)

Beside being less error-prone and more time-efficient, this design is also more space-efficient, since a `KeyedCSVRow` needs not maintain a string representation of itself any longer.

**Medium bug: Closure expressions**

Consider:
* A function definition is not an expression;
* a closure is a function definition;
* a closure is also an expression.

Err... what? Maybe we should say "a function definition is not *usually* an expression". Closures are special in that respect.

This is a problem for Joern, as it cannot cast a `Closure` to an `Expression`, which would be necessary, e.g., when constructing an assignment of a closure to a variable (since an `AssignmentExpression` rightfully expects both of its operands to be expressions.)

Since `Closure` already extends `PHPFunctionDef` which extends `FunctionDef`, `Closure` cannot extend `Expression`. This is a case where multiple inheritance would actually be nice -- this is not to say that it would be a good idea to have multiple inheritance in Java, but it would solve this particular problem elegantly. :wink: 

Therefore, analogously to `ExpressionStatement` which extends `Statement` and holds an `Expression` (see PR #92), I created a `ClosureExpression` which extends `Expression` and holds a `Closure`.

Whenever the edge interpreter encounters an "end node" which is a closure (i.e., it tries to add an edge from some start node, say an `AssignmentExpression`, to a `Closure`), it now creates a `ClosureExpression` holding that `Closure` and adds the edge from `AssignmentExpression` to the `ClosureExpression` instead, which resolves this problem.

**Small bugs**

Hardly worth the mention, but some of the child types I declared for some nodes were *too* specific (remember I tried to make them as specific as possible in PR #92). For instance, `Variable` nodes do not always have a `StringExpression` child (e.g., the PHP code `$foo` creates a `Variable` node with a `StringExpression` child that holds the string `foo`), but may also hold another `Variable` child (because PHP allows you to do things like `$$foo`... isn't it nice?). Or, a `StaticCallExpression` must not always use a `StringExpression` for its target method child (as in `Foo::bar($buz)`, where a `StringExpression` is created for `bar`), but can have an `ArrayIndexing` child for its target method (because, yes, PHP does allow you to do `Foo::{$bar[42]}($buz)`). There were several things like that; see the corresponding fix commits.

Finally, we have fully operational, well-tested PHP ASTs in Joern. I can go into the weekend happily. :relaxed:


